### PR TITLE
Drop setup node

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ Once you've installed `act`, it'll ask you what Docker image size you'd like. Th
 -P ubuntu-18.04=ghcr.io/catthehacker/ubuntu:act-18.04
 ```
 
+> Our GitHub Actions guidance states that Action workflows should have a [`runs-on` value](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on) of `ubuntu-latest`. These runners are updated frequently—you can find links to the the latest versions by navigating [here](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#preinstalled-software) and selecting the latest Ubuntu link. Because of this, you'll want to make sure your `ghcr.io/catthehacker/ubuntu` image stays up-to-date by doing a periodic [pull](https://docs.docker.com/desktop/dashboard/#pull-the-latest-image-from-docker-hub).
+
 Once it's configured, you can use the `-l` flag to to view all the workflows:
 
 ```sh

--- a/action.yml
+++ b/action.yml
@@ -12,13 +12,21 @@ runs:
   using: composite
   steps:
     # This is so we can guarantee a version of npm that supports lockfile@2
-    - name: setup node
-      uses: actions/setup-node@v3
-      with:
-        node-version: 16
+    # - name: setup node
+    #   uses: actions/setup-node@v3
+    #   with:
+    #     node-version: 16
+    - name: Node version
+      run: node -v
+      shell: bash
+      working-directory: ${{ github.action_path }}
+    - name: npm version
+      run: npm -v
+      shell: bash
+      working-directory: ${{ github.action_path }}
     # When we add debug support, we should make this a conditional step, see RM-3545
     - name: Install rdme deps
-      run: npm install --production --silent
+      run: npm install --production > /dev/null
       shell: bash
       working-directory: ${{ github.action_path }}
     - name: Execute rdme command

--- a/action.yml
+++ b/action.yml
@@ -11,22 +11,9 @@ inputs:
 runs:
   using: composite
   steps:
-    # This is so we can guarantee a version of npm that supports lockfile@2
-    # - name: setup node
-    #   uses: actions/setup-node@v3
-    #   with:
-    #     node-version: 16
-    - name: Node version
-      run: node -v
-      shell: bash
-      working-directory: ${{ github.action_path }}
-    - name: npm version
-      run: npm -v
-      shell: bash
-      working-directory: ${{ github.action_path }}
     # When we add debug support, we should make this a conditional step, see RM-3545
     - name: Install rdme deps
-      run: npm install --production > /dev/null
+      run: npm install --production --silent
       shell: bash
       working-directory: ${{ github.action_path }}
     - name: Execute rdme command


### PR DESCRIPTION
| 🚥 Fix #475 |
| :-- |

## 🧰 Changes

The only reason we have the `setup-node` step in the action is because I was under the impression that `ubuntu-latest` was running Node v14/npm@6 and I didn't want that to mess with our `package-lock.json`, which is `lockfileVersion@2`.

Turns out I was completely wrong and `ubuntu-latest` has been on Node 16 for several months now: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md

I realized this was because my local `act` runner image was out-of-date, so this PR also updates our contributing docs to call that out.

## 🧬 QA & Testing

Do tests pass and do the docs look good?
