### PR TITLE
ci: tweak ESLint config, small refactors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,16 @@
   "extends": ["@readme/eslint-config"],
   "root": true,
   "rules": {
-    "no-console": "off"
+    /**
+     * This is a small rule to prevent us from using console.log() statements in our commands.
+     *
+     * We've had troubles in the past where our test coverage required us to use Jest mocks for
+     * console.log() calls, hurting our ability to write resilient tests and easily debug issues.
+     *
+     * We should be returning Promise-wrapped values in our main command functions
+     * so we can write robust tests and take advantage of `bin/rdme`,
+     * which we use for printing function outputs and returning correct exit codes.
+     */
+    "no-console": ["warn", { "allow": ["info", "warn"] }]
   }
 }

--- a/bin/rdme
+++ b/bin/rdme
@@ -3,25 +3,20 @@ const chalk = require('chalk');
 
 require('../src')(process.argv.slice(2))
   .then(msg => {
+    // eslint-disable-next-line no-console
     if (msg) console.log(msg);
-    process.exit(0);
+    return process.exit(0);
   })
-  .catch(e => {
-    if (e) {
-      const err = e;
+  .catch(err => {
+    let message = `Yikes, something went wrong! Please try again and if the problem persists, get in touch with our support team at ${chalk.underline(
+      'support@readme.io'
+    )}.`;
 
-      if ('message' in err) {
-        console.error(chalk.red(`\n${err.message}\n`));
-      } else {
-        console.error(
-          chalk.red(
-            `Yikes, something went wrong! Please try again and if the problem persists, get in touch with our support team at ${chalk.underline(
-              'support@readme.io'
-            )}.\n`
-          )
-        );
-      }
+    if (err && 'message' in err) {
+      message = err.message;
     }
 
+    // eslint-disable-next-line no-console
+    console.error(chalk.red(`\n${message}\n`));
     return process.exit(1);
   });


### PR DESCRIPTION
## 🧰 Changes

- [x] Updates our ESLint config to add warnings when we attempt to use `console.log()` statements (and added an explanatory comment
- [x] Slight refactors to `bin/rdme` to make it a bit more readable.

## 🧬 QA & Testing

Does CI pass with no warnings?

**EDIT:** [yes](https://github.com/readmeio/rdme/runs/4745002939?check_suite_focus=true#step:5:12)
