### PR TITLE
feat: making the docs command recursive by default

### DIFF
--- a/__tests__/.eslintrc
+++ b/__tests__/.eslintrc
@@ -9,6 +9,7 @@
       {
         "assertFunctionNames": [
           "expect",
+          "getNockWithVersionHeader.**.reply",
           "nock.**.reply"
         ]
       }

--- a/__tests__/__fixtures__/existing-docs/subdir/another-doc.md
+++ b/__tests__/__fixtures__/existing-docs/subdir/another-doc.md
@@ -1,0 +1,4 @@
+---
+title: This is another document title
+---
+Another body

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -63,11 +63,8 @@ exports.run = async function (opts) {
     return [...files, ...subFiles];
   };
 
-  // Pull off the leading subdirectory, to keep things consistant with below
-  const allFiles = readdirRecursive(folder).map(file => file.replace(`${folder}${path.sep}`, ''));
-
   // Strip out non-markdown files
-  const files = allFiles.filter(file => file.endsWith('.md') || file.endsWith('.markdown'));
+  const files = readdirRecursive(folder).filter(file => file.endsWith('.md') || file.endsWith('.markdown'));
   if (!files.length) {
     return Promise.reject(new Error(`We were unable to locate Markdown files in ${folder}.`));
   }

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -68,8 +68,7 @@ exports.run = async function (opts) {
 
   // Strip out non-markdown files
   const files = allFiles.filter(file => file.endsWith('.md') || file.endsWith('.markdown'));
-
-  if (files.length === 0) {
+  if (!files.length) {
     return Promise.reject(new Error(`We were unable to locate Markdown files in ${folder}.`));
   }
 
@@ -93,7 +92,7 @@ exports.run = async function (opts) {
 
   function updateDoc(slug, file, hash, existingDoc) {
     if (hash === existingDoc.lastUpdatedHash) {
-      return `\`${slug}\` not updated. No changes.`;
+      return `\`${slug}\` was not updated because there were no changes.`;
     }
 
     return request
@@ -110,7 +109,7 @@ exports.run = async function (opts) {
 
   const updatedDocs = await Promise.allSettled(
     files.map(async filename => {
-      const file = await readFile(path.join(folder, filename), 'utf8');
+      const file = await readFile(filename, 'utf8');
       const matter = frontMatter(file);
 
       // Stripping the subdirectories and markdown extension from the filename and lowercasing to get the default slug.

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -29,11 +29,6 @@ exports.args = [
     description: 'Project version',
   },
   {
-    name: 'recursive',
-    type: Boolean,
-    description: 'Search for files recursively',
-  },
-  {
     name: 'folder',
     type: String,
     defaultOption: true,
@@ -41,7 +36,7 @@ exports.args = [
 ];
 
 exports.run = async function (opts) {
-  const { folder, key, version, recursive } = opts;
+  const { folder, key, version } = opts;
 
   if (!key) {
     return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
@@ -55,26 +50,22 @@ exports.run = async function (opts) {
     return Promise.reject(new Error(`No folder provided. Usage \`${config.cli} ${exports.usage}\`.`));
   }
 
-  // Find the files to sync, either recursively or not
-  let allFiles;
-  if (recursive) {
-    // A recursive function that returns a list of child file paths
-    const readdirRecursive = folderToSearch => {
-      const filesInFolder = fs.readdirSync(folderToSearch, { withFileTypes: true });
-      const files = filesInFolder
-        .filter(fileHandle => fileHandle.isFile())
-        .map(fileHandle => path.join(folderToSearch, fileHandle.name));
-      const folders = filesInFolder.filter(fileHandle => fileHandle.isDirectory());
-      const subFiles = [].concat(
-        ...folders.map(fileHandle => readdirRecursive(path.join(folderToSearch, fileHandle.name)))
-      );
-      return [...files, ...subFiles];
-    };
-    // Pull off the leading subdirectory, to keep things consistant with below
-    allFiles = readdirRecursive(folder).map(file => file.replace(`${folder}${path.sep}`, ''));
-  } else {
-    allFiles = fs.readdirSync(folder);
-  }
+  // Find the files to sync
+  const readdirRecursive = folderToSearch => {
+    const filesInFolder = fs.readdirSync(folderToSearch, { withFileTypes: true });
+    const files = filesInFolder
+      .filter(fileHandle => fileHandle.isFile())
+      .map(fileHandle => path.join(folderToSearch, fileHandle.name));
+    const folders = filesInFolder.filter(fileHandle => fileHandle.isDirectory());
+    const subFiles = [].concat(
+      ...folders.map(fileHandle => readdirRecursive(path.join(folderToSearch, fileHandle.name)))
+    );
+    return [...files, ...subFiles];
+  };
+
+  // Pull off the leading subdirectory, to keep things consistant with below
+  const allFiles = readdirRecursive(folder).map(file => file.replace(`${folder}${path.sep}`, ''));
+
   // Strip out non-markdown files
   const files = allFiles.filter(file => file.endsWith('.md') || file.endsWith('.markdown'));
 


### PR DESCRIPTION
## 🧰 Changes

* [x] Slightly alters the `--recursive` argument introduced in #313 to make the `docs` command recursive by default, always.
* [x] Updating our `docs` test to test recursive doc directory syncing.
* [x] Some general tidying up of the `docs` command to remove things that might look like internal IDs or API keys.

## 🧬 QA & Testing

* [ ] Tests pass?