### PR TITLE
feat: adding a new `validate` command for validating API definitions

### DIFF
--- a/__tests__/__fixtures__/swagger-with-invalid-extensions.json
+++ b/__tests__/__fixtures__/swagger-with-invalid-extensions.json
@@ -21,8 +21,7 @@
       "description": "Everything about your Pets",
       "externalDocs": {
         "description": "Find out more",
-        "url": "http://swagger.io",
-        "this-shouldnt-be-here": true
+        "url": "http://swagger.io"
       }
     }
   ],
@@ -176,5 +175,6 @@
   "externalDocs": {
     "description": "Find out more about Swagger",
     "url": "http://swagger.io"
-  }
+  },
+  "x-samples-languages": "some invalid value"
 }

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -18,7 +18,8 @@ Alias for \`rdme openapi\`. [deprecated]
 
 [4m[1mRelated commands[22m[24m
 
-  [90m$[39m rdme openapi   Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
+  [90m$[39m rdme openapi    Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
+  [90m$[39m rdme validate   Validate your OpenAPI/Swagger definition.                     
 "
 `;
 
@@ -67,8 +68,9 @@ exports[`cli --help should print help 1`] = `
 
 [4m[1mUpload OpenAPI/Swagger definitions[22m[24m
 
-  [90m$[39m rdme openapi   Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
-  [90m$[39m rdme swagger   Alias for \`rdme openapi\`. [deprecated]                        
+  [90m$[39m rdme openapi    Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
+  [90m$[39m rdme validate   Validate your OpenAPI/Swagger definition.                     
+  [90m$[39m rdme swagger    Alias for \`rdme openapi\`. [deprecated]                        
 
 [4m[1mDocumentation[22m[24m
 
@@ -139,8 +141,9 @@ exports[`cli --help should print help for the \`-H\` alias 1`] = `
 
 [4m[1mUpload OpenAPI/Swagger definitions[22m[24m
 
-  [90m$[39m rdme openapi   Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
-  [90m$[39m rdme swagger   Alias for \`rdme openapi\`. [deprecated]                        
+  [90m$[39m rdme openapi    Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
+  [90m$[39m rdme validate   Validate your OpenAPI/Swagger definition.                     
+  [90m$[39m rdme swagger    Alias for \`rdme openapi\`. [deprecated]                        
 
 [4m[1mDocumentation[22m[24m
 
@@ -184,7 +187,8 @@ Alias for \`rdme openapi\`. [deprecated]
 
 [4m[1mRelated commands[22m[24m
 
-  [90m$[39m rdme openapi   Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
+  [90m$[39m rdme openapi    Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
+  [90m$[39m rdme validate   Validate your OpenAPI/Swagger definition.                     
 "
 `;
 
@@ -206,7 +210,8 @@ Alias for \`rdme openapi\`. [deprecated]
 
 [4m[1mRelated commands[22m[24m
 
-  [90m$[39m rdme openapi   Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
+  [90m$[39m rdme openapi    Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
+  [90m$[39m rdme validate   Validate your OpenAPI/Swagger definition.                     
 "
 `;
 

