### PR TITLE
feat: debugging support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
       - name: Run `openapi` command
         uses: ./rdme-repo/
         with:
-          rdme: swagger oas-examples-repo/3.1/json/petstore.json --key=${{ secrets.RDME_TEST_PROJECT_API_KEY }} --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}
+          rdme: openapi oas-examples-repo/3.1/json/petstore.json --key=${{ secrets.RDME_TEST_PROJECT_API_KEY }} --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
       - name: Run `openapi` command
         uses: ./rdme-repo/
         with:
-          rdme: openapi oas-examples-repo/3.1/json/petstore.json --key=${{ secrets.RDME_TEST_PROJECT_API_KEY }} --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}
+          rdme: swagger oas-examples-repo/3.1/json/petstore.json --key=${{ secrets.RDME_TEST_PROJECT_API_KEY }} --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}

--- a/.github/workflows/gh-action-simple.yml
+++ b/.github/workflows/gh-action-simple.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Run `validate` command
         uses: ./ # in actual production usage, this value should be 'readmeio/rdme@XX'
         with:
-          rdme: validate __tests__/__fixtures__/ref-oas/petstore.json
+          rdme: validate __tests__/__fixtures__/invalid-oas.json

--- a/.github/workflows/gh-action-simple.yml
+++ b/.github/workflows/gh-action-simple.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Run `validate` command
         uses: ./ # in actual production usage, this value should be 'readmeio/rdme@XX'
         with:
-          rdme: validate __tests__/__fixtures__/invalid-oas.json
+          rdme: validate __tests__/__fixtures__/ref-oas/petstore.json

--- a/bin/rdme
+++ b/bin/rdme
@@ -36,6 +36,5 @@ require('../src')(process.argv.slice(2))
 
     // eslint-disable-next-line no-console
     console.error(chalk.red(`\n${message}\n`));
-
     return process.exit(1);
   });

--- a/bin/rdme
+++ b/bin/rdme
@@ -1,8 +1,11 @@
 #! /usr/bin/env node
 const chalk = require('chalk');
+const core = require('@actions/core');
 
 const updateNotifier = require('update-notifier');
 const pkg = require('../package.json');
+
+const isGHA = require('../src/lib/isGitHub');
 
 updateNotifier({ pkg }).notify();
 
@@ -21,7 +24,18 @@ require('../src')(process.argv.slice(2))
       message = err.message;
     }
 
-    // eslint-disable-next-line no-console
-    console.error(chalk.red(`\n${message}\n`));
+    /**
+     * If we're in a GitHub Actions environment,
+     * log errors with that formatting instead.
+     * @link: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+     * @link: https://github.com/actions/toolkit/tree/main/packages/core#annotations
+     */
+    if (isGHA) {
+      core.error(message);
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(chalk.red(`\n${message}\n`));
+    }
+
     return process.exit(1);
   });

--- a/bin/rdme
+++ b/bin/rdme
@@ -25,8 +25,7 @@ require('../src')(process.argv.slice(2))
     }
 
     /**
-     * If we're in a GitHub Actions environment,
-     * log errors with that formatting instead.
+     * If we're in a GitHub Actions environment, log errors with that formatting instead.
      * @link: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
      * @link: https://github.com/actions/toolkit/tree/main/packages/core#annotations
      */

--- a/bin/rdme
+++ b/bin/rdme
@@ -31,11 +31,11 @@ require('../src')(process.argv.slice(2))
      * @link: https://github.com/actions/toolkit/tree/main/packages/core#annotations
      */
     if (isGHA) {
-      core.error(message);
-    } else {
-      // eslint-disable-next-line no-console
-      console.error(chalk.red(`\n${message}\n`));
+      return core.setFailed(message);
     }
+
+    // eslint-disable-next-line no-console
+    console.error(chalk.red(`\n${message}\n`));
 
     return process.exit(1);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@actions/core": "^1.6.0",
         "chalk": "^4.1.2",
