### PR TITLE
docs: add GitHub Actions guidance

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           find: 'RDME_VERSION'
           replace: ${{ steps.rdme-version.outputs.RDME_VERSION }}
           regex: false
-          include: documentation/
+          include: documentation/*
 
       # And finally, with our updated documentation,
       # we run the `rdme` GitHub Action to sync the Markdown file

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
         run: ./bin/set-version-output
 
       # Next, we use this output to do a few find/replaces!
-      - name: Find and replace version placeholders in docs
+      - name: Find and replace Node.js version placeholders
         uses: jacobtomlinson/gha-find-replace@v2
         with:
           find: 'NODE_VERSION'
@@ -29,7 +29,7 @@ jobs:
           regex: false
           include: documentation/*
 
-      - name: Find and replace version placeholders in docs
+      - name: Find and replace `rdme` version placeholders
         uses: jacobtomlinson/gha-find-replace@v2
         with:
           find: 'RDME_VERSION'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,9 +34,9 @@ jobs:
       # in the `documentation` directory.
       # Here's the page we're syncing: https://docs.readme.com/docs/rdme
       - name: GitHub Action
-        # Use the `main` branch as ref for GitHub Action
-        # Not recommended, this can break your workflows!
-        # We recommend specifying a fixed version
+        # We use the `main` branch as ref for GitHub Action
+        # This is NOT recommended, as it can break your workflows without notice!
+        # We recommend specifying a fixed version, i.e. @7.0
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
         uses: readmeio/rdme@main
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       # Run GitHub Action to sync docs in `documentation` directory
+      # Page we're syncing: https://docs.readme.com/docs/rdme
       - name: GitHub Action
         # Use the `main` branch as ref for GitHub Action
         # Not recommended, this can break your workflows!

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,10 @@
 name: Sync `documentation` directory to ReadMe
 
 # Run workflow for every push to the `main` branch
-on: push
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   sync:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,13 +14,21 @@ jobs:
       # Note that these next two steps are not required
       # in order to sync your docs to ReadMe.
 
-      # First, we run a script that grabs the current version from
-      # our package.json and sets it as a GitHub Action output!
+      # First, we run a script that sets a few outputs:
+      # our package version and our Node.js version.
       - name: Retrieve `rdme` version from package.json
         id: rdme-version
         run: ./bin/set-version-output
 
-      # Next, we use this output to do a simple find and replace!
+      # Next, we use this output to do a few find/replaces!
+      - name: Find and replace version placeholders in docs
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: 'NODE_VERSION'
+          replace: ${{ steps.rdme-version.outputs.NODE_VERSION }}
+          regex: false
+          include: documentation/*
+
       - name: Find and replace version placeholders in docs
         uses: jacobtomlinson/gha-find-replace@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,7 @@
 name: Sync `documentation` directory to ReadMe
 
 # Run workflow for every push to the `main` branch
-on:
-  push:
-    branches:
-      - main
+on: push
 
 jobs:
   sync:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+name: Sync `documentation` directory to ReadMe
+
+# Run workflow for every push to the `main` branch
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v2.4.0
+
+      # Run GitHub Action to sync docs in `documentation` directory
+      - name: GitHub Action
+        # Use the `main` branch as ref for GitHub Action
+        # Not recommended, this can break your workflows!
+        # We recommend specifying a fixed version
+        # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
+        uses: readmeio/rdme@main
+        with:
+          rdme: docs ./documentation --key=${{ secrets.README_PROD_PROJECT_API_KEY }} --version=2.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,29 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v2.4.0
 
-      # Run GitHub Action to sync docs in `documentation` directory
-      # Page we're syncing: https://docs.readme.com/docs/rdme
+      # Let's dynamically update our docs with the latest version of rdme!
+      # Note that these next two steps are not required
+      # in order to sync your docs to ReadMe.
+
+      # First, we run a script that grabs the current version from
+      # our package.json and sets it as a GitHub Action output!
+      - name: Retrieve `rdme` version from package.json
+        id: rdme-version
+        run: ./bin/set-version-output
+
+      # Next, we use this output to do a simple find and replace!
+      - name: Find and replace version placeholders in docs
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: 'RDME_VERSION'
+          replace: ${{ steps.rdme-version.outputs.RDME_VERSION }}
+          regex: false
+          include: documentation/
+
+      # And finally, with our updated documentation,
+      # we run the `rdme` GitHub Action to sync the Markdown file
+      # in the `documentation` directory.
+      # Here's the page we're syncing: https://docs.readme.com/docs/rdme
       - name: GitHub Action
         # Use the `main` branch as ref for GitHub Action
         # Not recommended, this can break your workflows!

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ rdme validate [path-to-file.json]
 
 #### Syncing a Folder of Markdown Docs to ReadMe
 
+The Markdown files will require YAML front matter with certain ReadMe documentation attributes. Check out [our docs](https://docs.readme.com/docs/rdme#markdown-file-setup) for more info.
+
 ```sh
 rdme docs path-to-markdown-files --version={project-version}
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To ensure you're getting the latest features and security updates, we recommend 
 
 ### Authentication
 
-For usage in CI environments (GitHub Actions, CircleCI, Travis CI, etc.) or if you're working with multiple ReadMe projects, we recommend providing your project API key via the `--key` option instead of the configuration file authentication described below.
+For usage in CI environments (GitHub Actions, CircleCI, Travis CI, etc.) or if you're working with multiple ReadMe projects, we recommend providing your project API key via the `--key` option (instead of the configuration file authentication described below).
 
 For local CLI usage with a single project, you can authenticate `rdme` to your ReadMe project. This will save your API key to a local configuration file (`~/.config/configstore/rdme-production.json`) so you will not have to provide the `--key` option to commands that require it.
 
@@ -44,8 +44,8 @@ If you wish to get more information about any command within `rdme`, you can exe
 
 ### Common `rdme` Options
 
-- `--key <string>`: The API key associated with your ReadMe project. You can obtain this from your dashboard, or alternatively if you log in with `rdme login`, we will save your API key to a local configuration file (`~/.config/configstore/rdme-production.json`), saving you the hassle of having to supply this argument on commands that have it.
-- `--version <string>`: Your project version.
+- `--key <string>`: The API key associated with your ReadMe project. Note that most of the commands below require API key authentication, even though the `--key` flag is omitted from the examples. See the [Authentication](#authentication) section above for more information.
+- `--version <string>`: Your project version. See [our docs](https://docs.readme.com/docs/versions) for more information.
 
 ### GitHub Actions
 
@@ -80,7 +80,7 @@ Note that the `@XX` in the above examples refers to the version of `rdme` (e.g. 
 
 ### OpenAPI / Swagger
 
-ReadMe supports [OpenAPI 3.0](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md), [OpenAPI 3.1](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md), and [Swagger 2.x](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md).
+ReadMe supports [OpenAPI 3.1](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md), [OpenAPI 3.0](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md), and [Swagger 2.x](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md).
 
 The following examples use JSON files, but we support API Definitions that are written in either JSON or YAML.
 
@@ -104,14 +104,10 @@ rdme openapi [path-to-file.json] --id={existing-id}
 
 #### Uploading or Editing an API Definition in a Project Version
 
-You can additional include a version flag, specifying the target version for your file's destination
+You can additional include a version flag, specifying the target version for your file's destination. This approach will provide you with CLI prompts, so we do not recommend this technique in CI environments.
 
 ```sh
 rdme openapi [path-to-file.json] --version={project-version}
-```
-
-```sh
-rdme openapi [path-to-file.json] --id={existing-id} --version={project-version}
 ```
 
 #### Omitting the File Path

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![npm](https://img.shields.io/npm/v/rdme)](https://npm.im/rdme) [![Build](https://github.com/readmeio/rdme/workflows/CI/badge.svg)](https://github.com/readmeio/rdme)
 
-`rdme` is the CLI and [GitHub Action](#github-actions) wrapper for [ReadMe's RESTful API](https://docs.readme.com/reference/intro-to-the-readme-api). It allows you to sync [OpenAPI](https://spec.openapis.org) and [Swagger](https://swagger.io/specification/v2/) definitions with projects you create on [ReadMe](https://readme.com/). Additionally, you can sync documentation with your project, and manage project versions.
+`rdme` is [ReadMe](https://readme.com)'s official command-line interface (CLI) and [GitHub Action](#github-actions) wrapper. It allows you to sync [OpenAPI](https://spec.openapis.org) and [Swagger](https://swagger.io/specification/v2/) definitions with projects you create on [ReadMe](https://readme.com/). You can also access other parts of [ReadMe's RESTful API](https://docs.readme.com/reference/intro-to-the-readme-api), including syncing Markdown documentation with your project and managing project versions.
 
 ## Configuration
 
@@ -51,7 +51,7 @@ If you wish to get more information about any command within `rdme`, you can exe
 
 <!-- TODO: update this docs link if needed! -->
 
-> For a full GitHub Workflow file example and additional information on GitHub Actions usage, check out [our docs](https://docs.readme.com/docs/automatically-sync-api-specification-with-github).
+> For a full GitHub Workflow file example and additional information on GitHub Actions usage, check out [our docs](https://docs.readme.com/docs/rdme).
 
 For usage in [GitHub Actions](https://docs.github.com/actions), create [a new GitHub Workflow file](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions) in the `.github/workflows` directory of your repository and add the following [steps](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) to your workflow:
 
@@ -65,7 +65,7 @@ For usage in [GitHub Actions](https://docs.github.com/actions), create [a new Gi
 The command syntax in GitHub Actions is functionally equivalent to the CLI. For example, take the following CLI command:
 
 ```sh
-rdme openapi path/to/openapi.json --key=API_KEY --id=OPENAPI_ID
+rdme openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
 ```
 
 To execute this command via GitHub Actions, the step would look like this:
@@ -73,7 +73,7 @@ To execute this command via GitHub Actions, the step would look like this:
 ```yml
 - uses: readmeio/rdme@XX
   with:
-    rdme: openapi path/to/openapi.json --key=API_KEY --id=OPENAPI_ID
+    rdme: openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
 ```
 
 Note that the `@XX` in the above examples refers to the version of `rdme` (e.g. `@7.0`). We recommend [configuring Dependabot to keep your actions up-to-date](https://docs.github.com/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We recommend installing `rdme` in your project rather than doing a global instal
 npm install rdme --save-dev
 ```
 
-Once installed, we recommend using `npx` (which is included if you have `npm` installed) to prefix all of your CLI commands. For example:
+Once installed in your project, we recommend using `npx` (which is included if you have `npm` installed) to prefix all of your CLI commands. For example:
 
 ```sh
 npx rdme validate [file]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![npm](https://img.shields.io/npm/v/rdme)](https://npm.im/rdme) [![Build](https://github.com/readmeio/rdme/workflows/CI/badge.svg)](https://github.com/readmeio/rdme)
 
-`rdme` is [ReadMe](https://readme.com)'s official command-line interface (CLI) and [GitHub Action](#github-actions) wrapper. It allows you to sync [OpenAPI](https://spec.openapis.org) and [Swagger](https://swagger.io/specification/v2/) definitions with projects you create on [ReadMe](https://readme.com/). You can also access other parts of [ReadMe's RESTful API](https://docs.readme.com/reference/intro-to-the-readme-api), including syncing Markdown documentation with your project and managing project versions.
+`rdme` is [ReadMe](https://readme.com)'s official command-line interface (CLI) and [GitHub Action](#github-actions) wrapper. It allows you to sync [OpenAPI](https://spec.openapis.org/oas/v3.1.0.html) and [Swagger](https://swagger.io/specification/v2/) definitions with projects you create on [ReadMe](https://readme.com/). You can also access other parts of [ReadMe's RESTful API](https://docs.readme.com/reference/intro-to-the-readme-api), including syncing Markdown documentation with your project and managing project versions.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![npm](https://img.shields.io/npm/v/rdme)](https://npm.im/rdme) [![Build](https://github.com/readmeio/rdme/workflows/CI/badge.svg)](https://github.com/readmeio/rdme)
 
-`rdme` is the CLI and [GitHub Action](https://docs.github.com/actions) wrapper for [ReadMe's RESTful API](https://docs.readme.com/reference/intro-to-the-readme-api). It allows you to sync [OpenAPI](https://spec.openapis.org) and [Swagger](https://swagger.io/specification/v2/) files with projects you create on [ReadMe](https://readme.com/). Additionally, you can sync documentation with your project, and manage project versions.
+`rdme` is the CLI and [GitHub Action](https://docs.github.com/actions) wrapper for [ReadMe's RESTful API](https://docs.readme.com/reference/intro-to-the-readme-api). It allows you to sync [OpenAPI](https://spec.openapis.org) and [Swagger](https://swagger.io/specification/v2/) definitions with projects you create on [ReadMe](https://readme.com/). Additionally, you can sync documentation with your project, and manage project versions.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ If you wish to get more information about any command within `rdme`, you can exe
 
 ### GitHub Actions
 
-<!-- TODO: update this docs link if needed! -->
-
 > For a full GitHub Workflow file example and additional information on GitHub Actions usage, check out [our docs](https://docs.readme.com/docs/rdme).
 
 For usage in [GitHub Actions](https://docs.github.com/actions), create [a new GitHub Workflow file](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions) in the `.github/workflows` directory of your repository and add the following [steps](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) to your workflow:

--- a/README.md
+++ b/README.md
@@ -4,19 +4,33 @@
 
 [![npm](https://img.shields.io/npm/v/rdme)](https://npm.im/rdme) [![Build](https://github.com/readmeio/rdme/workflows/CI/badge.svg)](https://github.com/readmeio/rdme)
 
-`rdme` is the CLI wrapper for [ReadMe's RESTful API](https://docs.readme.com/reference/intro-to-the-readme-api). It allows you to upload and edit [OpenAPI](https://swagger.io/specification/) and [Swagger](https://swagger.io/specification/v2/) files associated with projects you create on [ReadMe](https://readme.com/). Additionally, you can sync documentation with your project, and manage project versions.
+`rdme` is the CLI and [GitHub Action](https://docs.github.com/actions) wrapper for [ReadMe's RESTful API](https://docs.readme.com/reference/intro-to-the-readme-api). It allows you to sync [OpenAPI](https://spec.openapis.org) and [Swagger](https://swagger.io/specification/v2/) files with projects you create on [ReadMe](https://readme.com/). Additionally, you can sync documentation with your project, and manage project versions.
 
 ## Configuration
 
-### Installation
+### Setup
+
+> These setup instructions are for CLI usage only. For usage in GitHub Actions, see [GitHub Actions](#github-actions) below.
+
+We recommend installing `rdme` in your project's `devDependencies` so you don't run into unexpected behavior with mismatching versions:
 
 ```sh
-npm install rdme
+npm install rdme --save-dev
 ```
+
+Once installed, we recommend using `npx` (which is included if you have `npm` installed) to prefix all of your CLI commands. For example:
+
+```sh
+npx rdme validate [file]
+```
+
+To ensure you're getting the latest features and security updates, we recommend using a tool like [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) to keep `rdme` (and your other dependencies) up-to-date.
 
 ### Authentication
 
-If you authenticate `rdme` to your ReadMe project, we will save your API key to a local configuration file (`~/.config/configstore/rdme-production.json`) so you will not have to provide the `--key` option to commands that require it.
+For usage in CI environments (GitHub Actions, CircleCI, Travis CI, etc.) or if you're working with multiple ReadMe projects, we recommend providing your project API key via the `--key` option instead of the configuration file authentication described below.
+
+For local CLI usage with a single project, you can authenticate `rdme` to your ReadMe project. This will save your API key to a local configuration file (`~/.config/configstore/rdme-production.json`) so you will not have to provide the `--key` option to commands that require it.
 
 ```sh
 rdme login
@@ -32,6 +46,37 @@ If you wish to get more information about any command within `rdme`, you can exe
 
 - `--key <string>`: The API key associated with your ReadMe project. You can obtain this from your dashboard, or alternatively if you log in with `rdme login`, we will save your API key to a local configuration file (`~/.config/configstore/rdme-production.json`), saving you the hassle of having to supply this argument on commands that have it.
 - `--version <string>`: Your project version.
+
+### GitHub Actions
+
+<!-- TODO: update this docs link if needed! -->
+
+> For a full GitHub Workflow file example and additional information on GitHub Actions usage, check out [our docs](https://docs.readme.com/docs/automatically-sync-api-specification-with-github).
+
+For usage in GitHub Actions, create [a new GitHub Workflow file](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) in the `.github/workflows` directory of your repository and add the following [steps](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) to your workflow:
+
+```yml
+- uses: actions/checkout@v2
+- uses: readmeio/rdme@XX
+  with:
+    rdme: [your command here]
+```
+
+The command syntax in GitHub Actions is functionally equivalent to the CLI. For example, take the following CLI command:
+
+```sh
+rdme openapi path/to/openapi.json --key=API_KEY --id=OPENAPI_ID
+```
+
+To execute this command via GitHub Actions, the step would look like this:
+
+```yml
+- uses: readmeio/rdme@XX
+  with:
+    rdme: openapi path/to/openapi.json --key=API_KEY --id=OPENAPI_ID
+```
+
+Note that the `@XX` in the above examples refers to the version of `rdme` (e.g. `@7.0`). We recommend [configuring Dependabot to keep your actions up-to-date](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot).
 
 ### OpenAPI / Swagger
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![npm](https://img.shields.io/npm/v/rdme)](https://npm.im/rdme) [![Build](https://github.com/readmeio/rdme/workflows/CI/badge.svg)](https://github.com/readmeio/rdme)
 
-`rdme` is the CLI and [GitHub Action](https://docs.github.com/actions) wrapper for [ReadMe's RESTful API](https://docs.readme.com/reference/intro-to-the-readme-api). It allows you to sync [OpenAPI](https://spec.openapis.org) and [Swagger](https://swagger.io/specification/v2/) definitions with projects you create on [ReadMe](https://readme.com/). Additionally, you can sync documentation with your project, and manage project versions.
+`rdme` is the CLI and [GitHub Action](#github-actions) wrapper for [ReadMe's RESTful API](https://docs.readme.com/reference/intro-to-the-readme-api). It allows you to sync [OpenAPI](https://spec.openapis.org) and [Swagger](https://swagger.io/specification/v2/) definitions with projects you create on [ReadMe](https://readme.com/). Additionally, you can sync documentation with your project, and manage project versions.
 
 ## Configuration
 
@@ -24,7 +24,7 @@ Once installed, we recommend using `npx` (which is included if you have `npm` in
 npx rdme validate [file]
 ```
 
-To ensure you're getting the latest features and security updates, we recommend using a tool like [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) to keep `rdme` (and your other dependencies) up-to-date.
+To ensure you're getting the latest features and security updates, we recommend using a tool like [Dependabot](https://docs.github.com/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) to keep `rdme` (and your other dependencies) up-to-date.
 
 ### Authentication
 
@@ -53,7 +53,7 @@ If you wish to get more information about any command within `rdme`, you can exe
 
 > For a full GitHub Workflow file example and additional information on GitHub Actions usage, check out [our docs](https://docs.readme.com/docs/automatically-sync-api-specification-with-github).
 
-For usage in GitHub Actions, create [a new GitHub Workflow file](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) in the `.github/workflows` directory of your repository and add the following [steps](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) to your workflow:
+For usage in [GitHub Actions](https://docs.github.com/actions), create [a new GitHub Workflow file](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions) in the `.github/workflows` directory of your repository and add the following [steps](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) to your workflow:
 
 ```yml
 - uses: actions/checkout@v2
@@ -76,7 +76,7 @@ To execute this command via GitHub Actions, the step would look like this:
     rdme: openapi path/to/openapi.json --key=API_KEY --id=OPENAPI_ID
 ```
 
-Note that the `@XX` in the above examples refers to the version of `rdme` (e.g. `@7.0`). We recommend [configuring Dependabot to keep your actions up-to-date](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot).
+Note that the `@XX` in the above examples refers to the version of `rdme` (e.g. `@7.0`). We recommend [configuring Dependabot to keep your actions up-to-date](https://docs.github.com/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot).
 
 ### OpenAPI / Swagger
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > These setup instructions are for CLI usage only. For usage in GitHub Actions, see [GitHub Actions](#github-actions) below.
 
-We recommend installing `rdme` in your project's `devDependencies` so you don't run into unexpected behavior with mismatching versions:
+We recommend installing `rdme` in your project rather than doing a global installation so you don't run into unexpected behavior with mismatching versions. We also suggest using the `--save-dev` flag since `rdme` is typically used as part of a CI process and is unlikely to be running in your production application:
 
 ```sh
 npm install rdme --save-dev

--- a/__tests__/lib/getNodeVersion.test.js
+++ b/__tests__/lib/getNodeVersion.test.js
@@ -1,0 +1,11 @@
+const getNodeVersion = require('../../src/lib/getNodeVersion');
+const pkg = require('../../package.json');
+const semver = require('semver');
+
+describe('#getNodeVersion()', () => {
+  it('should extract version that matches range in package.json', () => {
+    const version = parseInt(getNodeVersion(), 10);
+    const cleanedVersion = semver.valid(semver.coerce(version));
+    expect(semver.satisfies(cleanedVersion, pkg.engines.node)).toBe(true);
+  });
+});

--- a/bin/set-version-output
+++ b/bin/set-version-output
@@ -1,11 +1,14 @@
 #! /usr/bin/env node
 
+const getNodeVersion = require('../src/lib/getNodeVersion');
 const pkg = require('../package.json');
 
-const name = 'RDME_VERSION';
+const name1 = 'RDME_VERSION';
+const name2 = 'NODE_VERSION';
 
 /**
- * Sets output parameter for GitHub Actions workflow
+ * Sets output parameters for GitHub Actions workflow
  * Docs: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
  */