--- a/__tests__/cmds/__snapshots__/validate.test.js.snap
+++ b/__tests__/cmds/__snapshots__/validate.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rdme validate error handling should throw an error if an in valid Swagger definition is supplied 1`] = `
+[Error: Swagger schema validation failed.
+
+[31m[1mADDTIONAL PROPERTY[22m[39m[31m must NOT have additional properties[39m
+
+[0m [90m 23 |[39m         [32m"description"[39m[33m:[39m [32m"Find out more"[39m[33m,[39m[0m
+[0m [90m 24 |[39m         [32m"url"[39m[33m:[39m [32m"http://swagger.io"[39m[33m,[39m[0m
+[0m[31m[1m>[22m[39m[90m 25 |[39m         [32m"this-shouldnt-be-here"[39m[33m:[39m [36mtrue[39m[0m
+[0m [90m    |[39m         [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m [31m[1m😲  [95mthis-shouldnt-be-here[31m is not expected to be here![22m[39m[0m
+[0m [90m 26 |[39m       }[0m
+[0m [90m 27 |[39m     }[0m
+[0m [90m 28 |[39m   ][33m,[39m[0m]
+`;
+
+exports[`rdme validate error handling should throw an error if an invalid OpenAPI 3.1 definition is supplied 1`] = `
+[Error: OpenAPI schema validation failed.
+
+[31m[1mREQUIRED[22m[39m[31m must have required property 'openIdConnectUrl'[39m
+
+[0m [90m 24 |[39m   [32m"components"[39m[33m:[39m {[0m
+[0m [90m 25 |[39m     [32m"securitySchemes"[39m[33m:[39m {[0m
+[0m[31m[1m>[22m[39m[90m 26 |[39m       [32m"tlsAuth"[39m[33m:[39m {[0m
+[0m [90m    |[39m                  [31m[1m^[22m[39m [31m[1m☹️  [95mopenIdConnectUrl[31m is missing here![22m[39m[0m
+[0m [90m 27 |[39m         [32m"type"[39m[33m:[39m [32m"mutualTLS"[39m[0m
+[0m [90m 28 |[39m       }[0m
+[0m [90m 29 |[39m     }[0m]
+`;

--- a/__tests__/cmds/openapi.test.js
+++ b/__tests__/cmds/openapi.test.js
@@ -270,14 +270,20 @@ describe('rdme openapi', () => {
           help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
         });
 
-      return openapi.run({ spec: './__tests__/__fixtures__/invalid-swagger.json', key, version }).then(() => {
-        expect(console.log).toHaveBeenCalledTimes(1);
+      return openapi
+        .run({
+          spec: './__tests__/__fixtures__/swagger-with-invalid-extensions.json',
+          key,
+          version,
+        })
+        .then(() => {
+          expect(console.log).toHaveBeenCalledTimes(1);
 
-        const output = getCommandOutput();
-        expect(output).toMatch(/Unknown error \(README VALIDATION ERROR "x-samples-languages" /);
+          const output = getCommandOutput();
+          expect(output).toMatch(/Unknown error \(README VALIDATION ERROR "x-samples-languages" /);
 
-        mock.done();
-      });
+          mock.done();
+        });
     });
 
     it('should error if API errors', () => {

--- a/__tests__/cmds/validate.test.js
+++ b/__tests__/cmds/validate.test.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const validate = require('../../src/cmds/validate');
+
+const getCommandOutput = () => {
+  return [console.warn.mock.calls.join('\n\n'), console.log.mock.calls.join('\n\n')].filter(Boolean).join('\n\n');
+};
+
+describe('rdme validate', () => {
+  beforeEach(() => {
+    console.log = jest.fn();
+    console.warn = jest.fn();
+  });
+
+  afterEach(() => {
+    console.log.mockRestore();
+    console.warn.mockRestore();
+  });
+
+  it.each([
+    ['Swagger 2.0', 'json', '2.0'],
+    ['Swagger 2.0', 'yaml', '2.0'],
+    ['OpenAPI 3.0', 'json', '3.0'],
+    ['OpenAPI 3.0', 'yaml', '3.0'],
+    ['OpenAPI 3.1', 'json', '3.1'],
+    ['OpenAPI 3.1', 'yaml', '3.1'],
+  ])('should support validating a %s definition (format: %s)', (_, format, specVersion) => {
+    return validate
+      .run({
+        spec: require.resolve(`@readme/oas-examples/${specVersion}/${format}/petstore.${format}`),
+      })
+      .then(() => {
+        expect(console.log).toHaveBeenCalledTimes(1);
+
+        const output = getCommandOutput();
+        if (specVersion === '2.0') {
+          expect(output).toContain(`petstore.${format} is a valid Swagger API definition!`);
+        } else {
+          expect(output).toContain(`petstore.${format} is a valid OpenAPI API definition!`);
+        }
+      });
+  });
+
+  it('should discover and upload an API definition if none is provided', () => {
+    // Surface our test fixture to the root directory so rdme can autodiscover it. It's easier to do
+    // this than mocking out the fs module because mocking the fs module here causes Jest sourcemaps
+    // to break.
+    fs.copyFileSync(require.resolve('@readme/oas-examples/2.0/json/petstore.json'), './swagger.json');
+
+    return validate.run({}).then(() => {
+      expect(console.log).toHaveBeenCalledTimes(2);
+
+      const output = getCommandOutput();
+      expect(output).toContain('We found swagger.json and are attempting to validate it.');
+      expect(output).toContain('swagger.json is a valid Swagger API definition!');
+
+      fs.unlinkSync('./swagger.json');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw an error if an invalid OpenAPI 3.0 definition is supplied', async () => {
+      await expect(validate.run({ spec: './__tests__/__fixtures__/invalid-oas.json' })).rejects.toThrow(
+        'Token "Error" does not exist.'
+      );
+    });
+
+    it('should throw an error if an invalid OpenAPI 3.1 definition is supplied', async () => {
+      await expect(validate.run({ spec: './__tests__/__fixtures__/invalid-oas-3.1.json' })).rejects.toMatchSnapshot();
+    });
+
+    it('should throw an error if an in valid Swagger definition is supplied', async () => {
+      await expect(validate.run({ spec: './__tests__/__fixtures__/invalid-swagger.json' })).rejects.toMatchSnapshot();
+    });
+  });
+});

--- a/src/cmds/validate.js
+++ b/src/cmds/validate.js
@@ -1,0 +1,62 @@
+const chalk = require('chalk');
+const fs = require('fs');
+const OASNormalize = require('oas-normalize');
+
+exports.command = 'validate';
+exports.usage = 'validate [file] [options]';
+exports.description = 'Validate your OpenAPI/Swagger definition.';
+exports.category = 'apis';
+exports.position = 2;
+
+exports.hiddenArgs = ['spec'];
+exports.args = [
+  {
+    name: 'spec',
+    type: String,
+    defaultOption: true,
+  },
+];
+
+exports.run = async function (opts) {
+  const { spec } = opts;
+
+  async function validateSpec(specPath) {
+    const oas = new OASNormalize(specPath, { colorizeErrors: true, enablePaths: true });
+
+    return oas
+      .validate(false)
+      .then(api => {
+        if (api.swagger) {
+          console.log(chalk.green(`${specPath} is a valid Swagger API definition!`));
+        } else {
+          console.log(chalk.green(`${specPath} is a valid OpenAPI API definition!`));
+        }
+      })
+      .catch(err => {
+        return Promise.reject(new Error(err.message));
+      });
+  }
+
+  if (spec) {
+    return validateSpec(spec);
+  }
+
+  // If the user didn't supply an API specification, let's try to locate what they've got, and validate that. If they
+  // don't have any, let's let the user know how they can get one going.
+  return new Promise((resolve, reject) => {
+    ['swagger.json', 'swagger.yaml', 'openapi.json', 'openapi.yaml'].forEach(file => {
+      if (!fs.existsSync(file)) {
+        return;
+      }
+
+      console.log(chalk.yellow(`We found ${file} and are attempting to validate it.`));
+      resolve(validateSpec(file));
+    });
+
+    reject(
+      new Error(
+        "We couldn't find an OpenAPI or Swagger definition.\n\nIf you need help creating one run `rdme oas init`!"
+      )
+    );
+  });
+};


### PR DESCRIPTION
## 🧰 Changes

This adds a new `rdme validate` command that can either take a file to validate or like `rdme openapi` search the local filesystem for a file matching `/(swagger|openapi).(json|yaml)/` to validate instead.

Resolves https://github.com/readmeio/rdme/issues/326.

## 🧬 QA & Testing

Here's what the command looks like in action:

![Screen Shot 2021-12-09 at 12 28 43 PM](https://user-images.githubusercontent.com/33762/145473225-45b3ed94-a2a6-4f41-9772-a0b05aefec25.png)