### PR TITLE
feat: drop support for node 8

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/readmeio/rdme/issues"
   },
   "main": "index.js",
+  "engines": {
+    "node": ">=10"
+  },
   "dependencies": {
     "cli-table": "^0.3.1",
     "colors": "^1.1.2",


### PR DESCRIPTION
Support for Node 8 ended at the start of the year so there's no reason for us to continue targeting it.