### PR TITLE
fix: command position sorting within the help screen

### DIFF
--- a/src/lib/help.js
+++ b/src/lib/help.js
@@ -12,7 +12,7 @@ const owlbert = () => {
   return `                    ${config.cli.blue.bold}
 
     ${`a utlity for interacting with ReadMe`.bold}
-       .                        
+       .
        .\\\\                          /.
       ’  ‘                        ‘ ‘
       ( nn\\\\    .           .     /  )
@@ -102,7 +102,7 @@ exports.globalUsage = async args => {
     };
 
     category.commands
-      .sort((a, b) => a.position > b.position)
+      .sort((a, b) => (a.position > b.position ? 1 : -1))
       .forEach(command => {
         commandCategory.content.push({
           command: styleCommand(command),


### PR DESCRIPTION
## 🧰 Changes

This fixes some improper `Array.sort()` logic within the help screen where the `position` properties that each command emits weren't being properly utilized.

## 🧬 QA & Testing

Before:

![Screen Shot 2021-07-20 at 11 20 17 PM](https://user-images.githubusercontent.com/33762/126440925-4726faa9-7e2e-4c25-9ccb-7d4997356f19.png)

After:

![Screen Shot 2021-07-20 at 11 20 25 PM](https://user-images.githubusercontent.com/33762/126440940-fa15e7ce-adde-4364-9e39-00ddd1c15a7e.png)