-console.log(`::set-output name=${name}::${pkg.version}`); // eslint-disable-line no-console
+console.log(`::set-output name=${name1}::${pkg.version}`); // eslint-disable-line no-console
+console.log(`::set-output name=${name2}::${getNodeVersion()}`); // eslint-disable-line no-console

--- a/bin/set-version-output
+++ b/bin/set-version-output
@@ -1,0 +1,11 @@
+#! /usr/bin/env node
+
+const pkg = require('../package.json');
+
+const name = 'RDME_VERSION';
+
+/**
+ * Sets output parameter for GitHub Actions workflow
+ * Docs: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+ */
+console.log(`::set-output name=${name}::${pkg.version}`); // eslint-disable-line no-console

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -1,5 +1,5 @@
 ---
-title: Syncing Docs via CLI / GitHub Action
+title: Syncing Docs via CLI / GitHub
 excerpt: Update your docs automatically with `rdme`, ReadMe's official CLI and GitHub Action!
 category: 5f7ce9e3a5504d0414d024c2
 ---

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -1,6 +1,6 @@
 ---
-title: CLI + GitHub Action Usage
-excerpt: Learn more about `rdme`, ReadMe's official CLI and GitHub Action!
+title: Syncing Docs via CLI / GitHub Action
+excerpt: Update your docs automatically with `rdme`, ReadMe's official CLI and GitHub Action!
 category: 5f7ce9e3a5504d0414d024c2
 ---
 

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -185,7 +185,7 @@ jobs:
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: GitHub Action
-        # We recommend specifying a fixed version, i.e. @7.0
+        # We recommend specifying a fixed version, i.e. @RDME_VERSION
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
         uses: readmeio/rdme@RDME_VERSION
         with:

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -1,6 +1,6 @@
 ---
 title: CLI + GitHub Action Usage