-        "ci-info": "^3.3.0",
         "cli-table": "^0.3.1",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.0.2",
@@ -2825,7 +2824,8 @@
     "node_modules/ci-info": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw=="
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+      "dev": true
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
@@ -12118,7 +12118,8 @@
     "ci-info": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw=="
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+      "dev": true
     },
     "cjs-module-lexer": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.6.0",
         "chalk": "^4.1.2",
+        "ci-info": "^3.3.0",
         "cli-table": "^0.3.1",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.0.2",
@@ -2824,8 +2825,7 @@
     "node_modules/ci-info": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
-      "dev": true
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw=="
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
@@ -12118,8 +12118,7 @@
     "ci-info": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
-      "dev": true
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw=="
     },
     "cjs-module-lexer": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "6.4.0",
       "license": "MIT",
       "dependencies": {
+        "@actions/core": "^1.6.0",
         "chalk": "^4.1.2",
         "cli-table": "^0.3.1",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.0.2",
         "config": "^3.1.0",
         "configstore": "^5.0.0",
+        "debug": "^4.3.3",
         "editor": "^1.0.0",
         "enquirer": "^2.3.0",
         "form-data": "^4.0.0",
@@ -43,6 +45,22 @@
       },
       "engines": {
         "node": "^12 || ^14 || ^16"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "dependencies": {
+        "@actions/http-client": "^1.0.11"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "dependencies": {
+        "tunnel": "0.0.6"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -3244,7 +3262,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -7513,8 +7530,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multilang-extract-comments": {
       "version": "0.4.0",
@@ -9512,6 +9528,14 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -10001,6 +10025,22 @@
     }
   },
   "dependencies": {
+    "@actions/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "requires": {
+        "@actions/http-client": "^1.0.11"
+      }
+    },
+    "@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "requires": {
+        "tunnel": "0.0.6"
+      }
+    },
     "@apidevtools/json-schema-ref-parser": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
@@ -12431,7 +12471,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -15716,8 +15755,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multilang-extract-comments": {
       "version": "0.4.0",
@@ -17286,6 +17324,11 @@
       "requires": {
         "tslib": "^1.8.1"
       }
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "type": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@actions/core": "^1.6.0",
     "chalk": "^4.1.2",
-    "ci-info": "^3.3.0",
     "cli-table": "^0.3.1",
     "command-line-args": "^5.2.0",
     "command-line-usage": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@actions/core": "^1.6.0",
     "chalk": "^4.1.2",
