### PR TITLE
fix: setting initial data for newVersion when creating a version

### DIFF
--- a/cmds/versions/create.js
+++ b/cmds/versions/create.js
@@ -72,7 +72,12 @@ exports.run = async function (opts) {
       .catch(e => Promise.reject(e.error));
   }
 
-  const promptResponse = await prompt(promptOpts.createVersionPrompt(versionList || [{}], opts));
+  const versionPrompt = promptOpts.createVersionPrompt(versionList || [{}], {
+    newVersion: version,
+    ...opts,
+  });
+
+  const promptResponse = await prompt(versionPrompt);
   const options = {
     json: {
       version,

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -81,6 +81,7 @@ exports.createVersionPrompt = (versionList, opts, isUpdate) => [
     type: 'input',
     name: 'newVersion',
     message: "What's your new version?",
+    initial: opts.newVersion || false,
     skip() {
       return opts.newVersion || !isUpdate;
     },


### PR DESCRIPTION
This resolves a strange issue with Enquirer where it wouldn't properly skip the `newVersion` question when creating a new version. 

Resolves https://github.com/readmeio/rdme/issues/206