### PR TITLE
feat: dropping support for node 12

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,9 @@
 {
   "extends": ["@readme/eslint-config"],
   "root": true,
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
   "rules": {
     /**
      * Because our command classes have a `run` method that might not always call `this` we need to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2.4.0

--- a/bin/rdme
+++ b/bin/rdme
@@ -17,7 +17,7 @@ require('../src')(process.argv.slice(2))
       'support@readme.io'
     )}.`;
 
-    if (err && 'message' in err) {
+    if (err?.message) {
       message = err.message;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "prettier": "^2.4.1"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16"
+        "node": "^14 || ^16"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "author": "ReadMe <support@readme.io> (https://readme.com)",
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^14 || ^16"
   },
   "bin": {
     "rdme": "bin/rdme"
@@ -23,7 +23,8 @@
     "oas",
     "apidoc",
     "microservice",
-    "documentation"
+    "documentation",
+    "readme"
   ],
   "repository": {
     "type": "git",

--- a/src/lib/apiError.js
+++ b/src/lib/apiError.js
@@ -4,7 +4,7 @@ module.exports = class extends Error {
 
     // Special handling to for fetch `res` arguments where `res.error` will contain our API error response.
     if (typeof res === 'object') {
-      if ('error' in res && typeof res.error === 'object') {
+      if (typeof res?.error === 'object') {
         err = res.error;
       } else {
         err = res;
@@ -20,7 +20,7 @@ module.exports = class extends Error {
 
       // If we returned help info in the API, show it otherwise don't render out multiple empty lines as we sometimes
       // throw `Error('non-api custom error message')` instances and catch them with this class.
-      if ('help' in err) {
+      if (err?.help) {
         this.message = [err.message, '', err.help].join('\n');
       } else {
         this.message = err.message;

--- a/src/lib/prompts.js
+++ b/src/lib/prompts.js
@@ -148,7 +148,7 @@ exports.createVersionPrompt = (versionList, opts, isUpdate) => [
     name: 'is_stable',
     message: 'Would you like to make this version the main version for this project?',
     skip() {
-      return opts.main || (isUpdate && isUpdate.is_stable);
+      return opts.main || isUpdate?.is_stable;
     },
   },
   {


### PR DESCRIPTION
> ⚠️ Do not merge this until the new Github Action workflow has been tagged to the current v6 release series.

## 🧰 Changes

Node 12 hits EOL in April and with our new action in #437 it'd be nice to start with a clean start, breaking change for folks, so we might as well drop support for Node 12 now and publish a breaking change rather than having to publish another breaking change in a few months. 

This also allows us to _finally_ start using optional chaining in this codebase as that was introduced in Node 14.

## 🧬 QA & Testing

* [ ] All tests still passing?