### PR TITLE
feat(docs): add `--dryRun` option

### DIFF
--- a/__tests__/cmds/docs.test.js
+++ b/__tests__/cmds/docs.test.js
@@ -112,14 +112,12 @@ describe('rdme docs', () => {
       return docs.run({ folder: './__tests__/__fixtures__/existing-docs', key, version }).then(updatedDocs => {
         // All docs should have been updated because their hashes from the GET request were different from what they
         // are currently.
-        expect(updatedDocs).toStrictEqual([
-          {
-            category,
-            slug: simpleDoc.slug,
-            body: simpleDoc.doc.content,
-          },
-          { category, slug: anotherDoc.slug, body: anotherDoc.doc.content },
-        ]);
+        expect(updatedDocs).toBe(
+          [
+            "✏️ successfully updated 'simple-doc' with contents from __tests__/__fixtures__/existing-docs/simple-doc.md",
+            "✏️ successfully updated 'another-doc' with contents from __tests__/__fixtures__/existing-docs/subdir/another-doc.md",
+          ].join('\n')
+        );
 
         getMocks.done();
         updateMocks.done();
@@ -144,10 +142,12 @@ describe('rdme docs', () => {
         .reply(200, { version });
 
       return docs.run({ folder: './__tests__/__fixtures__/existing-docs', key, version }).then(skippedDocs => {
-        expect(skippedDocs).toStrictEqual([
-          '`simple-doc` was not updated because there were no changes.',
-          '`another-doc` was not updated because there were no changes.',
-        ]);
+        expect(skippedDocs).toBe(
+          [
+            '`simple-doc` was not updated because there were no changes.',
+            '`another-doc` was not updated because there were no changes.',
+          ].join('\n')
+        );
 
         getMocks.done();
         versionMock.done();
@@ -181,15 +181,9 @@ describe('rdme docs', () => {
         .basicAuth({ user: key })
         .reply(200, { version });
 
-      await expect(docs.run({ folder: './__tests__/__fixtures__/new-docs', key, version })).resolves.toStrictEqual([
-        {
-          slug: 'new-doc',
-          body: '\nBody\n',
-          category: '5ae122e10fdf4e39bb34db6f',
-          title: 'This is the document title',
-          lastUpdatedHash: 'a23046c1e9d8ab47f8875ae7c5e429cb95be1c48',
-        },
-      ]);
+      await expect(docs.run({ folder: './__tests__/__fixtures__/new-docs', key, version })).resolves.toBe(
+        "🌱 successfully created 'new-doc' with contents from __tests__/__fixtures__/new-docs/new-doc.md"
+      );
 
       getMock.done();
       postMock.done();
@@ -301,15 +295,9 @@ describe('rdme docs', () => {
         .basicAuth({ user: key })
         .reply(200, { version });
 
-      await expect(docs.run({ folder: './__tests__/__fixtures__/slug-docs', key, version })).resolves.toStrictEqual([
-        {
-          slug: 'marc-actually-wrote-a-test',
-          body: '\nBody\n',
-          category: 'CATEGORY_ID',
-          title: 'This is the document title',
-          lastUpdatedHash: 'c9cb7cc26e90775548e1d182ae7fcaa0eaba96bc',
-        },
-      ]);
+      await expect(docs.run({ folder: './__tests__/__fixtures__/slug-docs', key, version })).resolves.toBe(
+        "🌱 successfully created 'marc-actually-wrote-a-test' with contents from __tests__/__fixtures__/slug-docs/new-doc-slug.md"
+      );
 
       getMock.done();
       postMock.done();

--- a/__tests__/cmds/docs.test.js
+++ b/__tests__/cmds/docs.test.js
@@ -45,9 +45,25 @@ describe('rdme docs', () => {
     );
   });
 
-  it.todo('should error if the argument isnt a folder');
+  it('should error if the argument isnt a folder', async () => {
+    const versionMock = getApiNock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
 
-  it.todo('should error if the folder contains no markdown files');
+    await expect(docs.run({ key, version: '1.0.0', folder: 'not-a-folder' })).rejects.toThrow(
+      "ENOENT: no such file or directory, scandir 'not-a-folder'"
+    );
+
+    versionMock.done();
+  });
+
+  it('should error if the folder contains no markdown files', async () => {
+    const versionMock = getApiNock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
+
+    await expect(docs.run({ key, version: '1.0.0', folder: '.github/workflows' })).rejects.toThrow(
+      'We were unable to locate Markdown files in .github/workflows.'
+    );
+
+    versionMock.done();
+  });
 
   describe('existing docs', () => {
     let simpleDoc;

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -91,10 +91,11 @@ module.exports = class DocsCommand {
     function createDoc(slug, file, filename, hash, err) {
       if (err.error !== 'DOC_NOTFOUND') return Promise.reject(err);
 
-      if (dryRun)
+      if (dryRun) {
         return `🎭 dry run! This will create '${slug}' with contents from ${filename} with the following metadata: ${JSON.stringify(
           file.data
         )}`;
+      }
 
       return fetch(`${config.get('host')}/api/v1/docs`, {
         method: 'post',
@@ -120,10 +121,11 @@ module.exports = class DocsCommand {
         } updated because there were no changes.`;
       }
 
-      if (dryRun)
+      if (dryRun) {
         return `🎭 dry run! This will update '${slug}' with contents from ${filename} with the following metadata: ${JSON.stringify(
           file.data
         )}`;
+      }
 
       return fetch(`${config.get('host')}/api/v1/docs/${slug}`, {
         method: 'put',


### PR DESCRIPTION
## 🧰 Changes

Realized while working on the docs syncing workflow in #439 that this would be a super easy win and extremely useful to have.
- [x] Adds `--dryRun` option to `docs` command
- [x] Adds `--dryRun` tests
- [x] If someone runs the `docs` command successfully, the output an enormous, mostly unreadable JS array of objects ([example](https://github.com/readmeio/rdme/runs/5340425438?check_suite_focus=true#step:6:19)). Since this tool now supports debugging, this isn't really necessary and isn't particularly user-friendly. So this PR reformats the `docs` command outputs so it always returns formatted success messages doc objects
- [x] Backfilled some test TODOs and updated tests to reflect new command outputs

## 🧬 QA & Testing

If tests pass, we should be good to go! You can also try this out yourself on any project by checking out this branch and running the following command: 
```sh
bin/rdme docs --dryRun --key=API_KEY __tests__/__fixtures__/new-docs
```
This won't make any changes in your project and instead will return a command output that looks like this:
```
🎭 dry run! This will create 'new-doc' with contents from __tests__/__fixtures__/new-docs/new-doc.md with the following metadata: {"category":"5ae122e10fdf4e39bb34db6f","title":"This is the document title"}
```
