### PR TITLE
Send as json instead of application/x-www-form-urlencoded

### DIFF
--- a/lib/push.js
+++ b/lib/push.js
@@ -11,7 +11,7 @@ exports.run = function(config, info) {
     token: info.opts.token,
     swagger: JSON.stringify(info.swagger),
   };
-  request.post(`${config.host.url}/cli/swagger`, { json: true, form: form }, function(a, b, data) {
+  request.post(`${config.host.url}/cli/swagger`, { json: form }, function(a, b, data) {
     if (data.success) {
       console.log("");
       console.log("Success! ".green);
@@ -23,7 +23,7 @@ exports.run = function(config, info) {
       console.log("You can also use .yaml to get the YAML representation.".grey);
       */
     } else {
-  console.log(data)
+      console.log(data)
       console.error("There was an error uploading!".red);
     }
 


### PR DESCRIPTION
Since the content type was application/x-www-form-urlencoded, the body-parser size limit for json wasn't being applied, so even small swagger files were being blocked.