### PR TITLE
feat: ci awareness to disable terminal prompting within commands

### DIFF
--- a/__tests__/cmds/versions.test.js
+++ b/__tests__/cmds/versions.test.js
@@ -155,9 +155,7 @@ describe('rdme versions*', () => {
           .reply(200, [{ version }, { version }]);
 
         await expect(createVersion.run({ key, version })).rejects.toThrow(
-          new Error(
-            "We've detected you're running within a CircleCI environment, please supply the following required arguments for your command instead of relying on our terminal prompt system: fork"
-          )
+          /We've detected you're running within a (.*) environment, please supply the following required arguments for your command instead of relying on our terminal prompt system: fork/
         );
 
         mockRequest.done();

--- a/__tests__/cmds/versions.test.js
+++ b/__tests__/cmds/versions.test.js
@@ -155,7 +155,7 @@ describe('rdme versions*', () => {
           .reply(200, [{ version }, { version }]);
 
         await expect(createVersion.run({ key, version })).rejects.toThrow(
-          /We've detected you're running within a (.*) environment, please supply the following required arguments for your command instead of relying on our terminal prompt system: fork/
+          /we noticed you're running this command within/i
         );
 
         mockRequest.done();

--- a/__tests__/cmds/versions.test.js
+++ b/__tests__/cmds/versions.test.js
@@ -105,37 +105,27 @@ describe('rdme versions*', () => {
     });
 
     it('should create a specific version', async () => {
+      const args = { key, version, fork: '1.0.0', main: false, beta: true, public: true };
       const mockRequest = getApiNock()
         .post('/api/v1/version', {
           version: '1.0.0',
           codename: '',
           is_stable: false,
-          is_beta: false,
+          is_beta: true,
           from: '1.0.0',
-          is_hidden: true,
+          is_hidden: false,
         })
         .basicAuth({ user: key })
         .reply(201, { version });
 
-      await expect(createVersion.run({ key, version, fork: '1.0.0', main: true, beta: false })).resolves.toBe(
-        'Version 1.0.0 created successfully.'
-      );
-
+      await expect(createVersion.run(args)).resolves.toBe('Version 1.0.0 created successfully.');
       mockRequest.done();
     });
 
     it.todo('should prompt a version list if no `--fork` argument is supplied');
 
     it('should catch any post request errors', async () => {
-      const args = {
-        key,
-        version,
-        fork: '0.0.5',
-        main: false,
-        beta: false,
-        public: false,
-      };
-
+      const args = { key, version, fork: '0.0.5', main: false, beta: false, public: false };
       const errorResponse = {
         error: 'VERSION_EMPTY',
         message: 'You need to include an x-readme-version header',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
+        "ci-info": "^3.3.0",
         "cli-table": "^0.3.1",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.0.2",
@@ -2806,8 +2807,7 @@
     "node_modules/ci-info": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
-      "dev": true
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw=="
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
@@ -12078,8 +12078,7 @@
     "ci-info": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
-      "dev": true
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw=="
     },
     "cjs-module-lexer": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
+    "ci-info": "^3.3.0",
     "cli-table": "^0.3.1",
     "command-line-args": "^5.2.0",
     "command-line-usage": "^6.0.2",

--- a/src/cmds/versions/create.js
+++ b/src/cmds/versions/create.js
@@ -118,7 +118,7 @@ module.exports = class CreateVersionCommand {
         is_stable: opts.main || answers.main,
         is_beta: opts.beta || answers.beta,
         from: opts.fork || answers.fork,
-        is_hidden: answers.is_stable ? false : !('public' in opts || answers.public),
+        is_hidden: opts.main || answers.main ? false : !('public' in opts || answers.public),
       }),
     })
       .then(handleRes)

--- a/src/cmds/versions/create.js
+++ b/src/cmds/versions/create.js
@@ -1,6 +1,6 @@
 const config = require('config');
 const semver = require('semver');
-const enquirer = require('../../lib/enquirer');
+const prompt = require('../../lib/prompt');
 
 const fetch = require('../../lib/fetch');
 const { cleanHeaders, handleRes } = require('../../lib/fetch');
@@ -108,7 +108,10 @@ module.exports = class CreateVersionCommand {
       },
     ];
 
-    const answers = await enquirer(opts, questions);
+    const answers = await prompt(opts, questions);
+
+    const isMain = opts.main || answers.main;
+    const isPublic = 'public' in opts || answers.public;
 
     return fetch(`${config.get('host')}/api/v1/version`, {
       method: 'post',
@@ -122,7 +125,7 @@ module.exports = class CreateVersionCommand {
         is_stable: opts.main || answers.main,
         is_beta: opts.beta || answers.beta,
         from: opts.fork || answers.fork,
-        is_hidden: opts.main || answers.main ? false : !('public' in opts || answers.public),
+        is_hidden: isMain ? false : !isPublic,
       }),
     })
       .then(handleRes)

--- a/src/lib/enquirer.js
+++ b/src/lib/enquirer.js
@@ -1,0 +1,58 @@
+const Enquirer = require('enquirer');
+const chalk = require('chalk');
+
+function disablePromptsInCI(answers = {}) {
+  return enquirer => {
+    const prompt = enquirer.prompt.bind(enquirer);
+    const context = { ...enquirer.answers, ...answers };
+
+    // eslint-disable-next-line no-param-reassign
+    enquirer.prompt = async questions => {
+      const list = [].concat(questions || []);
+
+      // Purposefully loading `ci-info` here so we can adequately test it.
+      const ci = require('ci-info'); // eslint-disable-line global-require
+      if (!ci.isCI) {
+        // If we aren't in a CI environment then we shouldn't look for unanswered questions.
+        return prompt(list);
+      }
+
+      const missingArgs = [];
+
+      (questions || []).forEach(item => {
+        // Confirm-style questions are always optional!
+        if (item.type !== 'confirm') {
+          const value = context[item.name];
+          if (value === undefined && !item.skip()) {
+            missingArgs.push(item.name);
+          }
+        }
+      });
+
+      if (missingArgs.length) {
+        throw new Error(
+          `We've detected you're running within a ${
+            ci.name
+          } environment, please supply the following required arguments for your command instead of relying on our terminal prompt system: ${chalk.yellow(
+            missingArgs.join(',')
+          )}`
+        );
+      }
+
+      return prompt(list);
+    };
+  };
+}
+
+module.exports = function (answers = {}, questions = []) {
+  const enquirer = new Enquirer();
+
+  enquirer.use(disablePromptsInCI(answers));
+
+  return enquirer.prompt(questions).catch(err => {
+    // If the Enquirer promise was rejected without an error then the user killed an open prompt so
+    // we should abide by their wishes and bail out.
+    if (!err) process.exit(0);
+    throw err;
+  });
+};

--- a/src/lib/prompt.js
+++ b/src/lib/prompt.js
@@ -1,5 +1,4 @@
 const Enquirer = require('enquirer');
-const chalk = require('chalk');
 
 function disablePromptsInCI(answers = {}) {
   return enquirer => {
@@ -30,12 +29,9 @@ function disablePromptsInCI(answers = {}) {
       });
 
       if (missingArgs.length) {
+        // prettier-ignore
         throw new Error(
-          `We've detected you're running within a ${
-            ci.name
-          } environment, please supply the following required arguments for your command instead of relying on our terminal prompt system: ${chalk.yellow(
-            missingArgs.join(',')
-          )}`
+          `Oops! We noticed you're running this command within a ${ci.name} environment, but we have a few questions we were going to ask you! We'll need the following arguments for your command to run question-free: ${missingArgs.join(',')}`
         );
       }
 


### PR DESCRIPTION
| 🚥 Fix RM-3621 |
| :-- |

## 🧰 Changes

With our new workflow in #437 there's a new issue that will likely crop up for some folks is that if you don't supply all of the required arguments for a command in a CI environment, our [enquirer](https://npm.im/enquirer) setup will prompt the terminal for input -- something that will never be answered in a CI environment.

For this we're introducing some new awareness to our commands that ask the user for input to not do that if it's within a CI environment and instead throw an error telling them that they're missing arguments.

I'm also making some other adjustments to a couple commands to clean up their argument structure:

* [x] `versions:create`
  * `--main` and `--beta` are now booleans
  * `--isPublic` has been renamed to just `--public` and it's also been made into a boolean.
  * [ ] Make sure usage in README.md is updated
* [ ] `versions:update`
  * `--main` and `--beta` are now booleans
  * `--isPublic` has been renamed to just `--public` and it's also been made into a boolean.
  * [ ] Make sure usage in README.md is updated
## 🧬 QA & Testing

If with all the changes I made tests are still passing, 👍 

You can also test this behavior out locally by prefixing `GITHUB_ACTIONS=true` to a `./bin/rdme` call:

```
$ GITHUB_ACTIONS=true ./bin/rdme versions:create --version=1.0.0

We've detected you're running within a GitHub Actions environment, please supply the following required 
arguments for your command instead of relying on our terminal prompt system: fork
```

