### PR TITLE
Adding new authentication oriented commands

### DIFF
--- a/cmds/docs/edit.js
+++ b/cmds/docs/edit.js
@@ -12,7 +12,7 @@ exports.command = 'docs:edit';
 exports.usage = 'docs:edit <slug> [options]';
 exports.description = 'Edit a single file from your ReadMe project without saving locally.';
 exports.category = 'docs';
-exports.weight = 4;
+exports.position = 2;
 
 exports.hiddenArgs = ['slug'];
 exports.args = [

--- a/cmds/docs/index.js
+++ b/cmds/docs/index.js
@@ -12,7 +12,7 @@ exports.command = 'docs';
 exports.usage = 'docs <folder> [options]';
 exports.description = 'Sync a folder of markdown files to your ReadMe project.';
 exports.category = 'docs';
-exports.weight = 3;
+exports.position = 1;
 
 exports.hiddenArgs = ['folder'];
 exports.args = [

--- a/cmds/login.js
+++ b/cmds/login.js
@@ -11,7 +11,7 @@ exports.command = 'login';
 exports.usage = 'login [options]';
 exports.description = 'Login to a ReadMe project.';
 exports.category = 'admin';
-exports.weight = 1;
+exports.position = 1;
 
 exports.args = [
   {

--- a/cmds/login.js
+++ b/cmds/login.js
@@ -72,7 +72,7 @@ exports.run = async function(opts) {
       configStore.set('email', email);
       configStore.set('project', project);
 
-      return `Successfully logged in as ${email.green} in the ${project.blue} project`;
+      return `Successfully logged in as ${email.green} to the ${project.blue} project.`;
     })
     .catch(badRequest);
 };

--- a/cmds/logout.js
+++ b/cmds/logout.js
@@ -2,22 +2,22 @@ const config = require('config');
 const configStore = require('../lib/configstore');
 const loginCmd = require('./login');
 
-exports.command = 'whoami';
-exports.usage = 'whoami';
-exports.description = 'Displays the current user and project authenticated with ReadMe.';
+exports.command = 'logout';
+exports.usage = 'logout';
+exports.description = 'Logs the currently authenticated user out of ReadMe.';
 exports.category = 'admin';
-exports.weight = 3;
+exports.weight = 2;
 
 exports.args = [];
 
-exports.run = () => {
+exports.run = async () => {
   if (!configStore.has('email') || !configStore.has('project')) {
     return Promise.reject(new Error(`Please login using \`${config.cli} ${loginCmd.command}\`.`));
   }
 
+  configStore.clear();
+
   return Promise.resolve(
-    `You are currently logged in as ${configStore.get('email').green} to the ${
-      configStore.get('project').blue
-    } project.`,
+    `You have logged out of Readme. Please use \`${config.cli} ${loginCmd.command}\` to login again.`,
   );
 };

--- a/cmds/logout.js
+++ b/cmds/logout.js
@@ -6,7 +6,7 @@ exports.command = 'logout';
 exports.usage = 'logout';
 exports.description = 'Logs the currently authenticated user out of ReadMe.';
 exports.category = 'admin';
-exports.weight = 2;
+exports.position = 2;
 
 exports.args = [];
 

--- a/cmds/logout.js
+++ b/cmds/logout.js
@@ -11,11 +11,9 @@ exports.position = 2;
 exports.args = [];
 
 exports.run = async () => {
-  if (!configStore.has('email') || !configStore.has('project')) {
-    return Promise.reject(new Error(`Please login using \`${config.cli} ${loginCmd.command}\`.`));
+  if (configStore.has('email') && configStore.has('project')) {
+    configStore.clear();
   }
-
-  configStore.clear();
 
   return Promise.resolve(
     `You have logged out of Readme. Please use \`${config.cli} ${loginCmd.command}\` to login again.`,

--- a/cmds/oas.js
+++ b/cmds/oas.js
@@ -8,7 +8,7 @@ exports.command = 'oas';
 exports.usage = 'oas';
 exports.description = 'OAS related tasks. See https://npm.im/oas for more information.';
 exports.category = 'utilities';
-exports.weight = 4;
+exports.position = 1;
 
 exports.args = [];
 

--- a/cmds/open.js
+++ b/cmds/open.js
@@ -7,7 +7,7 @@ exports.command = 'open';
 exports.usage = 'open';
 exports.description = 'Open your current ReadMe project in the browser.';
 exports.category = 'utilities';
-exports.weight = 1;
+exports.position = 2;
 
 exports.args = [];
 

--- a/cmds/open.js
+++ b/cmds/open.js
@@ -1,6 +1,7 @@
 const config = require('config');
 const open = require('opn');
 const configStore = require('../lib/configstore');
+const loginCmd = require('./login');
 
 exports.command = 'open';
 exports.usage = 'open';
@@ -13,7 +14,7 @@ exports.args = [];
 exports.run = function(opts) {
   const project = configStore.get('project');
   if (!project) {
-    return Promise.reject(new Error(`Please login using \`${config.cli} ${exports.usage}\`.`));
+    return Promise.reject(new Error(`Please login using \`${config.cli} ${loginCmd.command}\`.`));
   }
 
   return (opts.mockOpen || open)(config.hub.replace('{project}', project), {

--- a/cmds/swagger.js
+++ b/cmds/swagger.js
@@ -9,7 +9,7 @@ exports.command = 'swagger';
 exports.usage = 'swagger [file] [options]';
 exports.description = 'Upload, or sync, your Swagger/OpenAPI file to ReadMe.';
 exports.category = 'apis';
-exports.weight = 2;
+exports.position = 1;
 
 exports.hiddenArgs = ['token', 'spec'];
 exports.args = [

--- a/cmds/versions/create.js
+++ b/cmds/versions/create.js
@@ -7,7 +7,7 @@ exports.command = 'versions:create';
 exports.usage = 'versions:create <version> [options]';
 exports.description = 'Create a new version for your project.';
 exports.category = 'versions';
-exports.weight = 4;
+exports.position = 2;
 
 exports.hiddenArgs = ['version'];
 exports.args = [

--- a/cmds/versions/delete.js
+++ b/cmds/versions/delete.js
@@ -5,7 +5,7 @@ exports.command = 'versions:delete';
 exports.usage = 'versions:delete <version> [options]';
 exports.description = 'Delete a version associated with your ReadMe project.';
 exports.category = 'versions';
-exports.weight = 4;
+exports.position = 4;
 
 exports.hiddenArgs = ['version'];
 exports.args = [

--- a/cmds/versions/index.js
+++ b/cmds/versions/index.js
@@ -8,7 +8,7 @@ exports.usage = 'versions [options]';
 exports.description =
   'List versions available in your project or get a version by SemVer (https://semver.org/).';
 exports.category = 'versions';
-exports.weight = 3;
+exports.position = 1;
 
 exports.args = [
   {

--- a/cmds/versions/update.js
+++ b/cmds/versions/update.js
@@ -7,7 +7,7 @@ exports.command = 'versions:update';
 exports.usage = 'versions:update <version> [options]';
 exports.description = 'Update an existing version for your project.';
 exports.category = 'versions';
-exports.weight = 4;
+exports.position = 3;
 
 exports.args = [
   {

--- a/cmds/whoami.js
+++ b/cmds/whoami.js
@@ -1,0 +1,23 @@
+const config = require('config');
+const configStore = require('../lib/configstore');
+const loginCmd = require('./login');
+
+exports.command = 'whoami';
+exports.usage = 'whoami';
+exports.description = 'Displays the current user and project authenticated with ReadMe.';
+exports.category = 'admin';
+exports.weight = 2;
+
+exports.args = [];
+
+exports.run = () => {
+  if (!configStore.has('email') || !configStore.has('project')) {
+    return Promise.reject(new Error(`Please login using \`${config.cli} ${loginCmd.command}\`.`));
+  }
+
+  return Promise.resolve(
+    `You are currently logged in as ${configStore.get('email').green} to the ${
+      configStore.get('project').blue
+    } project.`,
+  );
+};

--- a/cmds/whoami.js
+++ b/cmds/whoami.js
@@ -6,7 +6,7 @@ exports.command = 'whoami';
 exports.usage = 'whoami';
 exports.description = 'Displays the current user and project authenticated with ReadMe.';
 exports.category = 'admin';
-exports.weight = 3;
+exports.position = 3;
 
 exports.args = [];
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -24,7 +24,7 @@ exports.listByCategory = () => {
     categories[c.command.category].commands.push({
       name: c.command.command,
       description: c.command.description,
-      weight: c.command.weight,
+      position: c.command.position,
     });
   });
 

--- a/lib/help.js
+++ b/lib/help.js
@@ -103,7 +103,7 @@ exports.globalUsage = async args => {
     };
 
     category.commands
-      .sort((a, b) => a.weight > b.weight)
+      .sort((a, b) => a.position > b.position)
       .forEach(command => {
         commandCategory.content.push({
           command: styleCommand(command),

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -88,7 +88,7 @@ describe('cli', () => {
     });
 
     it('should not show related commands on commands that have none', () => {
-      cli(['login', '--help']).then(output => {
+      cli(['swagger', '--help']).then(output => {
         assert.ok(output.indexOf('Related commands') === -1);
       });
     });

--- a/test/cmds/docs.test.js
+++ b/test/cmds/docs.test.js
@@ -13,7 +13,7 @@ const fixturesDir = `${__dirname}./../fixtures`;
 const key = 'Xmw4bGctRVIQz7R7dQXqH9nQe5d0SPQs';
 const version = '1.0.0';
 
-describe('docs command', () => {
+describe('rdme docs', () => {
   beforeAll(() => nock.disableNetConnect());
   afterAll(() => nock.cleanAll());
 
@@ -137,7 +137,7 @@ describe('docs command', () => {
   });
 });
 
-describe('docs:edit', () => {
+describe('rdme docs:edit', () => {
   it('should error if no api key provided', () =>
     docsEdit.run({}).catch(err => {
       assert.equal(err.message, 'No project API key provided. Please use `--key`.');

--- a/test/cmds/login.test.js
+++ b/test/cmds/login.test.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const configStore = require('../../lib/configstore');
 const cmd = require('../../cmds/login');
 
-describe('login command', () => {
+describe('rdme login', () => {
   beforeAll(() => nock.disableNetConnect());
   afterAll(() => nock.cleanAll());
   afterEach(() => configStore.clear());

--- a/test/cmds/logout.test.js
+++ b/test/cmds/logout.test.js
@@ -1,10 +1,10 @@
 const assert = require('assert');
 const config = require('config');
 const configStore = require('../../lib/configstore');
-const cmd = require('../../cmds/whoami');
+const cmd = require('../../cmds/logout');
 const loginCmd = require('../../cmds/login');
 
-describe('whoami command', () => {
+describe('logout command', () => {
   it('should error if user is not authenticated', done => {
     configStore.delete('email');
     configStore.delete('project');
@@ -20,14 +20,15 @@ describe('whoami command', () => {
       });
   });
 
-  it('should return the authenticated user', done => {
+  it('should log the user out', done => {
     configStore.set('email', 'email@example.com');
     configStore.set('project', 'subdomain');
 
     cmd
       .run({})
       .then(() => {
-        assert.ok(true);
+        assert.equal(configStore.get('email'), undefined, 'config was not destroyed');
+        assert.equal(configStore.get('project'), undefined, 'config was not destroyed');
         return done();
       })
       .catch(err => {

--- a/test/cmds/logout.test.js
+++ b/test/cmds/logout.test.js
@@ -5,17 +5,21 @@ const cmd = require('../../cmds/logout');
 const loginCmd = require('../../cmds/login');
 
 describe('rdme logout', () => {
-  it('should error if user is not authenticated', done => {
+  it("should report the user as logged out if they aren't logged in", done => {
     configStore.delete('email');
     configStore.delete('project');
 
     cmd
       .run({})
-      .then(() => {
-        assert.ok(false, 'unauthenticated error message not displayed');
+      .then(msg => {
+        assert.equal(
+          msg,
+          `You have logged out of Readme. Please use \`${config.cli} ${loginCmd.command}\` to login again.`,
+        );
+        return done();
       })
       .catch(err => {
-        assert.equal(err.message, `Please login using \`${config.cli} ${loginCmd.command}\`.`);
+        assert.ok(false, err);
         return done();
       });
   });

--- a/test/cmds/logout.test.js
+++ b/test/cmds/logout.test.js
@@ -4,7 +4,7 @@ const configStore = require('../../lib/configstore');
 const cmd = require('../../cmds/logout');
 const loginCmd = require('../../cmds/login');
 
-describe('logout command', () => {
+describe('rdme logout', () => {
   it('should error if user is not authenticated', done => {
     configStore.delete('email');
     configStore.delete('project');

--- a/test/cmds/open.test.js
+++ b/test/cmds/open.test.js
@@ -4,7 +4,7 @@ const configStore = require('../../lib/configstore');
 const cmd = require('../../cmds/open');
 const loginCmd = require('../../cmds/login');
 
-describe('open command', () => {
+describe('rdme open', () => {
   it('should error if no project provided', done => {
     configStore.delete('project');
 

--- a/test/cmds/open.test.js
+++ b/test/cmds/open.test.js
@@ -2,13 +2,14 @@ const assert = require('assert');
 const config = require('config');
 const configStore = require('../../lib/configstore');
 const cmd = require('../../cmds/open');
+const loginCmd = require('../../cmds/login');
 
 describe('open command', () => {
   it('should error if no project provided', done => {
     configStore.delete('project');
 
     cmd.run({}).catch(err => {
-      assert.equal(err.message, `Please login using \`${config.cli} ${cmd.usage}\`.`);
+      assert.equal(err.message, `Please login using \`${config.cli} ${loginCmd.command}\`.`);
       return done();
     });
   });

--- a/test/cmds/swagger.test.js
+++ b/test/cmds/swagger.test.js
@@ -9,7 +9,7 @@ const version = '1.0.0';
 
 jest.mock('../../lib/prompts');
 
-describe('swagger command', () => {
+describe('rdme swagger', () => {
   beforeAll(() => nock.disableNetConnect());
   afterEach(() => nock.cleanAll());
 

--- a/test/cmds/versions.test.js
+++ b/test/cmds/versions.test.js
@@ -34,11 +34,11 @@ const version2Payload = {
 
 jest.mock('../../lib/prompts');
 
-describe('Versions CLI Commands', () => {
+describe('rdme versions*', () => {
   beforeAll(() => nock.disableNetConnect());
   afterEach(() => nock.cleanAll());
 
-  describe('base command', () => {
+  describe('rdme versions', () => {
     it('should error if no api key provided', () => {
       versions.run({}).catch(err => {
         assert.equal(err.message, 'No project API key provided. Please use `--key`.');
@@ -92,7 +92,7 @@ describe('Versions CLI Commands', () => {
     });
   });
 
-  describe('create new version', () => {
+  describe('rdme versions:create', () => {
     it('should error if no api key provided', () => {
       createVersion.run({}).catch(err => {
         assert.equal(err.message, 'No project API key provided. Please use `--key`.');
@@ -148,7 +148,7 @@ describe('Versions CLI Commands', () => {
     });
   });
 
-  describe('delete version', () => {
+  describe('rdme versions:delete', () => {
     it('should error if no api key provided', () => {
       deleteVersion.run({}).catch(err => {
         assert.equal(err.message, 'No project API key provided. Please use `--key`.');
@@ -187,7 +187,7 @@ describe('Versions CLI Commands', () => {
     });
   });
 
-  describe('update version', () => {
+  describe('rdme versions:update', () => {
     it('should error if no api key provided', () => {
       updateVersion.run({}).catch(err => {
         assert.equal(err.message, 'No project API key provided. Please use `--key`.');
@@ -203,7 +203,7 @@ describe('Versions CLI Commands', () => {
       });
     });
 
-    it('should get a specific version object', async () => {
+    it('should update a specific version object', async () => {
       promptHandler.createVersionPrompt.mockResolvedValue({
         is_stable: false,
         is_beta: false,
@@ -222,7 +222,7 @@ describe('Versions CLI Commands', () => {
       mockRequest.done();
     });
 
-    it('should catch any post request errors', async () => {
+    it('should catch any put request errors', async () => {
       promptHandler.createVersionPrompt.mockResolvedValue({
         is_stable: false,
         is_beta: false,

--- a/test/cmds/whoami.test.js
+++ b/test/cmds/whoami.test.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+const config = require('config');
+const configStore = require('../../lib/configstore');
+const cmd = require('../../cmds/whoami');
+const loginCmd = require('../../cmds/login');
+
+describe('whoami command', () => {
+  it('should error if user is not authenticate', done => {
+    configStore.delete('email');
+    configStore.delete('project');
+
+    cmd
+      .run({})
+      .then(() => {
+        assert.ok(false, 'unauthenticated error message not displayed');
+      })
+      .catch(err => {
+        assert.equal(err.message, `Please login using \`${config.cli} ${loginCmd.command}\`.`);
+        return done();
+      });
+  });
+
+  it('should return the authenticated user', done => {
+    configStore.set('email', 'email@example.com');
+    configStore.set('project', 'subdomain');
+
+    cmd
+      .run({})
+      .then(() => {
+        assert.ok(true);
+        return done();
+      })
+      .catch(err => {
+        assert.ok(false, err);
+        return done();
+      });
+  });
+});

--- a/test/cmds/whoami.test.js
+++ b/test/cmds/whoami.test.js
@@ -4,7 +4,7 @@ const configStore = require('../../lib/configstore');
 const cmd = require('../../cmds/whoami');
 const loginCmd = require('../../cmds/login');
 
-describe('whoami command', () => {
+describe('rdme whoami', () => {
   it('should error if user is not authenticated', done => {
     configStore.delete('email');
     configStore.delete('project');

--- a/test/lib/commands.test.js
+++ b/test/lib/commands.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const commands = require('../../lib/commands').list();
 
 describe('utils', () => {
-  describe('getCommands', () => {
+  describe('#getCommands', () => {
     it('should have commands returned', done => {
       assert.notEqual(commands.length, 0);
       done();

--- a/test/lib/commands.test.js
+++ b/test/lib/commands.test.js
@@ -35,8 +35,8 @@ describe('utils', () => {
           );
 
           assert.ok(
-            typeof cmd.weight === 'number' && cmd.usage.weight !== 0,
-            `${file} does not have a weight`,
+            typeof cmd.position === 'number' && cmd.usage.position !== 0,
+            `${file} does not have a position`,
           );
 
           assert.ok(Array.isArray(cmd.args), `${file} does not have an args array defined`);


### PR DESCRIPTION
This adds two new commands: 

- `rdme logout` - Logs the current user out and clears their saved config file.
- `rdme whoami` - Returns the email and project of the user that's currently logged in.

I also did a few minor maintenancey things to clean some things up from https://github.com/readmeio/rdme/pull/49:

- Renaming the `weight` property in commands to `position`. Since our new `help` screen shows the split groups, the weight is really more of a position declaration in that screen now so I've renamed it to reflect that. It still works the same, this is just purely renaming the property so it's clearer what it represents.
- Making our test descriptions `describe('...' () => {})` consistent.