### PR TITLE
If an OAS is not supplied, attempt to discover one in the root dir.

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -21,37 +21,64 @@ exports.run = function({ args, opts }) {
     return Promise.reject(new Error('No api key provided. Please use --key'));
   }
 
-  if (!args[0]) {
-    return Promise.reject(
-      new Error('No swagger file provided. Usage `rdme swagger <swagger-file>`'),
-    );
-  }
-
-  function success(data) {
-    console.log(data);
-    console.log('Success! '.green);
-  }
-
-  function error(err) {
-    try {
-      return Promise.reject(new Error(JSON.parse(err.error).description));
-    } catch (e) {
-      return Promise.reject(new Error('There was an error uploading!'));
+  function callApi(specPath) {
+    function success(data) {
+      console.log(data);
+      console.log('Success! '.green);
     }
+
+    function error(err) {
+      try {
+        if (err.statusCode === 401) {
+          return Promise.reject(
+            new Error('There was a problem with your api key. Please try again.'),
+          );
+        }
+
+        return Promise.reject(new Error(JSON.parse(err.error).description));
+      } catch (e) {
+        return Promise.reject(new Error('There was an error uploading!'));
+      }
+    }
+
+    const options = {
+      formData: {
+        swagger: fs.createReadStream(path.resolve(process.cwd(), specPath)),
+      },
+      auth: { user: key },
+    };
+
+    // Create
+    if (!id) {
+      return request.post(`${config.host}/api/v1/swagger`, options).then(success, error);
+    }
+
+    // Update
+    return request.put(`${config.host}/api/v1/swagger/${id}`, options).then(success, error);
   }
 
-  const options = {
-    formData: {
-      swagger: fs.createReadStream(path.resolve(process.cwd(), args[0])),
-    },
-    auth: { user: key },
-  };
-
-  // Create
-  if (!id) {
-    return request.post(`${config.host}/api/v1/swagger`, options).then(success, error);
+  if (args[0]) {
+    return callApi(args[0]);
   }
 
-  // Update
-  return request.put(`${config.host}/api/v1/swagger/${id}`, options).then(success, error);
+  // If the user didn't supply a specification, let's try to locate what they've got, and upload
+  // that. If they don't have any, let's let the user know how they can get one going.
+  return new Promise((resolve, reject) => {
+    ['swagger.json', 'swagger.yaml', 'openapi.json', 'openapi.yaml'].forEach(function(file) {
+      if (!fs.existsSync(file)) {
+        return;
+      }
+
+      console.log(`We found ${file} and are attempting to upload it.`.yellow);
+
+      resolve(callApi(file));
+    });
+
+    reject(
+      new Error(
+        'We were unable to locate a Swagger or OpenAPI file to upload.\n' +
+          "Don't worry, it's easy to get started! Run `rdme oas init` to get started.",
+      ),
+    );
+  });
 };

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -76,8 +76,8 @@ exports.run = function({ args, opts }) {
 
     reject(
       new Error(
-        'We were unable to locate a Swagger or OpenAPI file to upload.\n' +
-          "Don't worry, it's easy to get started! Run `rdme oas init` to get started.",
+        "We couldn't find a Swagger or OpenAPI file.\n\n" +
+          'Run `rdme swagger ./path/to/file` to upload an existing file or `rdme oas init` to create a fresh one!',
       ),
     );
   });

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -61,11 +61,13 @@ exports.run = function({ args, opts }) {
 
     // Create
     if (!id) {
-      return request.post(`${config.host}/api/v1/swagger`, options).then(success, error);
+      return request.post(`${config.host}/api/v1/api-specification`, options).then(success, error);
     }
 
     // Update
-    return request.put(`${config.host}/api/v1/swagger/${id}`, options).then(success, error);
+    return request
+      .put(`${config.host}/api/v1/api-specification/${id}`, options)
+      .then(success, error);
   }
 
   if (args[0]) {

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -29,12 +29,6 @@ exports.run = function({ args, opts }) {
 
     function error(err) {
       try {
-        if (err.statusCode === 401) {
-          return Promise.reject(
-            new Error('There was a problem with your api key. Please try again.'),
-          );
-        }
-
         return Promise.reject(new Error(JSON.parse(err.error).description));
       } catch (e) {
         return Promise.reject(new Error('There was an error uploading!'));

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "scripts": {
     "lint": "eslint -f unix .",
     "prettier": "prettier --list-different \"./**/**.js\"",
+    "prettier:write": "prettier --write \"./**/**.js\"",
     "pretest": "npm run lint && npm run prettier",
     "test": "jest --coverage"
   },

--- a/test/swagger.test.js
+++ b/test/swagger.test.js
@@ -24,9 +24,9 @@ describe('swagger command', () => {
 
   it('should POST a discovered file if none provided', () => {
     const mock = nock(config.host)
-      .post('/api/v1/swagger', body => body.match('form-data; name="swagger"'))
+      .post('/api/v1/api-specification', body => body.match('form-data; name="spec"'))
       .basicAuth({ user: key })
-      .reply(201);
+      .reply(201, { body: '{ id: 1 }' });
 
     // Surface our test fixture to the root directory so rdme can autodiscover it. It's easier to do
     // this than mocking out the fs module because mocking the fs module here causes Jest sourcemaps

--- a/test/swagger.test.js
+++ b/test/swagger.test.js
@@ -15,20 +15,6 @@ describe('swagger command', () => {
       'No api key provided. Please use --key',
     ));
 
-  it('should error if a bad api key is provided', async () => {
-    const badKey = 'thisIsABadApiKey';
-    const mock = nock(config.host)
-      .post('/api/v1/swagger', body => body.match('form-data; name="swagger"'))
-      .basicAuth({ user: badKey })
-      .reply(401);
-
-    await expect(swagger(['./test/fixtures/swagger.json'], { key: badKey })).rejects.toThrow(
-      'There was a problem with your api key. Please try again.',
-    );
-
-    mock.done();
-  });
-
   it('should error if no file was provided or able to be discovered', () => {
     expect(swagger([], { key })).rejects.toThrow(
       "We couldn't find a Swagger or OpenAPI file.\n\n" +

--- a/test/swagger.test.js
+++ b/test/swagger.test.js
@@ -31,8 +31,8 @@ describe('swagger command', () => {
 
   it('should error if no file was provided or able to be discovered', () => {
     expect(swagger([], { key })).rejects.toThrow(
-      'We were unable to locate a Swagger or OpenAPI file to upload.\n' +
-        "Don't worry, it's easy to get started! Run `rdme oas init` to get started.",
+      "We couldn't find a Swagger or OpenAPI file.\n\n" +
+        'Run `rdme swagger ./path/to/file` to upload an existing file or `rdme oas init` to create a fresh one!',
     );
   });
 


### PR DESCRIPTION
This makes the OAS argument of `rdme swagger` optional. If one is not supplied, we will now attempt to locate a `(swagger|openapi).(json|yaml)` file in the directory that `rdme swagger` is being run within. If one is then not found, we'll now point the user in the direction of using `rdme oas init` to get started down the path to spec creation.

I've also fixed a minor bug where if you supplied an incorrect API key to `rdme swagger`, we will now fail with a clearer error message than "There was an error uploading!".