### PR TITLE
feat(versions): stringify JSON for `--raw` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ rdme docs:edit <slug> --version={project-version}
 rdme versions
 ```
 
-If you wish to see the raw output from our API in this response, supply  the `--raw` flag.
+If you wish to see the raw JSON output from our API in this response, supply  the `--raw` flag.
 
 #### Get All Information About a Particular Version
 ```sh
 rdme versions --version={project-version}
 ```
 
-If you wish to see the raw output from our API in this response, supply  the `--raw` flag.
+If you wish to see the raw JSON output from our API in this response, supply  the `--raw` flag.
 
 #### Create a New Version
 ```sh

--- a/__tests__/cmds/versions.test.js
+++ b/__tests__/cmds/versions.test.js
@@ -64,7 +64,7 @@ describe('rdme versions*', () => {
         .reply(200, [versionPayload, version2Payload]);
 
       const response = await versions.run({ key, raw: true });
-      expect(response).toStrictEqual([versionPayload, version2Payload]);
+      expect(response).toStrictEqual(JSON.stringify([versionPayload, version2Payload], null, 2));
       mockRequest.done();
     });
 
@@ -88,7 +88,7 @@ describe('rdme versions*', () => {
         .reply(200, versionPayload);
 
       return versions.run({ key, version, raw: true }).then(response => {
-        expect(response).toStrictEqual(versionPayload);
+        expect(response).toStrictEqual(JSON.stringify(versionPayload, null, 2));
         mockRequest.done();
       });
     });

--- a/src/cmds/versions/index.js
+++ b/src/cmds/versions/index.js
@@ -102,7 +102,7 @@ exports.run = function (opts) {
       }
 
       if (raw) {
-        return Promise.resolve(data);
+        return Promise.resolve(JSON.stringify(data, null, 2));
       }
 
       let versions = data;


### PR DESCRIPTION
## 🧰 Changes

Updates the `--raw` option so it outputs a JSON object rather than a JS object. Resolves #369.

## 🧬 QA & Testing

See tests! You can also check this branch out locally and run commands like:
```sh
bin/rdme versions --raw | jq
```
and do filtering with something like:
```sh
bin/rdme versions --raw | jq '.[] | select(.is_stable == true)'
```