-description: Learn more about `rdme`, ReadMe's official CLI and GitHub Action!
+excerpt: Learn more about `rdme`, ReadMe's official CLI and GitHub Action!
 category: 5f7ce9e3a5504d0414d024c2
 ---
 
@@ -32,7 +32,7 @@ In order to sync a directory of Markdown files to your guides, you'll need to ad
 ```markdown
 ---
 title: CLI + GitHub Action Usage
-description: Learn more about `rdme`, ReadMe's official CLI and GitHub Action!
+excerpt: Learn more about `rdme`, ReadMe's official CLI and GitHub Action!
 category: 5f7ce9e3a5504d0414d024c2
 ---
 
@@ -46,7 +46,7 @@ We automatically derive the page's slug via the file name (e.g. the file name `r
 ```markdown
 ---
 title: CLI + GitHub Action Usage
-description: Learn more about `rdme`, ReadMe's official CLI and GitHub Action!
+excerpt: Learn more about `rdme`, ReadMe's official CLI and GitHub Action!
 category: 5f7ce9e3a5504d0414d024c2
 slug: an-alternative-page-slug-example
 ---

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -207,3 +207,29 @@ To use a GitHub secret in your `rdme` GitHub Action, first [create a new reposit
   with:
     rdme: docs ./documentation --key=${{ secrets.README_API_KEY }} --version=2.0
 ```
