### PR TITLE
fix: catch upload timeouts and return a better error message

### DIFF
--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -86,6 +86,14 @@ exports.run = async function (opts) {
         const parsedError = JSON.parse(err.error);
         return Promise.reject(new APIError(parsedError));
       } catch (e) {
+        if (e.message.includes('Unexpected token < in JSON')) {
+          return Promise.reject(
+            new Error(
+              "We're sorry, your upload request timed out. Please try again or split your file up into smaller chunks."
+            )
+          );
+        }
+
         return Promise.reject(new Error('There was an error uploading!'));
       }
     }


### PR DESCRIPTION
## 🧰 Changes

Our API sometimes has trouble with 1.5MB+ OpenAPI files during upload with the request timing out and returning an invalid payload through our API. When this happens rdme will surface an "There was an error uploading!" error which isn't helpful.

Instead, we're now looking for these timeouts and returning a contextual error about it with a suggestion to help get the file uploaded. Obviously it'd be better if our API didn't have these pitfalls, but it's a gigantic project to rework that backend to not have these issues.

## 🧬 QA & Testing

Upload the file attached in https://github.com/readmeio/rdme/issues/84#issuecomment-858369838, it should timeout and throw this new error message I've added here.