### PR TITLE
fix: allow customers to define the slug in the metadata

### DIFF
--- a/__tests__/__fixtures__/slug-docs/new-doc-slug.md
+++ b/__tests__/__fixtures__/slug-docs/new-doc-slug.md
@@ -1,0 +1,7 @@
+---
+category: 5ae122e10fdf4e39bb34db6f
+title: This is the document title
+slug: marc-actually-wrote-a-test
+---
+
+Body

--- a/__tests__/__fixtures__/slug-docs/new-doc-slug.md
+++ b/__tests__/__fixtures__/slug-docs/new-doc-slug.md
@@ -1,5 +1,5 @@
 ---
-category: 5ae122e10fdf4e39bb34db6f
+category: CATEGORY_ID
 title: This is the document title
 slug: marc-actually-wrote-a-test
 ---

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -116,7 +116,7 @@ exports.run = async function (opts) {
       const matter = frontMatter(file);
 
       // Stripping the subdirectories and markdown extension from the filename and lowercasing to get the default slug.
-      const slug = path.basename(filename).replace(path.extname(filename), '').toLowerCase();
+      const slug = matter.data.slug || path.basename(filename).replace(path.extname(filename), '').toLowerCase();
       const hash = crypto.createHash('sha1').update(file).digest('hex');
 
       return fetch(`${config.host}/api/v1/docs/${slug}`, {


### PR DESCRIPTION
## 🧰 Changes

Coinbase was running into an issue where pages were getting new slugs instead of updating the existing ones. They added a `slug` field in their metadata in the markdown files, which it seems like we didn't officially support. Since we were using the file name to generate the slug when seeing if a doc existed or not, but still created the page with the slug they defined it was ending up in a weird state where pages were being created on every sync. 

## 🧬 QA & Testing

If you want to test locally you can run the following:

```
./rdme/bin/rdme docs ~/path/to/markdown --key KEY --version 1.0
```

This will update the page here: https://dash.readme.com/project/PROJECT/v1.0/docs/new-page

```
---
title: "New Page"
slug: "new-page"
category: "CATEGORY ID"
---
# This is a page with a slug defined

Look at that slug. 🐌 (not a slug, but the best I can do)
```