### PR TITLE
chore(deps): bump to setup-node v3 in action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
   steps:
     # This is so we can guarantee a version of npm that supports lockfile@2
     - name: setup node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16
     # When we add debug support, we should make this a conditional step, see RM-3545


### PR DESCRIPTION
## 🧰 Changes

Noticed https://github.com/readmeio/rdme/pull/459 and decided to bump that in our action. Not sure if it does anything 🤷🏽‍♂️ 

## 🧬 QA & Testing

If the [GitHub Action Dry Run part of CI](https://github.com/readmeio/rdme/runs/5383759437?check_suite_focus=true) passes, we should be good to go!
