### PR TITLE
fix/help-semver-validation

### DIFF
--- a/cmds/versions/create.js
+++ b/cmds/versions/create.js
@@ -1,10 +1,11 @@
 const request = require('request-promise-native');
 const config = require('config');
+const semver = require('semver');
 const { prompt } = require('enquirer');
 const promptOpts = require('../../lib/prompts');
 
 exports.command = 'versions:create';
-exports.usage = 'versions:create <version> | --version={project-version} [options]';
+exports.usage = 'versions:create --version=<version> [options]';
 exports.description = 'Create a new version for your project.';
 exports.category = 'versions';
 exports.position = 2;
@@ -56,10 +57,10 @@ exports.run = async function(opts) {
     return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
   }
 
-  if (!version) {
+  if (!version || !semver.valid(semver.coerce(version))) {
     return Promise.reject(
       new Error(
-        `No version provided. Please specify a semantic version. See \`${config.cli} help ${exports.command}\` for help.`,
+        `Please specify a semantic version. See \`${config.cli} help ${exports.command}\` for help.`,
       ),
     );
   }

--- a/cmds/versions/delete.js
+++ b/cmds/versions/delete.js
@@ -1,8 +1,9 @@
 const request = require('request-promise-native');
 const config = require('config');
+const semver = require('semver');
 
 exports.command = 'versions:delete';
-exports.usage = 'versions:delete --version={project-version} [options]';
+exports.usage = 'versions:delete --version=<version> [options]';
 exports.description = 'Delete a version associated with your ReadMe project.';
 exports.category = 'versions';
 exports.position = 4;
@@ -28,10 +29,10 @@ exports.run = async function(opts) {
     return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
   }
 
-  if (!version) {
+  if (!version || !semver.valid(semver.coerce(version))) {
     return Promise.reject(
       new Error(
-        `No version provided. Please specify a semantic version. See \`${config.cli} help ${exports.command}\` for help.`,
+        `Please specify a semantic version. See \`${config.cli} help ${exports.command}\` for help.`,
       ),
     );
   }

--- a/cmds/versions/update.js
+++ b/cmds/versions/update.js
@@ -1,10 +1,11 @@
 const request = require('request-promise-native');
 const config = require('config');
+const semver = require('semver');
 const { prompt } = require('enquirer');
 const promptOpts = require('../../lib/prompts');
 
 exports.command = 'versions:update';
-exports.usage = 'versions:update --version={project-version} [options]';
+exports.usage = 'versions:update --version=<version> [options]';
 exports.description = 'Update an existing version for your project.';
 exports.category = 'versions';
 exports.position = 3;
@@ -49,10 +50,10 @@ exports.run = async function(opts) {
     return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
   }
 
-  if (!version) {
+  if (!version || !semver.valid(semver.coerce(version))) {
     return Promise.reject(
       new Error(
-        `No version provided. Please specify a semantic version. See \`${config.cli} help ${exports.command}\` for help.`,
+        `Please specify a semantic version. See \`${config.cli} help ${exports.command}\` for help.`,
       ),
     );
   }

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -1,3 +1,5 @@
+const semver = require('semver');
+
 exports.generatePrompts = versionList => [
   {
     type: 'select',
@@ -57,6 +59,11 @@ exports.createVersionPrompt = (versionList, opts, isUpdate) => [
       return opts.newVersion || !isUpdate;
     },
     hint: '1.0.0',
+    validate(val) {
+      return semver.valid(semver.coerce(val))
+        ? true
+        : this.styles.danger('Please specify a semantic version as your value.');
+    },
   },
   {
     type: 'confirm',

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -62,7 +62,7 @@ exports.createVersionPrompt = (versionList, opts, isUpdate) => [
     validate(val) {
       return semver.valid(semver.coerce(val))
         ? true
-        : this.styles.danger('Please specify a semantic version as your value.');
+        : this.styles.danger('Please specify a semantic version.');
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "read": "^1.0.7",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
+    "semver": "^6.3.0",
     "table-layout": "^1.0.0"
   },
   "devDependencies": {

--- a/test/cmds/versions.test.js
+++ b/test/cmds/versions.test.js
@@ -103,7 +103,7 @@ describe('rdme versions*', () => {
       createVersion.run({ key }).catch(err => {
         assert.equal(
           err.message,
-          'No version provided. Please specify a semantic version. See `rdme help versions:create` for help.',
+          'Please specify a semantic version. See `rdme help versions:create` for help.',
         );
       });
     });
@@ -159,7 +159,7 @@ describe('rdme versions*', () => {
       deleteVersion.run({ key }).catch(err => {
         assert.equal(
           err.message,
-          'No version provided. Please specify a semantic version. See `rdme help versions:delete` for help.',
+          'Please specify a semantic version. See `rdme help versions:delete` for help.',
         );
       });
     });
@@ -198,7 +198,7 @@ describe('rdme versions*', () => {
       updateVersion.run({ key }).catch(err => {
         assert.equal(
           err.message,
-          'No version provided. Please specify a semantic version. See `rdme help versions:update` for help.',
+          'Please specify a semantic version. See `rdme help versions:update` for help.',
         );
       });
     });

--- a/test/lib/prompts.test.js
+++ b/test/lib/prompts.test.js
@@ -61,6 +61,11 @@ describe('prompt test bed', () => {
         await prompt.keypress(null, { name: 'down' });
         await prompt.keypress(null, { name: 'up' });
         await prompt.submit();
+        if (prompt.name === 'newVersion') {
+          // eslint-disable-next-line
+          prompt.value = '1.2.1';
+          await prompt.submit();
+        }
       });
       const answer = await enquirer.prompt(
         promptHandler.createVersionPrompt(versionlist, opts, false),


### PR DESCRIPTION
Ticket addresses:
1.  `help` flag for `versions:create`, `versions:delete`, and 'versions:update` by fixing parse error for dependency
2. Adding support for semver validation in prompt and directly when using the cli with flags.