### PR TITLE
chore: remove deprecated `token` parameter

### DIFF
--- a/__tests__/cmds/openapi.test.js
+++ b/__tests__/cmds/openapi.test.js
@@ -152,30 +152,6 @@ describe('rdme openapi', () => {
       return mock.done();
     });
 
-    it('should still support `token`', async () => {
-      const mock = getApiNock()
-        .put(`/api/v1/api-specification/${id}`, body => body.match('form-data; name="spec"'))
-        .basicAuth({ user: key })
-        .reply(201, { _id: 1 }, { location: exampleRefLocation });
-
-      await expect(
-        openapi.run({
-          spec: require.resolve('@readme/oas-examples/3.1/json/petstore.json'),
-          token: `${key}-${id}`,
-          version,
-        })
-      ).resolves.toBe(successfulUpdate);
-
-      expect(console.warn).toHaveBeenCalledTimes(2);
-      expect(console.info).toHaveBeenCalledTimes(0);
-
-      const output = getCommandOutput();
-
-      expect(output).toMatch(/The `--token` option has been deprecated/i);
-
-      return mock.done();
-    });
-
     it('should return warning if providing `id` and `version`', async () => {
       const mock = getApiNock()
         .put(`/api/v1/api-specification/${id}`, body => body.match('form-data; name="spec"'))

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -34,11 +34,6 @@ module.exports = class OpenAPICommand {
         description: `Unique identifier for your API definition. Use this if you're re-uploading an existing API definition`,
       },
       {
-        name: 'token',
-        type: String,
-        description: 'Project token. Deprecated, please use `--key` instead',
-      },
-      {
         name: 'version',
         type: String,
         description: 'Project version',
@@ -57,8 +52,7 @@ module.exports = class OpenAPICommand {
   }
 
   async run(opts) {
-    const { spec, version, workdir } = opts;
-    let { key, id } = opts;
+    const { key, id, spec, version, workdir } = opts;
     let selectedVersion;
     let isUpdate;
 
@@ -67,14 +61,6 @@ module.exports = class OpenAPICommand {
 
     if (workdir) {
       process.chdir(workdir);
-    }
-
-    if (!key && opts.token) {
-      console.warn(
-        chalk.yellow('⚠️  Warning! The `--token` option has been deprecated. Please use `--key` and `--id` instead.')
-      );
-
-      [key, id] = opts.token.split('-');
     }
 
     if (version && id) {


### PR DESCRIPTION
## 🧰 Changes

The `token` parameter has been deprecated for some time now, so this PR removes it from the `openapi` command (targeting v7).

## 🧬 QA & Testing

Do tests pass?