+
+## Troubleshooting
+
+If you're running into unexpected behavior with `rdme` and need to troubleshoot the issue, you have several debug logging options available. We may ask for these logs (as well as a copy of your OpenAPI definition) when you contact our support team.
+
+### Troubleshooting CLI
+
+If you're troubleshooting issues with the CLI (or in some non-GitHub Actions environment), you can use the `DEBUG` environmental variable to print helpful debugging info to the console:
+
+```sh
+DEBUG=rdme* rdme openapi [path-to-file.json]
+```
+
+Note that this should only be used for development/debugging purposes and should not be enabled in production environments.
+
+### Troubleshooting GitHub Actions
+
+If you're troubleshooting issues in a GitHub Actions environment, you can enable [step debug logs](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging) in your GitHub Actions workflow by [setting the repository secret](https://docs.github.com/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) `ACTIONS_STEP_DEBUG` to `true`. For more information on accessing, downloading, and deleting logs, check out [GitHub's documentation](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs).
+
+> 🚧 Debug Logs May Contain Sensitive Information
+>
+> Enabling step debug logs will produce comprehensive logging for **all** of your GitHub Action workflow steps. While GitHub automatically masks any sensitive information you load in with [secrets](#example-using-github-secrets), there might be other sensitive information that's exposed. Anybody with read access to the repository will be able to see these logs.
+>
+> We **strongly recommend** that you only enable step debug logs in private repositories. If working in a public repository, we suggest recreating your GitHub workflow setup (e.g. with your GitHub workflow files, OpenAPI definitions, and anything else you need for syncing to ReadMe) in a separate private repository for testing purposes before enabling this setting.
+>
+> If you do enable step debug logs in your repository and your logs produce sensitive information, here are [GitHub's docs on deleting logs](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs#deleting-logs).

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -212,6 +212,8 @@ To use a GitHub secret in your `rdme` GitHub Action, first [create a new reposit
 
 Since `rdme` is a command-line tool at its core, you can use `rdme` to sync your documentation from virtually any CI/CD environment that runs shell commands—[Bitbucket Pipelines](https://support.atlassian.com/bitbucket-cloud/docs/get-started-with-bitbucket-pipelines/), [GitLab CI/CD](https://docs.gitlab.com/ee/ci/), you name it! You can do this by invoking `rdme` with `npx -y rdme@RDME_VERSION` in a Node.js environment. See below for a few simple examples.
 
+<!-- Note: the two code blocks below must be joined, despite what VS Code's formatter tells you!-->
+
 ```yml Bitbucket Pipelines (bitbucket-pipelines.yml)
 # Official framework image. Look for the different tagged releases at:
 # https://hub.docker.com/r/library/node/tags/
@@ -222,7 +224,6 @@ pipelines:
         script:
           - npx -y rdme@RDME_VERSION openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
 ```
-
 ```yml GitLab CI (rdme-sync.gitlab-ci.yml)
 # Official framework image. Look for the different tagged releases at:
 # https://hub.docker.com/r/library/node/tags/

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -39,7 +39,7 @@ category: 5f7ce9e3a5504d0414d024c2
 If you're anything like us...
 ```
 
-The only required attributes are the `title` and `category`. To determine what your `category` value should be, you can use [the Get all categories endpoint](https://docs.readme.com/reference/getcategories) and grab the `id` value from the response.
+The only required attributes are the `title` and `category`. To determine what your `category` value should be, you can use [the `Get all categories` endpoint](https://docs.readme.com/reference/getcategories) and grab the `id` value from the response.
 
 We automatically derive the page's slug via the file name (e.g. the file name `rdme.md` would become `/docs/rdme` in your ReadMe project), but you can override that as well:
 

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -208,6 +208,28 @@ To use a GitHub secret in your `rdme` GitHub Action, first [create a new reposit
     rdme: docs ./documentation --key=${{ secrets.README_API_KEY }} --version=2.0
 ```
 
+## Usage in Other CI Environments
+
+Since `rdme` is a command-line tool at its core, you can use `rdme` to sync your documentation from virtually any CI/CD environment that runs shell commands—[Bitbucket Pipelines](https://support.atlassian.com/bitbucket-cloud/docs/get-started-with-bitbucket-pipelines/), [GitLab CI/CD](https://docs.gitlab.com/ee/ci/), you name it! You can do this by invoking `rdme` with `npx -y rdme@RDME_VERSION` in a Node.js environment. See below for a few simple examples.
+
+```yml Bitbucket Pipelines (bitbucket-pipelines.yml)
+image: node:NODE_VERSION
+pipelines:
+  default:
+    - step:
+        script:
+          - npx -y rdme@RDME_VERSION openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
+```
+```yml GitLab CI (rdme-sync.gitlab-ci.yml)
+# Official framework image. Look for the different tagged releases at:
+# https://hub.docker.com/r/library/node/tags/
+image: node:NODE_VERSION
+
+sync-via-rdme:
+  script:
+    - npx -y rdme@RDME_VERSION openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
+```
+
 ## Troubleshooting
 
 If you're running into unexpected behavior with `rdme` and need to troubleshoot the issue, you have several debug logging options available. We may ask for these logs (as well as a copy of your OpenAPI definition) when you contact our support team.

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -183,7 +183,7 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v2.4.0
 
-      # Run GitHub Action to sync docs in `documentation` directory
+      # Run GitHub Action to sync OpenAPI file at [path-to-file.json]
       - name: GitHub Action
         # We recommend specifying a fixed version, i.e. @RDME_VERSION
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -7,7 +7,7 @@ category: 5f7ce9e3a5504d0414d024c2
 <!--
 
 Hello curious raw Markdown reader! 👋
-This Markdown page is syncing to ReadMe via the `rdme GitHub Action 🦉
+This Markdown page is syncing to ReadMe via the `rdme` GitHub Action 🦉
 Check out the "Syncing Markdown Docs" example below,
 and peep the resulting page in our docs: https://docs.readme.com/docs/rdme
 

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -17,7 +17,7 @@ Check out `.github/workflows/docs.yml` for more info on this!
 
 -->
 
-If you're anything like us, your documentation process may be a part of a broader [CI/CD](https://en.wikipedia.org/wiki/CI/CD) process. For example, you may want to automatically update your ReadMe guides or API reference every time you've ship new code. Enter [`rdme`](https://github.com/readmeio/rdme): ReadMe's official command-line interface (CLI) and GitHub Action!
+If you're anything like us, your documentation process may be a part of a broader CI/CD process. For example, you may want to automatically update your ReadMe guides or API reference every time you've ship new code. Enter `rdme`: ReadMe's official command-line interface (CLI) and GitHub Action!
 
 [![npm](https://img.shields.io/npm/v/rdme)](https://npm.im/rdme) [![Build](https://github.com/readmeio/rdme/workflows/CI/badge.svg)](https://github.com/readmeio/rdme)
 
@@ -68,7 +68,7 @@ You can also specify several other page attributes in your YAML front matter, su
 >
 > Note that the `@RDME_VERSION` in the below examples is the latest version of `rdme`. We recommend [configuring Dependabot to keep your actions up-to-date](https://docs.github.com/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot).
 
-For usage in [GitHub Actions](https://docs.github.com/actions), create [a new GitHub Workflow file](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions) in the `.github/workflows` directory of your repository and add the following [steps](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) to your workflow:
+For usage in GitHub Actions, create [a new GitHub Workflow file](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions) in the `.github/workflows` directory of your repository and add the following [steps](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) to your workflow:
 
 ```yml
 - uses: actions/checkout@v2

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -189,6 +189,8 @@ jobs:
           rdme: openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
 ```
 
+In the example above, every push to the `main` branch will check out your repository's contents and sync the OpenAPI file located at `./path-to-file.json` with your ReadMe project.
+
 ### Example: Using GitHub Secrets
 
 > 🚧 Secretly store your ReadMe API Key!

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -17,9 +17,9 @@ Check out `.github/workflows/docs.yml` for more info on this!
 
 -->
 
-[![npm](https://img.shields.io/npm/v/rdme)](https://npm.im/rdme) [![Build](https://github.com/readmeio/rdme/workflows/CI/badge.svg)](https://github.com/readmeio/rdme)
-
 If you're anything like us, your documentation process may be a part of a broader [CI/CD](https://en.wikipedia.org/wiki/CI/CD) process. For example, you may want to automatically update your ReadMe guides or API reference every time you've ship new code. Enter [`rdme`](https://github.com/readmeio/rdme): ReadMe's official command-line interface (CLI) and GitHub Action!
+
+[![npm](https://img.shields.io/npm/v/rdme)](https://npm.im/rdme) [![Build](https://github.com/readmeio/rdme/workflows/CI/badge.svg)](https://github.com/readmeio/rdme)
 
 With `rdme`, you can create workflows for a variety of use cases, including:
 

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -1,7 +1,204 @@
 ---
-title: rdme
+title: CLI + GitHub Action Usage
+description: Learn more about `rdme`, ReadMe's official CLI and GitHub Action!
 category: 5f7ce9e3a5504d0414d024c2
-hidden: true
 ---
 
-Hello Owlbert!
+<!--
+
+Hello curious raw Markdown reader! 👋
+This Markdown page is syncing to ReadMe via the `rdme GitHub Action 🦉
+Check out the "Syncing Markdown Docs" example below,
+and peep the resulting page in our docs: https://docs.readme.com/docs/rdme
+
+-->
+
+If you're anything like us, your documentation process may be a part of a broader [CI/CD](https://en.wikipedia.org/wiki/CI/CD) process. For example, you may want to automatically update your ReadMe guides or API reference every time you've ship new code. Enter [`rdme`](https://github.com/readmeio/rdme): ReadMe's official command-line interface (CLI) and GitHub Action!
+
+With `rdme`, you can create workflows for a variety of use cases, including:
+
+- Syncing [OpenAPI/Swagger](https://docs.readme.com/docs/openapi) definitions (with support for bundling external references) 📦
+- Pre-upload validation (including OpenAPI 3.1) ✅
+- Syncing directories of Markdown files 📖
+
+## General Setup and Usage
+
+To see detailed CLI setup instructions and all available commands, check out [the `rdme` GitHub repository](https://github.com/readmeio/rdme#readme).
+
+### Markdown File Setup
+
+In order to sync a directory of Markdown files to your guides, you'll need to add certain attributes to the top of each page via a [YAML front matter block](https://jekyllrb.com/docs/front-matter/). See below for an example (using the page you're currently reading!):
+
+```markdown
+---
+title: CLI + GitHub Action Usage
+description: Learn more about `rdme`, ReadMe's official CLI and GitHub Action!
+category: 5f7ce9e3a5504d0414d024c2
+---
+
+If you're anything like us...
+```
+
+The only required attributes are the `title` and `category`. To determine what your `category` value should be, you can use [the Get all categories endpoint](https://docs.readme.com/reference/getcategories) and grab the `id` value from the response.
+
+We automatically derive the page's slug via the file name (e.g. the file name `rdme.md` would become `/docs/rdme` in your ReadMe project), but you can override that as well:
+
+```markdown
+---
+title: CLI + GitHub Action Usage
+description: Learn more about `rdme`, ReadMe's official CLI and GitHub Action!
+category: 5f7ce9e3a5504d0414d024c2
+slug: an-alternative-page-slug-example
+---
+```
+
+You can also specify several other page attributes in your YAML front matter, such as `hidden` (a boolean which denotes whether your page is published or unpublished). Any attributes you omit will remain unchanged on `rdme` runs. To view the full list of attributes, check out our [`Create doc` endpoint documentation](https://docs.readme.com/reference/createdoc).
+
+## GitHub Actions Usage
+
+[GitHub Actions](https://docs.github.com/actions) makes it easy to automatically execute workflows when certain events take place in your GitHub repository (e.g. new code is merged into the default branch, a new pull request is opened, etc.).
+
+<!-- TODO: it might be nice to have some sort of CI workflow that auto-updates the version in the examples below! -->
+<!-- TODO: populate marketplace listing link! -->
+
+> 📘 Keeping `rdme` up-to-date
+>
+> Note that the `@XX` in the below examples refers to the version of `rdme` (e.g. `@7.0`), which you can find in [the Marketplace listing](). We recommend [configuring Dependabot to keep your actions up-to-date](https://docs.github.com/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot).
+
+For usage in [GitHub Actions](https://docs.github.com/actions), create [a new GitHub Workflow file](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions) in the `.github/workflows` directory of your repository and add the following [steps](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) to your workflow:
+
+```yml
+- uses: actions/checkout@v2
+- uses: readmeio/rdme@XX
+  with:
+    rdme: [your command here]
+```
+
+The command syntax in GitHub Actions is functionally equivalent to the CLI. For example, take the following CLI command:
+
+```sh
+rdme openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
+```
+
+To execute this command via GitHub Actions, the step would look like this:
+
+```yml
+- uses: readmeio/rdme@XX
+  with:
+    rdme: openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
+```
+
+We'll dive into several full GitHub Workflow file examples below!
+
+### Example: Syncing Markdown Docs
+
+Not to get too meta on you, but... the page that you're currently reading is actually being synced from the `rdme` GitHub repository via the `rdme` GitHub Action! Here are a few links to the relevant files:
+
+- [The Markdown source file for the page you're reading](https://github.com/readmeio/rdme/tree/main/docs/rdme.md)
+- [The full GitHub Action workflow file that we use to sync the file to docs.readme.com](https://github.com/readmeio/rdme/blob/main/.github/workflows/docs.yml)
+- And finally... [the workflow run results](https://github.com/readmeio/rdme/actions/workflows/docs.yml)!
+
+To recreate this magic in your repository, your GitHub Workflow file will look like this:
+
+```yml
+name: Sync `documentation` directory to ReadMe
+
+# Run workflow for every push to the `main` branch
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v2.4.0
+
+      # Run GitHub Action to sync docs in `documentation` directory
+      - name: GitHub Action
+        # We recommend specifying a fixed version, i.e. @7.0
+        # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
+        uses: readmeio/rdme@XX
+        with:
+          rdme: docs ./documentation --key=API_KEY --version=2.0
+```
+
+In the example above, every push to the `main` branch will check out your repository's contents and sync the contents of the `documentation` directory with your ReadMe project.
+
+### Example: Syncing an OpenAPI Definition
+
+To sync an OpenAPI or Swagger definition, you'll first want to obtain a unique API definition ID from ReadMe so we know which definition you want to update on subsequent re-syncs. You can obtain this API definition ID in one of several ways, but we'll dive into two below: uploading a file directly into the ReadMe dashboard and using the `rdme` CLI locally.
+
+<details>
+<summary>Uploading a file</summary>
+
+Follow [these instructions](https://docs.readme.com/docs/openapi#file-upload) on uploading a new OpenAPI file in the dashboard. Once the file is uploaded, you'll see the following in the API Reference settings of your dashboard (the red outline is where you'll find your API definition ID):
+
+![](https://files.readme.io/d57b7c8-Screen_Shot_2022-02-23_at_11.54.21_AM.png)
+
+</details>
+<details>
+<summary>Using the <code>rdme</code> CLI</summary>
+
+Alternatively, you can obtain the API definition ID by running the following `rdme` CLI command on your local machine:
+
+```sh
+rdme openapi [path-to-file.json]
+```
+
+Once you follow the prompts and upload your OpenAPI definition, you'll receive a confirmation message that looks something like this:
+
+```
+You've successfully updated an OpenAPI file on your ReadMe project!
+
+        http://dash.readme.com/project/{your_project}/v1.0/refs/pet
+
+To update your OpenAPI or Swagger definition, run the following:
+
+        rdme openapi FILE --key=API_KEY --id=API_DEFINITION_ID
+```
+
+</details>
+
+Once you've obtained your API definition ID, your full GitHub Workflow file will look something like this:
+
+```yml
+name: Sync OpenAPI definition to ReadMe
+
+# Run workflow for every push to the `main` branch
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v2.4.0
+
+      # Run GitHub Action to sync docs in `documentation` directory
+      - name: GitHub Action
+        # We recommend specifying a fixed version, i.e. @7.0
+        # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
+        uses: readmeio/rdme@XX
+        with:
+          rdme: openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
+```
+
+### Example: Using GitHub Secrets
+
+> 🚧 Secretly store your ReadMe API Key!
+>
+> GitHub Actions has [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) to securely store sensitive information so it isn't publicly visible. We **strongly** recommend using these for storing your ReadMe API Key, your API definition ID, and any other secret keys—whether your repository is public or private. You can read more about setting these up [in their documentation](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+
+To use a GitHub secret in your `rdme` GitHub Action, first [create a new repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository). Let's say you create a new secret key called `README_API_KEY`. The usage in the `rdme` step will look something like this:
+
+```yml
+- uses: readmeio/rdme@XX
+  with:
+    rdme: docs ./documentation --key=${{ secrets.README_API_KEY }} --version=2.0
+```

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -11,7 +11,13 @@ This Markdown page is syncing to ReadMe via the `rdme GitHub Action 🦉
 Check out the "Syncing Markdown Docs" example below,
 and peep the resulting page in our docs: https://docs.readme.com/docs/rdme
 
+We also do some fancy little find-and-replace action to swap out every instance
+of `RDME_VERSION` below with the latest version of rdme.
+Check out `.github/workflows/docs.yml` for more info on this!
+
 -->
+
+[![npm](https://img.shields.io/npm/v/rdme)](https://npm.im/rdme) [![Build](https://github.com/readmeio/rdme/workflows/CI/badge.svg)](https://github.com/readmeio/rdme)
 
 If you're anything like us, your documentation process may be a part of a broader [CI/CD](https://en.wikipedia.org/wiki/CI/CD) process. For example, you may want to automatically update your ReadMe guides or API reference every time you've ship new code. Enter [`rdme`](https://github.com/readmeio/rdme): ReadMe's official command-line interface (CLI) and GitHub Action!
 
@@ -58,18 +64,15 @@ You can also specify several other page attributes in your YAML front matter, su
 
 [GitHub Actions](https://docs.github.com/actions) makes it easy to automatically execute workflows when certain events take place in your GitHub repository (e.g. new code is merged into the default branch, a new pull request is opened, etc.).
 
-<!-- TODO: it might be nice to have some sort of CI workflow that auto-updates the version in the examples below! -->
-<!-- TODO: populate marketplace listing link! -->
-
 > 📘 Keeping `rdme` up-to-date
 >
-> Note that the `@XX` in the below examples refers to the version of `rdme` (e.g. `@7.0`), which you can find in [the Marketplace listing](). We recommend [configuring Dependabot to keep your actions up-to-date](https://docs.github.com/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot).
+> Note that the `@RDME_VERSION` in the below examples is the latest version of `rdme`. We recommend [configuring Dependabot to keep your actions up-to-date](https://docs.github.com/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot).
 
 For usage in [GitHub Actions](https://docs.github.com/actions), create [a new GitHub Workflow file](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions) in the `.github/workflows` directory of your repository and add the following [steps](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) to your workflow:
 
 ```yml
 - uses: actions/checkout@v2
-- uses: readmeio/rdme@XX
+- uses: readmeio/rdme@RDME_VERSION
   with:
     rdme: [your command here]
 ```
@@ -83,7 +86,7 @@ rdme openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
 To execute this command via GitHub Actions, the step would look like this:
 
 ```yml
-- uses: readmeio/rdme@XX
+- uses: readmeio/rdme@RDME_VERSION
   with:
     rdme: openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
 ```
@@ -118,9 +121,9 @@ jobs:
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: GitHub Action
-        # We recommend specifying a fixed version, i.e. @7.0
+        # We recommend specifying a fixed version, i.e. @RDME_VERSION
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@XX
+        uses: readmeio/rdme@RDME_VERSION
         with:
           rdme: docs ./documentation --key=API_KEY --version=2.0
 ```
@@ -184,7 +187,7 @@ jobs:
       - name: GitHub Action
         # We recommend specifying a fixed version, i.e. @7.0
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        uses: readmeio/rdme@XX
+        uses: readmeio/rdme@RDME_VERSION
         with:
           rdme: openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
 ```
@@ -200,7 +203,7 @@ In the example above, every push to the `main` branch will check out your reposi
 To use a GitHub secret in your `rdme` GitHub Action, first [create a new repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository). Let's say you create a new secret key called `README_API_KEY`. The usage in the `rdme` step will look something like this:
 
 ```yml
-- uses: readmeio/rdme@XX
+- uses: readmeio/rdme@RDME_VERSION
   with:
     rdme: docs ./documentation --key=${{ secrets.README_API_KEY }} --version=2.0
 ```

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -213,6 +213,8 @@ To use a GitHub secret in your `rdme` GitHub Action, first [create a new reposit
 Since `rdme` is a command-line tool at its core, you can use `rdme` to sync your documentation from virtually any CI/CD environment that runs shell commands—[Bitbucket Pipelines](https://support.atlassian.com/bitbucket-cloud/docs/get-started-with-bitbucket-pipelines/), [GitLab CI/CD](https://docs.gitlab.com/ee/ci/), you name it! You can do this by invoking `rdme` with `npx -y rdme@RDME_VERSION` in a Node.js environment. See below for a few simple examples.
 
 ```yml Bitbucket Pipelines (bitbucket-pipelines.yml)
+# Official framework image. Look for the different tagged releases at:
+# https://hub.docker.com/r/library/node/tags/
 image: node:NODE_VERSION
 pipelines:
   default:
@@ -220,6 +222,7 @@ pipelines:
         script:
           - npx -y rdme@RDME_VERSION openapi [path-to-file.json] --key=API_KEY --id=API_DEFINITION_ID
 ```
+
 ```yml GitLab CI (rdme-sync.gitlab-ci.yml)
 # Official framework image. Look for the different tagged releases at:
 # https://hub.docker.com/r/library/node/tags/

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -101,7 +101,7 @@ Not to get too meta on you, but... the page that you're currently reading is act
 - [The full GitHub Action workflow file that we use to sync the file to docs.readme.com](https://github.com/readmeio/rdme/blob/main/.github/workflows/docs.yml)
 - And finally... [the workflow run results](https://github.com/readmeio/rdme/actions/workflows/docs.yml)!
 
-To recreate this magic in your repository, your GitHub Workflow file will look like this:
+To recreate this magic in your repository, your GitHub Workflow file will look something like this:
 
 ```yml
 name: Sync `documentation` directory to ReadMe

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -1,0 +1,7 @@
+---
+title: rdme
+category: 5f7ce9e3a5504d0414d024c2
+hidden: true
+---
+
+Hello Owlbert!

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -198,9 +198,9 @@ In the example above, every push to the `main` branch will check out your reposi
 
 > 🚧 Secretly store your ReadMe API Key!
 >
-> GitHub Actions has [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) to securely store sensitive information so it isn't publicly visible. We **strongly** recommend using these for storing your ReadMe API Key, your API definition ID, and any other secret keys—whether your repository is public or private. You can read more about setting these up [in their documentation](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+> GitHub Actions has [secrets](https://docs.github.com/actions/security-guides/encrypted-secrets) to securely store sensitive information so it isn't publicly visible. We **strongly** recommend using these for storing your ReadMe API Key, your API definition ID, and any other secret keys—whether your repository is public or private. You can read more about setting these up [in their documentation](https://docs.github.com/actions/security-guides/encrypted-secrets).
 
-To use a GitHub secret in your `rdme` GitHub Action, first [create a new repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository). Let's say you create a new secret key called `README_API_KEY`. The usage in the `rdme` step will look something like this:
+To use a GitHub secret in your `rdme` GitHub Action, first [create a new repository secret](https://docs.github.com/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository). Let's say you create a new secret key called `README_API_KEY`. The usage in the `rdme` step will look something like this:
 
 ```yml
 - uses: readmeio/rdme@RDME_VERSION

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rdme",
   "version": "6.4.0",
-  "description": "The official CLI and GitHub Action wrapper for the ReadMe API.",
+  "description": "ReadMe's official CLI and GitHub Action wrapper.",
   "license": "MIT",
   "author": "ReadMe <support@readme.io> (https://readme.com)",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rdme",
   "version": "6.4.0",
-  "description": "ReadMe's API CLI",
+  "description": "The official CLI and GitHub Action wrapper for the ReadMe API.",
   "license": "MIT",
   "author": "ReadMe <support@readme.io> (https://readme.com)",
   "engines": {

--- a/src/lib/getNodeVersion.js
+++ b/src/lib/getNodeVersion.js
@@ -1,0 +1,15 @@
+const pkg = require('../../package.json');
+
+/**
+ * @example 14
+ * @returns {String} The minimum major Node.js version specified in the package.json
+ */
+function extractNodeVersion() {
+  const { node } = pkg.engines;
+
+  const match = Array.from(node.matchAll(/\d+/g)).pop();
+
+  return match;
+}
+
+module.exports = extractNodeVersion;

--- a/src/lib/getNodeVersion.js
+++ b/src/lib/getNodeVersion.js
@@ -2,7 +2,7 @@ const pkg = require('../../package.json');
 
 /**
  * @example 14
- * @returns {String} The minimum major Node.js version specified in the package.json
+ * @returns {String} The maximum major Node.js version specified in the package.json
  */
 function extractNodeVersion() {
   const { node } = pkg.engines;


### PR DESCRIPTION
This is a doozy. This PR updates our README.md, adds docs for [our knowledge base](https://docs.readme.com/docs/rdme), and sets up a CI workflow for doing a find/replace and syncing the knowledge base page to ReadMe.

Fixes RM-3553