+    "ci-info": "^3.3.0",
     "cli-table": "^0.3.1",
     "command-line-args": "^5.2.0",
     "command-line-usage": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,14 @@
     "url": "https://github.com/readmeio/rdme/issues"
   },
   "dependencies": {
+    "@actions/core": "^1.6.0",
     "chalk": "^4.1.2",
     "cli-table": "^0.3.1",
     "command-line-args": "^5.2.0",
     "command-line-usage": "^6.0.2",
     "config": "^3.1.0",
     "configstore": "^5.0.0",
+    "debug": "^4.3.3",
     "editor": "^1.0.0",
     "enquirer": "^2.3.0",
     "form-data": "^4.0.0",

--- a/src/cmds/docs/edit.js
+++ b/src/cmds/docs/edit.js
@@ -6,6 +6,7 @@ const APIError = require('../../lib/apiError');
 const { getProjectVersion } = require('../../lib/versionSelect');
 const fetch = require('../../lib/fetch');
 const { cleanHeaders, handleRes } = require('../../lib/fetch');
+const { debug } = require('../../lib/logger');
 
 const writeFile = promisify(fs.writeFile);
 const readFile = promisify(fs.readFile);
@@ -41,6 +42,9 @@ module.exports = class EditDocsCommand {
 
   async run(opts) {
     const { slug, key, version } = opts;
+
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
 
     if (!key) {
       return Promise.reject(new Error('No project API key provided. Please use `--key`.'));

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -43,8 +43,8 @@ module.exports = class DocsCommand {
   async run(opts) {
     const { folder, key, version } = opts;
 
-    debug('docs command');
-    debug(`opts passed: ${JSON.stringify(opts)}`);
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
 
     if (!key) {
       return Promise.reject(new Error('No project API key provided. Please use `--key`.'));

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -8,6 +8,7 @@ const { promisify } = require('util');
 const { getProjectVersion } = require('../../lib/versionSelect');
 const fetch = require('../../lib/fetch');
 const { cleanHeaders, handleRes } = require('../../lib/fetch');
+const { debug } = require('../../lib/logger');
 
 const readFile = promisify(fs.readFile);
 
@@ -42,6 +43,9 @@ module.exports = class DocsCommand {
   async run(opts) {
     const { folder, key, version } = opts;
 
+    debug('docs command');
+    debug(`opts passed: ${JSON.stringify(opts)}`);
+
     if (!key) {
       return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
     }
@@ -54,6 +58,8 @@ module.exports = class DocsCommand {
     // Let's revisit this once we re-evaluate our category logic in the API.
     // Ideally we should ignore this parameter entirely if the category is included.
     const selectedVersion = await getProjectVersion(version, key, false);
+
+    debug(`selectedVersion: ${selectedVersion}`);
 
     // Find the files to sync
     const readdirRecursive = folderToSearch => {
@@ -70,6 +76,9 @@ module.exports = class DocsCommand {
 
     // Strip out non-markdown files
     const files = readdirRecursive(folder).filter(file => file.endsWith('.md') || file.endsWith('.markdown'));
+
+    debug(`number of files: ${files.length}`);
+
     if (!files.length) {
       return Promise.reject(new Error(`We were unable to locate Markdown files in ${folder}.`));
     }
@@ -122,6 +131,8 @@ module.exports = class DocsCommand {
         const slug = matter.data.slug || path.basename(filename).replace(path.extname(filename), '').toLowerCase();
         const hash = crypto.createHash('sha1').update(file).digest('hex');
 
+        debug(`fetching data for ${slug}`);
+
         return fetch(`${config.get('host')}/api/v1/docs/${slug}`, {
           method: 'get',
           headers: cleanHeaders(key, {
@@ -131,9 +142,12 @@ module.exports = class DocsCommand {
         })
           .then(res => res.json())
           .then(res => {
+            debug(`GET /docs/:slug API response for ${slug}: ${JSON.stringify(res)}`);
             if (res.error) {
+              debug(`error retrieving data for ${slug}, creating doc`);
               return createDoc(slug, matter, hash, res);
             }
+            debug(`data received for ${slug}, updating doc`);
             return updateDoc(slug, matter, hash, res);
           })
           .catch(err => {

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -124,8 +124,10 @@ module.exports = class DocsCommand {
 
     const updatedDocs = await Promise.all(
       files.map(async filename => {
+        debug(`reading file ${filename}`);
         const file = await readFile(filename, 'utf8');
         const matter = frontMatter(file);
+        debug(`frontmatter for ${filename}: ${JSON.stringify(matter)}`);
 
         // Stripping the subdirectories and markdown extension from the filename and lowercasing to get the default slug.
         const slug = matter.data.slug || path.basename(filename).replace(path.extname(filename), '').toLowerCase();

--- a/src/cmds/login.js
+++ b/src/cmds/login.js
@@ -6,6 +6,7 @@ const read = promisify(require('read'));
 const configStore = require('../lib/configstore');
 const fetch = require('../lib/fetch');
 const { handleRes } = require('../lib/fetch');
+const { debug } = require('../lib/logger');
 
 const testing = process.env.NODE_ENV === 'testing';
 
@@ -33,6 +34,9 @@ module.exports = class LoginCommand {
 
   async run(opts) {
     let { email, password, project, token } = opts;
+
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
 
     /* istanbul ignore next */
     async function getCredentials() {

--- a/src/cmds/logout.js
+++ b/src/cmds/logout.js
@@ -1,5 +1,6 @@
 const config = require('config');
 const configStore = require('../lib/configstore');
+const { debug } = require('../lib/logger');
 
 module.exports = class LogoutCommand {
   constructor() {
@@ -13,6 +14,8 @@ module.exports = class LogoutCommand {
   }
 
   async run() {
+    debug(`command: ${this.command}`);
+
     if (configStore.has('email') && configStore.has('project')) {
       configStore.clear();
     }

--- a/src/cmds/oas.js
+++ b/src/cmds/oas.js
@@ -1,5 +1,6 @@
 const { spawn } = require('child_process');
 const path = require('path');
+const { debug } = require('../lib/logger');
 
 module.exports = class OASCommand {
   constructor() {
@@ -13,6 +14,8 @@ module.exports = class OASCommand {
   }
 
   async run() {
+    debug(`command: ${this.command}`);
+
     const cp = spawn(path.join(__dirname, '..', '..', 'node_modules', '.bin', 'oas'), process.argv.slice(3), {
       stdio: 'inherit',
     });

--- a/src/cmds/oas.js
+++ b/src/cmds/oas.js
@@ -15,6 +15,7 @@ module.exports = class OASCommand {
 
   async run() {
     debug(`command: ${this.command}`);
+    debug('spawning new process with `oas`');
 
     const cp = spawn(path.join(__dirname, '..', '..', 'node_modules', '.bin', 'oas'), process.argv.slice(3), {
       stdio: 'inherit',
@@ -22,6 +23,7 @@ module.exports = class OASCommand {
 
     return new Promise((resolve, reject) => {
       cp.on('close', code => {
+        debug(`closing \`oas\` process with code: ${code}`);
         if (code && code > 0) return reject();
 
         return resolve();

--- a/src/cmds/open.js
+++ b/src/cmds/open.js
@@ -2,6 +2,7 @@ const chalk = require('chalk');
 const config = require('config');
 const open = require('open');
 const configStore = require('../lib/configstore');
+const { debug } = require('../lib/logger');
 
 module.exports = class OpenCommand {
   constructor() {
@@ -15,6 +16,9 @@ module.exports = class OpenCommand {
   }
 
   async run(opts) {
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
+
     const project = configStore.get('project');
     if (!project) {
       return Promise.reject(new Error(`Please login using \`${config.get('cli')} login\`.`));

--- a/src/cmds/open.js
+++ b/src/cmds/open.js
@@ -20,6 +20,8 @@ module.exports = class OpenCommand {
     debug(`opts: ${JSON.stringify(opts)}`);
 
     const project = configStore.get('project');
+    debug(`project: ${project}`);
+
     if (!project) {
       return Promise.reject(new Error(`Please login using \`${config.get('cli')} login\`.`));
     }

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -11,6 +11,7 @@ const { cleanHeaders } = require('../lib/fetch');
 const FormData = require('form-data');
 const parse = require('parse-link-header');
 const { file: tmpFile } = require('tmp-promise');
+const { debug } = require('../lib/logger');
 
 module.exports = class OpenAPICommand {
   constructor() {
@@ -55,6 +56,9 @@ module.exports = class OpenAPICommand {
     let { key, id } = opts;
     let selectedVersion;
     let isUpdate;
+
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
 
     if (!key && opts.token) {
       console.warn(

--- a/src/cmds/swagger.js
+++ b/src/cmds/swagger.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk');
 const OpenAPICommand = require('./openapi');
+const { debug } = require('../lib/logger');
 
 module.exports = class SwaggerCommand extends OpenAPICommand {
   constructor() {
@@ -12,6 +13,9 @@ module.exports = class SwaggerCommand extends OpenAPICommand {
   }
 
   async run(opts) {
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
+
     console.warn(chalk.yellow('⚠️  Warning! `rdme swagger` has been deprecated. Please use `rdme openapi` instead.'));
     return super.run(opts);
   }

--- a/src/cmds/validate.js
+++ b/src/cmds/validate.js
@@ -1,6 +1,7 @@
 const chalk = require('chalk');
 const fs = require('fs');
 const OASNormalize = require('oas-normalize');
+const { debug } = require('../lib/logger');
 
 module.exports = class ValidateCommand {
   constructor() {
@@ -22,6 +23,9 @@ module.exports = class ValidateCommand {
 
   async run(opts) {
     const { spec } = opts;
+
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
 
     async function validateSpec(specPath) {
       const oas = new OASNormalize(specPath, { colorizeErrors: true, enablePaths: true });

--- a/src/cmds/validate.js
+++ b/src/cmds/validate.js
@@ -39,6 +39,7 @@ module.exports = class ValidateCommand {
           return Promise.resolve(chalk.green(`${specPath} is a valid OpenAPI API definition!`));
         })
         .catch(err => {
+          debug(`raw validation error object: ${JSON.stringify(err)}`);
           return Promise.reject(new Error(err.message));
         });
     }
@@ -51,7 +52,9 @@ module.exports = class ValidateCommand {
     // don't have any, let's let the user know how they can get one going.
     return new Promise((resolve, reject) => {
       ['swagger.json', 'swagger.yaml', 'openapi.json', 'openapi.yaml'].forEach(file => {
+        debug(`looking for definition with filename: ${file}`);
         if (!fs.existsSync(file)) {
+          debug(`${file} not found`);
           return;
         }
 

--- a/src/cmds/versions/create.js
+++ b/src/cmds/versions/create.js
@@ -4,6 +4,7 @@ const { prompt } = require('enquirer');
 const promptOpts = require('../../lib/prompts');
 const fetch = require('../../lib/fetch');
 const { cleanHeaders, handleRes } = require('../../lib/fetch');
+const { debug } = require('../../lib/logger');
 
 module.exports = class CreateVersionCommand {
   constructor() {
@@ -56,6 +57,9 @@ module.exports = class CreateVersionCommand {
   async run(opts) {
     let versionList;
     const { key, version, codename, fork, main, beta, isPublic } = opts;
+
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
 
     if (!key) {
       return Promise.reject(new Error('No project API key provided. Please use `--key`.'));

--- a/src/cmds/versions/delete.js
+++ b/src/cmds/versions/delete.js
@@ -41,6 +41,8 @@ module.exports = class DeleteVersionCommand {
       return Promise.reject(e);
     });
 
+    debug(`selectedVersion: ${selectedVersion}`);
+
     return fetch(`${config.get('host')}/api/v1/version/${selectedVersion}`, {
       method: 'delete',
       headers: cleanHeaders(key),

--- a/src/cmds/versions/delete.js
+++ b/src/cmds/versions/delete.js
@@ -2,6 +2,7 @@ const config = require('config');
 const { getProjectVersion } = require('../../lib/versionSelect');
 const fetch = require('../../lib/fetch');
 const { cleanHeaders, handleRes } = require('../../lib/fetch');
+const { debug } = require('../../lib/logger');
 
 module.exports = class DeleteVersionCommand {
   constructor() {
@@ -28,6 +29,9 @@ module.exports = class DeleteVersionCommand {
 
   async run(opts) {
     const { key, version } = opts;
+
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
 
     if (!key) {
       return Promise.reject(new Error('No project API key provided. Please use `--key`.'));

--- a/src/cmds/versions/index.js
+++ b/src/cmds/versions/index.js
@@ -4,6 +4,7 @@ const config = require('config');
 const CreateVersionCmd = require('./create');
 const fetch = require('../../lib/fetch');
 const { cleanHeaders, handleRes } = require('../../lib/fetch');
+const { debug } = require('../../lib/logger');
 
 module.exports = class VersionsCommand {
   constructor() {
@@ -86,6 +87,9 @@ module.exports = class VersionsCommand {
 
   async run(opts) {
     const { key, version, raw } = opts;
+
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
 
     if (!key) {
       return Promise.reject(new Error('No project API key provided. Please use `--key`.'));

--- a/src/cmds/versions/update.js
+++ b/src/cmds/versions/update.js
@@ -62,6 +62,8 @@ module.exports = class UpdateVersionCommand {
       return Promise.reject(e);
     });
 
+    debug(`selectedVersion: ${selectedVersion}`);
+
     const foundVersion = await fetch(`${config.get('host')}/api/v1/version/${selectedVersion}`, {
       method: 'get',
       headers: cleanHeaders(key),

--- a/src/cmds/versions/update.js
+++ b/src/cmds/versions/update.js
@@ -4,6 +4,7 @@ const promptOpts = require('../../lib/prompts');
 const { getProjectVersion } = require('../../lib/versionSelect');
 const fetch = require('../../lib/fetch');
 const { cleanHeaders, handleRes } = require('../../lib/fetch');
+const { debug } = require('../../lib/logger');
 
 module.exports = class UpdateVersionCommand {
   constructor() {
@@ -49,6 +50,9 @@ module.exports = class UpdateVersionCommand {
 
   async run(opts) {
     const { key, version, codename, newVersion, main, beta, isPublic, deprecated } = opts;
+
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
 
     if (!key) {
       return Promise.reject(new Error('No project API key provided. Please use `--key`.'));

--- a/src/cmds/whoami.js
+++ b/src/cmds/whoami.js
@@ -1,6 +1,7 @@
 const chalk = require('chalk');
 const config = require('config');
 const configStore = require('../lib/configstore');
+const { debug } = require('../lib/logger');
 
 module.exports = class WhoAmICommand {
   constructor() {
@@ -14,6 +15,8 @@ module.exports = class WhoAmICommand {
   }
 
   async run() {
+    debug(`command: ${this.command}`);
+
     if (!configStore.has('email') || !configStore.has('project')) {
       return Promise.reject(new Error(`Please login using \`${config.get('cli')} login\`.`));
     }

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const { version } = require('../package.json');
 const configStore = require('./lib/configstore');
 const help = require('./lib/help');
 const commands = require('./lib/commands');
+const { debug } = require('./lib/logger');
 
 /**
  * @param {Array} processArgv - An array of arguments from the current process. Can be used to mock
@@ -40,6 +41,8 @@ module.exports = processArgv => {
 
   const argv = cliArgs(mainArgs, { partial: true, argv: processArgv });
   const cmd = argv.command || false;
+
+  debug(`command-line-args processing: ${JSON.stringify(argv)}`);
 
   // Add support for `-V` as an additional `--version` alias.
   if (typeof argv._unknown !== 'undefined') {

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -25,7 +25,7 @@ module.exports = (url, options = { headers: {} }) => {
 
   options.headers['x-readme-source'] = source;
 
-  debug(`making fetch request to ${url}`);
+  debug(`making ${options.method.toUpperCase() || 'GET'} request to ${url}`);
 
   return fetch(url, options);
 };

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -25,7 +25,7 @@ module.exports = (url, options = { headers: {} }) => {
 
   options.headers['x-readme-source'] = source;
 
-  debug(`making ${(options.method && options.method.toUpperCase()) || 'GET'} request to ${url}`);
+  debug(`making ${(options.method || 'get').toUpperCase()} request to ${url}`);
 
   return fetch(url, options);
 };

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -1,15 +1,9 @@
 /* eslint-disable no-param-reassign */
+const debug = require('./logger');
 const fetch = require('node-fetch');
+const isGHA = require('./isGitHub');
 const pkg = require('../../package.json');
 const APIError = require('./apiError');
-
-/**
- * Small env check to determine if we're in a GitHub Actions environment
- * @link https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
- */
-function isGHA() {
-  return process.env.GITHUB_ACTIONS === 'true';
-}
 
 /**
  * Wrapper for the `fetch` API so we can add rdme-specific headers to all API requests.
@@ -30,6 +24,8 @@ module.exports = (url, options = { headers: {} }) => {
   }
 
   options.headers['x-readme-source'] = source;
+
+  debug(`making fetch request to ${url} with options: ${JSON.stringify(options)}`);
 
   return fetch(url, options);
 };

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -25,7 +25,7 @@ module.exports = (url, options = { headers: {} }) => {
 
   options.headers['x-readme-source'] = source;
 
-  debug(`making ${options.method.toUpperCase() || 'GET'} request to ${url}`);
+  debug(`making ${(options.method && options.method.toUpperCase()) || 'GET'} request to ${url}`);
 
   return fetch(url, options);
 };

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-const debug = require('./logger');
+const { debug } = require('./logger');
 const fetch = require('node-fetch');
 const isGHA = require('./isGitHub');
 const pkg = require('../../package.json');

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -25,7 +25,7 @@ module.exports = (url, options = { headers: {} }) => {
 
   options.headers['x-readme-source'] = source;
 
-  debug(`making fetch request to ${url} with options: ${JSON.stringify(options)}`);
+  debug(`making fetch request to ${url}`);
 
   return fetch(url, options);
 };

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -48,6 +48,7 @@ module.exports.getUserAgent = function getUserAgent() {
  */
 module.exports.handleRes = async function handleRes(res) {
   const body = await res.json();
+  debug(`received status code ${res.status} with response body: ${JSON.stringify(body)}`);
   if (body.error) {
     return Promise.reject(new APIError(body));
   }

--- a/src/lib/isGitHub.js
+++ b/src/lib/isGitHub.js
@@ -1,0 +1,7 @@
+/**
+ * Small env check to determine if we're in a GitHub Actions environment
+ * @link https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+ */
+module.exports = function isGHA() {
+  return process.env.GITHUB_ACTIONS === 'true';
+};

--- a/src/lib/isGitHub.js
+++ b/src/lib/isGitHub.js
@@ -3,6 +3,5 @@
  * @link https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
  */
 module.exports = function isGHA() {
-  // eslint-disable-next-line global-require
-  return require('ci-info').GITHUB_ACTIONS;
+  return process.env.GITHUB_ACTIONS === 'true';
 };

--- a/src/lib/isGitHub.js
+++ b/src/lib/isGitHub.js
@@ -3,5 +3,6 @@
  * @link https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
  */
 module.exports = function isGHA() {
-  return process.env.GITHUB_ACTIONS === 'true';
+  // eslint-disable-next-line global-require
+  return require('ci-info').GITHUB_ACTIONS;
 };

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,0 +1,25 @@
+const chalk = require('chalk');
+const config = require('config');
+const core = require('@actions/core');
+const debug = require('debug')(config.get('cli'));
+const isGHA = require('./isGitHub');
+
+/**
+ * Wrapper for debug statements.
+ * @param {String} arg
+ */
+module.exports = function (arg) {
+  if (isGHA()) core.debug(arg);
+  return debug(arg);
+};
+
+/**
+ * Logs the arguments to stdout using console.warn()
+ * with yellow text and prefixed with a '⚠️  Warning!'
+ * @param  {...any} args Any number of arguments.
+ * The output will return the arguments separated
+ * by a space.
+ */
+module.exports.warn = function (...args) {
+  return console.warn(chalk.yellow('⚠️  Warning!', ...args));
+};

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,17 +1,17 @@
 const chalk = require('chalk');
 const config = require('config');
 const core = require('@actions/core');
-const debug = require('debug')(config.get('cli'));
+const debugPackage = require('debug')(config.get('cli'));
 const isGHA = require('./isGitHub');
 
 /**
  * Wrapper for debug statements.
  * @param {String} arg
  */
-module.exports = function (arg) {
-  if (isGHA()) core.debug(arg);
-  return debug(arg);
-};
+function debug(arg) {
+  if (isGHA() && process.env.NODE_ENV !== 'testing') core.debug(arg);
+  return debugPackage(arg);
+}
 
 /**
  * Logs the arguments to stdout using console.warn()
@@ -23,3 +23,6 @@ module.exports = function (arg) {
 module.exports.warn = function (...args) {
   return console.warn(chalk.yellow('⚠️  Warning!', ...args));
 };
+
+module.exports = debug;
+module.exports.debug = debug;

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,4 +1,3 @@
-const chalk = require('chalk');
 const config = require('config');
 const core = require('@actions/core');
 const debugPackage = require('debug')(config.get('cli'));
@@ -8,10 +7,8 @@ const isGHA = require('./isGitHub');
  * Wrapper for debug statements.
  * @param {String} arg
  */
-function debug(arg) {
+module.exports.debug = function debug(arg) {
+  /* istanbul ignore next */
   if (isGHA() && process.env.NODE_ENV !== 'testing') core.debug(arg);
   return debugPackage(arg);
-}
-
-module.exports = debug;
-module.exports.debug = debug;
+};

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -13,17 +13,5 @@ function debug(arg) {
   return debugPackage(arg);
 }
 
-/**
- * Logs the arguments to stdout using console.warn()
- * with yellow text and prefixed with a '⚠️  Warning!'
- * @param  {...any} args Any number of arguments.
- * The output will return the arguments separated
- * by a space.
- */
-module.exports.warn = function (...args) {
-  if (isGHA() && process.env.NODE_ENV !== 'testing') return core.warning(args.join(' '));
-  return console.warn(chalk.yellow('⚠️  Warning!', ...args));
-};
-
 module.exports = debug;
 module.exports.debug = debug;

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -21,6 +21,7 @@ function debug(arg) {
  * by a space.
  */
 module.exports.warn = function (...args) {
+  if (isGHA() && process.env.NODE_ENV !== 'testing') return core.warning(args.join(' '));
   return console.warn(chalk.yellow('⚠️  Warning!', ...args));
 };
 

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -5,10 +5,10 @@ const isGHA = require('./isGitHub');
 
 /**
  * Wrapper for debug statements.
- * @param {String} arg
+ * @param {String} input
  */
-module.exports.debug = function debug(arg) {
+module.exports.debug = function debug(input) {
   /* istanbul ignore next */
-  if (isGHA() && process.env.NODE_ENV !== 'testing') core.debug(arg);
-  return debugPackage(arg);
+  if (isGHA() && process.env.NODE_ENV !== 'testing') core.debug(`rdme: ${input}`);
+  return debugPackage(input);
 };


### PR DESCRIPTION
## 🧰 Changes

<details>
<summary><b>Commands that now have debugging</b></summary>

- [x] `login`
- [x] `logout`
- [x] `whoami`
- [x] `openapi`
- [x] `validate`
- [x] `swagger`
- [x] `docs`
- [x] `docs:edit`
- [x] `versions`
- [x] `versions:create`
- [x] `versions:update`
- [x] `versions:delete`
- [x] `oas`
- [x] `open`

</details>

<details>
<summary><b>Helper functions that now have debugging</b></summary>

- [x] `fetch()`
- [x] `handleRes()`

Obviously there are many other helper functions, but these are the only ones that felt necessary.

</details>

Additionally, I made a small enhancement to `bin/rdme` to output errors via the native GitHub Action annotation format so they're properly surfaced. You can see an example of this in [this workflow run](https://github.com/readmeio/rdme/actions/runs/1890909393) (and in the image below[^1]).

<img width="931" alt="image" src="https://user-images.githubusercontent.com/8854718/155449846-d54a718c-2bf9-469a-b184-6ae93c36511b.png">

## 🧬 QA & Testing

No functional changes beyond migrating `isGHA()` into its own file and enhancing the logging in `bin/rdme` (the results of which you can see in the annotation example above). Do tests pass? And can you see debug logs on [this workflow run](https://github.com/readmeio/rdme/runs/5313514327?check_suite_focus=true#step:3:116)?

Fixes RM-3451, RM-3544

[^1]: Yes, the "Process completed with exit code 1" error is excessive and is bugging me as well, and no, I don't know how to get rid of it... I think this is an unfortunate by-product of going with the composite action route 😞 