### PR TITLE
Check if command is 'oas' before throwing error

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -100,7 +100,7 @@ module.exports = processArgv => {
       //
       // Instead of failing out to the user with an undecipherable "Unknown value: ..." error, let's
       // try to parse their request again but a tad less eager.
-      if (e.name !== 'UNKNOWN_VALUE' || (e.name === 'UNKNOWN_VALUE' && !argv.version)) {
+      if ((e.name !== 'UNKNOWN_VALUE' || (e.name === 'UNKNOWN_VALUE' && !argv.version)) && argv.command !== 'oas') {
         throw e;
       }
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -117,4 +117,10 @@ describe('cli', () => {
       assert.equal(err.message, 'No project version provided. Please use `--version`.');
     });
   });
+
+  it('should not error with oas arguments passed in', () => {
+    assert.doesNotThrow(() => {
+      cli(['oas', 'init']);
+    });
+  });
 });


### PR DESCRIPTION
All `rdme oas <something>` commands are broken so this fixes that. I wrote a test that is currently broken because it doesn't properly throw in the failing case and I need to figure out why. Will update this description when it's ready!