### PR TITLE
ci: drop the npm@7 requirement before installing deps in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install npm@7
-        run: npm install -g npm@7
-
       - name: Install deps
         run: npm ci
 


### PR DESCRIPTION
## 🧰 Changes

Since rdme doesn't have any peerDependencies we don't need >= npm@7 in CI. 

## 🧬 QA & Testing

If all tests are still all passing then this is good to go.