### PR TITLE
fix(openapi): return rejected `Promise` if spec uploads fail

### DIFF
--- a/bin/rdme
+++ b/bin/rdme
@@ -11,7 +11,7 @@ require('../src')(process.argv.slice(2))
       const err = e;
 
       if ('message' in err) {
-        console.error(chalk.red(err.message));
+        console.error(chalk.red(`\n${err.message}\n`));
       } else {
         console.error(
           chalk.red(

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -150,23 +150,19 @@ exports.run = async function (opts) {
 
     function createSpec() {
       options.method = 'post';
-      return fetch(`${config.host}/api/v1/api-specification`, options)
-        .then(res => {
-          if (res.ok) return success(res);
-          return error(res);
-        })
-        .catch(err => console.log(chalk.red(`\n ${err.message}\n`)));
+      return fetch(`${config.host}/api/v1/api-specification`, options).then(res => {
+        if (res.ok) return success(res);
+        return error(res);
+      });
     }
 
     function updateSpec(specId) {
       isUpdate = true;
       options.method = 'put';
-      return fetch(`${config.host}/api/v1/api-specification/${specId}`, options)
-        .then(res => {
-          if (res.ok) return success(res);
-          return error(res);
-        })
-        .catch(err => console.log(chalk.red(`\n ${err.message}\n`)));
+      return fetch(`${config.host}/api/v1/api-specification/${specId}`, options).then(res => {
+        if (res.ok) return success(res);
+        return error(res);
+      });
     }
 
     /*

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ module.exports = processArgv => {
     return bin.run(cmdArgv);
   } catch (e) {
     if (e.message === 'Command not found.') {
-      e.description = `Type \`${chalk.yellow(`${config.cli} help`)}\` ${chalk.red('to see all commands')}`;
+      e.message = `${e.message}\n\nType \`${chalk.yellow(`${config.cli} help`)}\` ${chalk.red('to see all commands')}`;
     }
 
     return Promise.reject(e);


### PR DESCRIPTION
## 🧰 Changes

Turns out we had an edge case where we were returning a `console.log()` rather than a rejected `Promise` when we received errors from the API, resulting in an incorrectly successful exit code. This PR fixes that in https://github.com/readmeio/rdme/pull/409/commits/0f2372ed1fc0b94ddba546a5a162b35297c0444b so we properly return an exit code of 1. And as expected, some housekeeping:
- [x] Refactors existing tests to check for the rejected `Promise` rather than a console output https://github.com/readmeio/rdme/commit/8811c8ce6945e33958d7979668e95d39e85e3f54
- [x] Adds additional test coverage to check for our other API error edge cases. We're now over 90% line coverage in the OpenAPI command file! 📈 https://github.com/readmeio/rdme/commit/8811c8ce6945e33958d7979668e95d39e85e3f54
- [x] Slightly reformats our rejected `Promise` error outputs to be padded with newlines https://github.com/readmeio/rdme/commit/9936de5d68e6c9c77aebc762001d4076ff871115
- [x] Small fix to our general command handler so it properly uses our lengthier error message for invalid commands. https://github.com/readmeio/rdme/commit/3b75d297c32813a4fcd69dba009d92ff4e4439b1 See below for a before and after:

![image](https://user-images.githubusercontent.com/8854718/146616223-dbe14b60-c0d5-4cde-8397-44c26a06fa1d.png)

Resolves #407.

## 🧬 QA & Testing

If the tests pass, we should be good! But as an extra check, you can check out this branch and run the following commands to confirm that we see a non-zero exit code:

```sh
$ bin/rdme openapi --id="asdf" --key="asdf" ./__tests__/__fixtures__/ref-oas/petstore.json

We couldn't find your API key.

If you need help, email support@readme.io and include the following link to your API log: 'https://docs.readme.com/logs/xxx-xxx'.

$ echo $?
1
```