### PR TITLE
docs: add/improve our command warnings

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -13,7 +13,7 @@ Upload, or resync, your OpenAPI/Swagger definition to ReadMe.
   [1m--key[22m [4mstring[24m       Project API key                                                               
   [1m--id[22m [4mstring[24m        Unique identifier for your API definition. Use this if you're re-uploading an 
                      existing API definition                                                       
-  [1m--version[22m [4mstring[24m   Project version (this is not necessary if you are passing the \`--id\` option)  
+  [1m--version[22m [4mstring[24m   Project version                                                               
   [1m-h[22m, [1m--help[22m         Display this usage guide                                                      
 
 [4m[1mRelated commands[22m[24m
@@ -182,7 +182,7 @@ Upload, or resync, your OpenAPI/Swagger definition to ReadMe.
   [1m--key[22m [4mstring[24m       Project API key                                                               
   [1m--id[22m [4mstring[24m        Unique identifier for your API definition. Use this if you're re-uploading an 
                      existing API definition                                                       
-  [1m--version[22m [4mstring[24m   Project version (this is not necessary if you are passing the \`--id\` option)  
+  [1m--version[22m [4mstring[24m   Project version                                                               
   [1m-h[22m, [1m--help[22m         Display this usage guide                                                      
 
 [4m[1mRelated commands[22m[24m
@@ -205,7 +205,7 @@ Upload, or resync, your OpenAPI/Swagger definition to ReadMe.
   [1m--key[22m [4mstring[24m       Project API key                                                               
   [1m--id[22m [4mstring[24m        Unique identifier for your API definition. Use this if you're re-uploading an 
                      existing API definition                                                       
-  [1m--version[22m [4mstring[24m   Project version (this is not necessary if you are passing the \`--id\` option)  
+  [1m--version[22m [4mstring[24m   Project version                                                               
   [1m-h[22m, [1m--help[22m         Display this usage guide                                                      
 
 [4m[1mRelated commands[22m[24m

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -2,24 +2,24 @@
 
 exports[`cli --help should not surface args that are designated as hidden 1`] = `
 "
-Alias for \`rdme openapi\`. [deprecated]
+Upload, or resync, your OpenAPI/Swagger definition to ReadMe.
 
 [4m[1mUsage[22m[24m
 
-  rdme swagger [file] [options] 
+  rdme openapi [file] [options] 
 
 [4m[1mOptions[22m[24m
 
   [1m--key[22m [4mstring[24m       Project API key                                                               
-  [1m--id[22m [4mstring[24m        Unique identifier for your API definition. Use this if you're resyncing an    
+  [1m--id[22m [4mstring[24m        Unique identifier for your API definition. Use this if you're re-uploading an 
                      existing API definition                                                       
-  [1m--version[22m [4mstring[24m   Project version                                                               
+  [1m--version[22m [4mstring[24m   Project version (this is not necessary if you are passing the \`--id\` option)  
   [1m-h[22m, [1m--help[22m         Display this usage guide                                                      
 
 [4m[1mRelated commands[22m[24m
 
-  [90m$[39m rdme openapi    Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
-  [90m$[39m rdme validate   Validate your OpenAPI/Swagger definition.                     
+  [90m$[39m rdme validate   Validate your OpenAPI/Swagger definition. 
+  [90m$[39m rdme swagger    Alias for \`rdme openapi\`. [deprecated]    
 "
 `;
 
@@ -171,47 +171,47 @@ To get more help with ReadMe, check out our docs at https://docs.readme.com.
 
 exports[`cli --help should print usage for a given command 1`] = `
 "
-Alias for \`rdme openapi\`. [deprecated]
+Upload, or resync, your OpenAPI/Swagger definition to ReadMe.
 
 [4m[1mUsage[22m[24m
 
-  rdme swagger [file] [options] 
+  rdme openapi [file] [options] 
 
 [4m[1mOptions[22m[24m
 
   [1m--key[22m [4mstring[24m       Project API key                                                               
-  [1m--id[22m [4mstring[24m        Unique identifier for your API definition. Use this if you're resyncing an    
+  [1m--id[22m [4mstring[24m        Unique identifier for your API definition. Use this if you're re-uploading an 
                      existing API definition                                                       
-  [1m--version[22m [4mstring[24m   Project version                                                               
+  [1m--version[22m [4mstring[24m   Project version (this is not necessary if you are passing the \`--id\` option)  
   [1m-h[22m, [1m--help[22m         Display this usage guide                                                      
 
 [4m[1mRelated commands[22m[24m
 
-  [90m$[39m rdme openapi    Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
-  [90m$[39m rdme validate   Validate your OpenAPI/Swagger definition.                     
+  [90m$[39m rdme validate   Validate your OpenAPI/Swagger definition. 
+  [90m$[39m rdme swagger    Alias for \`rdme openapi\`. [deprecated]    
 "
 `;
 
 exports[`cli --help should print usage for a given command if supplied as \`help <command>\` 1`] = `
 "
-Alias for \`rdme openapi\`. [deprecated]
+Upload, or resync, your OpenAPI/Swagger definition to ReadMe.
 
 [4m[1mUsage[22m[24m
 
-  rdme swagger [file] [options] 
+  rdme openapi [file] [options] 
 
 [4m[1mOptions[22m[24m
 
   [1m--key[22m [4mstring[24m       Project API key                                                               
-  [1m--id[22m [4mstring[24m        Unique identifier for your API definition. Use this if you're resyncing an    
+  [1m--id[22m [4mstring[24m        Unique identifier for your API definition. Use this if you're re-uploading an 
                      existing API definition                                                       
-  [1m--version[22m [4mstring[24m   Project version                                                               
+  [1m--version[22m [4mstring[24m   Project version (this is not necessary if you are passing the \`--id\` option)  
   [1m-h[22m, [1m--help[22m         Display this usage guide                                                      
 
 [4m[1mRelated commands[22m[24m
 
-  [90m$[39m rdme openapi    Upload, or resync, your OpenAPI/Swagger definition to ReadMe. 
-  [90m$[39m rdme validate   Validate your OpenAPI/Swagger definition.                     
+  [90m$[39m rdme validate   Validate your OpenAPI/Swagger definition. 
+  [90m$[39m rdme swagger    Alias for \`rdme openapi\`. [deprecated]    
 "
 `;
 

--- a/__tests__/cmds/openapi.test.js
+++ b/__tests__/cmds/openapi.test.js
@@ -144,12 +144,12 @@ describe('rdme openapi', () => {
       return openapi
         .run({ spec: require.resolve('@readme/oas-examples/3.1/json/petstore.json'), token: `${key}-${id}`, version })
         .then(() => {
-          expect(console.warn).toHaveBeenCalledTimes(1);
+          expect(console.warn).toHaveBeenCalledTimes(2);
           expect(console.log).toHaveBeenCalledTimes(1);
 
           const output = getCommandOutput();
 
-          expect(output).toMatch(/using `rdme` with --token has been deprecated/i);
+          expect(output).toMatch(/The `--token` option has been deprecated/i);
 
           mock.done();
         });

--- a/__tests__/cmds/openapi.test.js
+++ b/__tests__/cmds/openapi.test.js
@@ -154,6 +154,26 @@ describe('rdme openapi', () => {
           mock.done();
         });
     });
+
+    it('should return warning if providing `id` and `version`', () => {
+      const mock = nock(config.host)
+        .put(`/api/v1/api-specification/${id}`, body => body.match('form-data; name="spec"'))
+        .basicAuth({ user: key })
+        .reply(201, { id: 1 }, { location: exampleRefLocation });
+
+      return openapi
+        .run({ spec: require.resolve('@readme/oas-examples/3.1/json/petstore.json'), key, id, version })
+        .then(() => {
+          expect(console.warn).toHaveBeenCalledTimes(1);
+          expect(console.log).toHaveBeenCalledTimes(1);
+
+          const output = getCommandOutput();
+
+          expect(output).toMatch(/the `--version` option will be ignored/i);
+
+          mock.done();
+        });
+    });
   });
 
   describe('versioning', () => {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -69,15 +69,15 @@ describe('cli', () => {
     });
 
     it('should print usage for a given command', async () => {
-      await expect(cli(['swagger', '--help'])).resolves.toMatchSnapshot();
+      await expect(cli(['openapi', '--help'])).resolves.toMatchSnapshot();
     });
 
     it('should print usage for a given command if supplied as `help <command>`', async () => {
-      await expect(cli(['help', 'swagger'])).resolves.toMatchSnapshot();
+      await expect(cli(['help', 'openapi'])).resolves.toMatchSnapshot();
     });
 
     it('should not surface args that are designated as hidden', async () => {
-      await expect(cli(['swagger', '--help'])).resolves.toMatchSnapshot();
+      await expect(cli(['openapi', '--help'])).resolves.toMatchSnapshot();
     });
 
     it('should show related commands for a subcommands help menu', async () => {

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -38,7 +38,7 @@ exports.args = [
   {
     name: 'version',
     type: String,
-    description: 'Project version (this is not necessary if you are passing the `--id` option)',
+    description: 'Project version',
   },
   {
     name: 'spec',

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -28,7 +28,7 @@ exports.args = [
   {
     name: 'id',
     type: String,
-    description: `Unique identifier for your API definition. Use this if you're resyncing an existing API definition`,
+    description: `Unique identifier for your API definition. Use this if you're re-uploading an existing API definition`,
   },
   {
     name: 'token',
@@ -38,7 +38,7 @@ exports.args = [
   {
     name: 'version',
     type: String,
-    description: 'Project version',
+    description: 'Project version (this is not necessary if you are passing the `--id` option)',
   },
   {
     name: 'spec',

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -54,9 +54,13 @@ exports.run = async function (opts) {
   let isUpdate;
 
   if (!key && opts.token) {
-    console.warn('Using `rdme` with --token has been deprecated. Please use `--key` and `--id` instead.');
+    console.warn('Warning: `--token` has been deprecated. Please use `--key` and `--id` instead.');
 
     [key, id] = opts.token.split('-');
+  }
+
+  if (version && id) {
+    console.warn('Warning: `--version` parameter is ignored because `--id` parameter is');
   }
 
   if (!key) {

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -54,16 +54,20 @@ exports.run = async function (opts) {
   let isUpdate;
 
   if (!key && opts.token) {
-    console.warn('Heads up! The `--token` option has been deprecated. Please use `--key` and `--id` instead.');
+    console.warn(
+      chalk.yellow('⚠️  Warning! The `--token` option has been deprecated. Please use `--key` and `--id` instead.')
+    );
 
     [key, id] = opts.token.split('-');
   }
 
   if (version && id) {
     console.warn(
-      `Heads up! We'll be using the version associated with the \`--${
-        opts.token ? 'token' : 'id'
-      }\` option, so the \`--version\` option will be ignored.`
+      chalk.yellow(
+        `⚠️  Warning! We'll be using the version associated with the \`--${
+          opts.token ? 'token' : 'id'
+        }\` option, so the \`--version\` option will be ignored.`
+      )
     );
   }
 

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -54,13 +54,17 @@ exports.run = async function (opts) {
   let isUpdate;
 
   if (!key && opts.token) {
-    console.warn('Warning: `--token` has been deprecated. Please use `--key` and `--id` instead.');
+    console.warn('Heads up! The `--token` option has been deprecated. Please use `--key` and `--id` instead.');
 
     [key, id] = opts.token.split('-');
   }
 
   if (version && id) {
-    console.warn('Warning: `--version` parameter is ignored because `--id` parameter is');
+    console.warn(
+      `Heads up! We'll be using the version associated with the \`--${
+        opts.token ? 'token' : 'id'
+      }\` option, so the \`--version\` option will be ignored.`
+    );
   }
 
   if (!key) {

--- a/src/cmds/swagger.js
+++ b/src/cmds/swagger.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk');
 const openapi = require('./openapi');
 
 exports.command = 'swagger';
@@ -10,6 +11,6 @@ exports.hiddenArgs = openapi.hiddenArgs;
 exports.args = openapi.args;
 
 exports.run = async function (opts) {
-  console.warn('`rdme swagger` has been deprecated. Please use `rdme openapi` instead.');
+  console.warn(chalk.yellow('⚠️  Warning! `rdme swagger` has been deprecated. Please use `rdme openapi` instead.'));
   return openapi.run(opts);
 };


### PR DESCRIPTION
## 🧰 Changes

- [x] Added a warning for when someone uses the `openapi` command with both a `version` and `id` parameter, since the `version` parameter is ignored in this case. This has created a lot of confusion for users so hopefully this warning should provide some clarification
   - [x] Added a test for this
- [x] Enhanced language and formatting in several warnings 🟡 (one potential enhancement idea: what if we had an ESLint rule or something that prevented us from using `console.warn` and instead we had to use a standard shared chalk-formatted logger function? cc: @erunion)
- [x] Updated a test to test against our `openapi` command and refreshed its corresponding snapshot (see [this comment](https://github.com/readmeio/rdme/pull/406#discussion_r770807518))

## 🧬 QA & Testing

Do tests pass?
