### PR TITLE
feat: add version selection to all relevant commands

### DIFF
--- a/__tests__/cmds/docs.test.js
+++ b/__tests__/cmds/docs.test.js
@@ -392,7 +392,7 @@ describe('rdme docs:edit', () => {
     const slug = 'getting-started';
     const body = 'abcdef';
 
-    nock(config.host)
+    const getMock = nock(config.host)
       .get(`/api/v1/docs/${slug}`)
       .reply(200, { body })
       .get(`/api/v1/version/${version}`)
@@ -404,6 +404,7 @@ describe('rdme docs:edit', () => {
     }
 
     return docsEdit.run({ slug, key, version: '1.0.0', mockEditor }).catch(err => {
+      getMock.done();
       expect(err.message).toBe('Non zero exit code from $EDITOR');
       fs.unlinkSync(`${slug}.md`);
     });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -114,7 +114,7 @@ describe('cli', () => {
     conf.set('apiKey', '123456');
     return cli(['docs']).catch(err => {
       conf.delete('apiKey');
-      expect(err.message).toBe('No project version provided. Please use `--version`.');
+      expect(err.message).toBe('No folder provided. Usage `rdme docs <folder> [options]`.');
     });
   });
 

--- a/src/cmds/docs/edit.js
+++ b/src/cmds/docs/edit.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const editor = require('editor');
 const { promisify } = require('util');
 const APIError = require('../../lib/apiError');
-const { getSwaggerVersion } = require('../../lib/versionSelect');
+const { getProjectVersion } = require('../../lib/versionSelect');
 
 const writeFile = promisify(fs.writeFile);
 const readFile = promisify(fs.readFile);
@@ -46,7 +46,7 @@ exports.run = async function (opts) {
     return Promise.reject(new Error(`No slug provided. Usage \`${config.cli} ${exports.usage}\`.`));
   }
 
-  const selectedVersion = await getSwaggerVersion(version, key, true).catch(e => {
+  const selectedVersion = await getProjectVersion(version, key, true).catch(e => {
     return Promise.reject(e);
   });
 

--- a/src/cmds/docs/edit.js
+++ b/src/cmds/docs/edit.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const editor = require('editor');
 const { promisify } = require('util');
 const APIError = require('../../lib/apiError');
+const { getSwaggerVersion } = require('../../lib/versionSelect');
 
 const writeFile = promisify(fs.writeFile);
 const readFile = promisify(fs.readFile);
@@ -41,19 +42,19 @@ exports.run = async function (opts) {
     return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
   }
 
-  if (!version) {
-    return Promise.reject(new Error('No project version provided. Please use `--version`.'));
-  }
-
   if (!slug) {
     return Promise.reject(new Error(`No slug provided. Usage \`${config.cli} ${exports.usage}\`.`));
   }
+
+  const selectedVersion = await getSwaggerVersion(version, key).catch(e => {
+    return Promise.reject(e);
+  });
 
   const filename = `${slug}.md`;
   const options = {
     auth: { user: key },
     headers: {
-      'x-readme-version': version,
+      'x-readme-version': selectedVersion,
     },
   };
 

--- a/src/cmds/docs/edit.js
+++ b/src/cmds/docs/edit.js
@@ -46,7 +46,7 @@ exports.run = async function (opts) {
     return Promise.reject(new Error(`No slug provided. Usage \`${config.cli} ${exports.usage}\`.`));
   }
 
-  const selectedVersion = await getSwaggerVersion(version, key).catch(e => {
+  const selectedVersion = await getSwaggerVersion(version, key, true).catch(e => {
     return Promise.reject(e);
   });
 

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -47,7 +47,7 @@ exports.run = async function (opts) {
     return Promise.reject(new Error(`No folder provided. Usage \`${config.cli} ${exports.usage}\`.`));
   }
 
-  const selectedVersion = await getSwaggerVersion(version, key).catch(e => {
+  const selectedVersion = await getSwaggerVersion(version, key, true).catch(e => {
     return Promise.reject(e);
   });
 

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -7,7 +7,7 @@ const crypto = require('crypto');
 const frontMatter = require('gray-matter');
 const { promisify } = require('util');
 const APIError = require('../../lib/apiError');
-const { getSwaggerVersion } = require('../../lib/versionSelect');
+const { getProjectVersion } = require('../../lib/versionSelect');
 
 const readFile = promisify(fs.readFile);
 
@@ -47,7 +47,7 @@ exports.run = async function (opts) {
     return Promise.reject(new Error(`No folder provided. Usage \`${config.cli} ${exports.usage}\`.`));
   }
 
-  const selectedVersion = await getSwaggerVersion(version, key, true).catch(e => {
+  const selectedVersion = await getProjectVersion(version, key, true).catch(e => {
     return Promise.reject(e);
   });
 

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -7,6 +7,7 @@ const crypto = require('crypto');
 const frontMatter = require('gray-matter');
 const { promisify } = require('util');
 const APIError = require('../../lib/apiError');
+const { getSwaggerVersion } = require('../../lib/versionSelect');
 
 const readFile = promisify(fs.readFile);
 
@@ -42,13 +43,13 @@ exports.run = async function (opts) {
     return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
   }
 
-  if (!version) {
-    return Promise.reject(new Error('No project version provided. Please use `--version`.'));
-  }
-
   if (!folder) {
     return Promise.reject(new Error(`No folder provided. Usage \`${config.cli} ${exports.usage}\`.`));
   }
+
+  const selectedVersion = await getSwaggerVersion(version, key).catch(e => {
+    return Promise.reject(e);
+  });
 
   // Find the files to sync
   const readdirRecursive = folderToSearch => {
@@ -72,7 +73,7 @@ exports.run = async function (opts) {
   const options = {
     auth: { user: key },
     headers: {
-      'x-readme-version': version,
+      'x-readme-version': selectedVersion,
     },
   };
 

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -165,7 +165,7 @@ exports.run = async function (opts) {
   }
 
   if (!id) {
-    selectedVersion = await getSwaggerVersion(version, key).catch(e => {
+    selectedVersion = await getSwaggerVersion(version, key, true).catch(e => {
       return Promise.reject(e);
     });
   }

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -6,7 +6,7 @@ const { prompt } = require('enquirer');
 const OASNormalize = require('oas-normalize');
 const promptOpts = require('../lib/prompts');
 const APIError = require('../lib/apiError');
-const { getSwaggerVersion } = require('../lib/versionSelect');
+const { getProjectVersion } = require('../lib/versionSelect');
 
 exports.command = 'openapi';
 exports.usage = 'openapi [file] [options]';
@@ -165,7 +165,7 @@ exports.run = async function (opts) {
   }
 
   if (!id) {
-    selectedVersion = await getSwaggerVersion(version, key, true).catch(e => {
+    selectedVersion = await getProjectVersion(version, key, true).catch(e => {
       return Promise.reject(e);
     });
   }

--- a/src/cmds/versions/delete.js
+++ b/src/cmds/versions/delete.js
@@ -1,7 +1,7 @@
 const request = require('request-promise-native');
 const config = require('config');
 const APIError = require('../../lib/apiError');
-const { getSwaggerVersion } = require('../../lib/versionSelect');
+const { getProjectVersion } = require('../../lib/versionSelect');
 
 exports.command = 'versions:delete';
 exports.usage = 'versions:delete --version=<version> [options]';
@@ -30,7 +30,7 @@ exports.run = async function (opts) {
     return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
   }
 
-  const selectedVersion = await getSwaggerVersion(version, key, false).catch(e => {
+  const selectedVersion = await getProjectVersion(version, key, false).catch(e => {
     return Promise.reject(e);
   });
 

--- a/src/cmds/versions/delete.js
+++ b/src/cmds/versions/delete.js
@@ -1,7 +1,7 @@
 const request = require('request-promise-native');
 const config = require('config');
-const semver = require('semver');
 const APIError = require('../../lib/apiError');
+const { getSwaggerVersion } = require('../../lib/versionSelect');
 
 exports.command = 'versions:delete';
 exports.usage = 'versions:delete --version=<version> [options]';
@@ -30,17 +30,15 @@ exports.run = async function (opts) {
     return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
   }
 
-  if (!version || !semver.valid(semver.coerce(version))) {
-    return Promise.reject(
-      new Error(`Please specify a semantic version. See \`${config.cli} help ${exports.command}\` for help.`)
-    );
-  }
+  const selectedVersion = await getSwaggerVersion(version, key, false).catch(e => {
+    return Promise.reject(e);
+  });
 
   return request
-    .delete(`${config.host}/api/v1/version/${version}`, {
+    .delete(`${config.host}/api/v1/version/${selectedVersion}`, {
       json: true,
       auth: { user: key },
     })
-    .then(() => Promise.resolve(`Version ${version} deleted successfully.`))
+    .then(() => Promise.resolve(`Version ${selectedVersion} deleted successfully.`))
     .catch(err => Promise.reject(new APIError(err)));
 };

--- a/src/cmds/versions/update.js
+++ b/src/cmds/versions/update.js
@@ -3,7 +3,7 @@ const config = require('config');
 const { prompt } = require('enquirer');
 const promptOpts = require('../../lib/prompts');
 const APIError = require('../../lib/apiError');
-const { getSwaggerVersion } = require('../../lib/versionSelect');
+const { getProjectVersion } = require('../../lib/versionSelect');
 
 exports.command = 'versions:update';
 exports.usage = 'versions:update --version=<version> [options]';
@@ -51,7 +51,7 @@ exports.run = async function (opts) {
     return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
   }
 
-  const selectedVersion = await getSwaggerVersion(version, key, false).catch(e => {
+  const selectedVersion = await getProjectVersion(version, key, false).catch(e => {
     return Promise.reject(e);
   });
 

--- a/src/cmds/versions/update.js
+++ b/src/cmds/versions/update.js
@@ -1,9 +1,9 @@
 const request = require('request-promise-native');
 const config = require('config');
-const semver = require('semver');
 const { prompt } = require('enquirer');
 const promptOpts = require('../../lib/prompts');
 const APIError = require('../../lib/apiError');
+const { getSwaggerVersion } = require('../../lib/versionSelect');
 
 exports.command = 'versions:update';
 exports.usage = 'versions:update --version=<version> [options]';
@@ -51,14 +51,12 @@ exports.run = async function (opts) {
     return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
   }
 
-  if (!version || !semver.valid(semver.coerce(version))) {
-    return Promise.reject(
-      new Error(`Please specify a semantic version. See \`${config.cli} help ${exports.command}\` for help.`)
-    );
-  }
+  const selectedVersion = await getSwaggerVersion(version, key, false).catch(e => {
+    return Promise.reject(e);
+  });
 
   const foundVersion = await request
-    .get(`${config.host}/api/v1/version/${version}`, {
+    .get(`${config.host}/api/v1/version/${selectedVersion}`, {
       json: true,
       auth: { user: key },
     })
@@ -78,7 +76,7 @@ exports.run = async function (opts) {
   };
 
   return request
-    .put(`${config.host}/api/v1/version/${version}`, options)
-    .then(() => Promise.resolve(`Version ${version} updated successfully.`))
+    .put(`${config.host}/api/v1/version/${selectedVersion}`, options)
+    .then(() => Promise.resolve(`Version ${selectedVersion} updated successfully.`))
     .catch(err => Promise.reject(new APIError(err)));
 };

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -1,10 +1,13 @@
 const semver = require('semver');
 
-exports.generatePrompts = versionList => [
+exports.generatePrompts = (versionList, selectOnly = false) => [
   {
     type: 'select',
     name: 'option',
     message: 'Would you like to use an existing version or create a new one to associate with your OAS file?',
+    skip() {
+      return selectOnly;
+    },
     choices: [
       { message: 'Use existing', value: 'update' },
       { message: 'Create a new version', value: 'create' },
@@ -15,7 +18,7 @@ exports.generatePrompts = versionList => [
     name: 'versionSelection',
     message: 'Select your desired version',
     skip() {
-      return this.enquirer.answers.option !== 'update';
+      return selectOnly ? false : this.enquirer.answers.option !== 'update';
     },
     choices: versionList.map(v => {
       return {
@@ -29,7 +32,7 @@ exports.generatePrompts = versionList => [
     name: 'newVersion',
     message: "What's your new version?",
     skip() {
-      return this.enquirer.answers.option === 'update';
+      return selectOnly ? true : this.enquirer.answers.option === 'update';
     },
     hint: '1.0.0',
   },

--- a/src/lib/versionSelect.js
+++ b/src/lib/versionSelect.js
@@ -1,0 +1,32 @@
+const { prompt } = require('enquirer');
+const promptOpts = require('./prompts');
+const request = require('request-promise-native');
+const config = require('config');
+const APIError = require('./apiError');
+
+async function getSwaggerVersion(versionFlag, key) {
+  const options = { json: {}, auth: { user: key } };
+
+  try {
+    if (versionFlag) {
+      options.json.version = versionFlag;
+      const foundVersion = await request.get(`${config.host}/api/v1/version/${versionFlag}`, options);
+
+      return foundVersion.version;
+    }
+
+    const versionList = await request.get(`${config.host}/api/v1/version`, options);
+    const { option, versionSelection, newVersion } = await prompt(promptOpts.generatePrompts(versionList, versionFlag));
+
+    if (option === 'update') return versionSelection;
+
+    options.json = { from: versionList[0].version, version: newVersion, is_stable: false };
+    await request.post(`${config.host}/api/v1/version`, options);
+
+    return newVersion;
+  } catch (err) {
+    return Promise.reject(new APIError(err));
+  }
+}
+
+module.exports = { getSwaggerVersion };

--- a/src/lib/versionSelect.js
+++ b/src/lib/versionSelect.js
@@ -4,7 +4,7 @@ const request = require('request-promise-native');
 const config = require('config');
 const APIError = require('./apiError');
 
-async function getSwaggerVersion(versionFlag, key, allowNewVersion) {
+async function getProjectVersion(versionFlag, key, allowNewVersion) {
   const options = { json: {}, auth: { user: key } };
 
   try {
@@ -35,4 +35,4 @@ async function getSwaggerVersion(versionFlag, key, allowNewVersion) {
   }
 }
 
-module.exports = { getSwaggerVersion };
+module.exports = { getProjectVersion };


### PR DESCRIPTION
## 🧰 Changes

We had the option to select an existing version or create a new version with the openapi command if no version argument was provided, this PR adds that to all the commands that require the version argument.
- Adds version selection to the relevant docs and version commands
- Allows for specifying whether the user should receive the option to create a new version or just gives them a list of their current versions to choose from.

## 🧬 QA & Testing

- [x] Make sure tests pass. 
- [x] Make sure you can still input a version as a command line argument
