### PR TITLE
feat(openapi): specify spec path and type in success response

### DIFF
--- a/__tests__/cmds/__snapshots__/validate.test.js.snap
+++ b/__tests__/cmds/__snapshots__/validate.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rdme validate error handling should throw an error if an in valid Swagger definition is supplied 1`] = `
-[Error: Swagger schema validation failed.
+[SyntaxError: Swagger schema validation failed.
 
 ADDITIONAL PROPERTY must NOT have additional properties
 
@@ -15,7 +15,7 @@ ADDITIONAL PROPERTY must NOT have additional properties
 `;
 
 exports[`rdme validate error handling should throw an error if an invalid OpenAPI 3.1 definition is supplied 1`] = `
-[Error: OpenAPI schema validation failed.
+[SyntaxError: OpenAPI schema validation failed.
 
 REQUIRED must have required property 'name'
 

--- a/__tests__/cmds/openapi.test.js
+++ b/__tests__/cmds/openapi.test.js
@@ -23,15 +23,17 @@ const successfulMessageBase = specPath => [
   '',
   `\t${chalk.green(`rdme openapi ${specPath} --key=${key} --id=1`)}`,
 ];
-const successfulUpload = specPath =>
-  ["You've successfully uploaded a new OpenAPI file to your ReadMe project!", ...successfulMessageBase(specPath)].join(
-    '\n'
-  );
+const successfulUpload = (specPath, specType = 'OpenAPI') =>
+  [
+    `You've successfully uploaded a new ${specType} file to your ReadMe project!`,
+    ...successfulMessageBase(specPath),
+  ].join('\n');
 
-const successfulUpdate = specPath =>
-  ["You've successfully updated an OpenAPI file on your ReadMe project!", ...successfulMessageBase(specPath)].join(
-    '\n'
-  );
+const successfulUpdate = (specPath, specType = 'OpenAPI') =>
+  [
+    `You've successfully updated an existing ${specType} file on your ReadMe project!`,
+    ...successfulMessageBase(specPath),
+  ].join('\n');
 
 const testWorkingDir = process.cwd();
 
@@ -60,13 +62,13 @@ describe('rdme openapi', () => {
 
   describe('upload', () => {
     it.each([
-      ['Swagger 2.0', 'json', '2.0'],
-      ['Swagger 2.0', 'yaml', '2.0'],
-      ['OpenAPI 3.0', 'json', '3.0'],
-      ['OpenAPI 3.0', 'yaml', '3.0'],
-      ['OpenAPI 3.1', 'json', '3.1'],
-      ['OpenAPI 3.1', 'yaml', '3.1'],
-    ])('should support uploading a %s definition (format: %s)', async (_, format, specVersion) => {
+      ['Swagger 2.0', 'json', '2.0', 'Swagger'],
+      ['Swagger 2.0', 'yaml', '2.0', 'Swagger'],
+      ['OpenAPI 3.0', 'json', '3.0', 'OpenAPI'],
+      ['OpenAPI 3.0', 'yaml', '3.0', 'OpenAPI'],
+      ['OpenAPI 3.1', 'json', '3.1', 'OpenAPI'],
+      ['OpenAPI 3.1', 'yaml', '3.1', 'OpenAPI'],
+    ])('should support uploading a %s definition (format: %s)', async (_, format, specVersion, type) => {
       const mock = getApiNock()
         .get('/api/v1/api-specification')
         .basicAuth({ user: key })
@@ -86,7 +88,7 @@ describe('rdme openapi', () => {
           key,
           version,
         })
-      ).resolves.toBe(successfulUpload(spec));
+      ).resolves.toBe(successfulUpload(spec, type));
 
       expect(console.info).toHaveBeenCalledTimes(0);
 
@@ -116,7 +118,7 @@ describe('rdme openapi', () => {
       // to break.
       fs.copyFileSync(require.resolve('@readme/oas-examples/2.0/json/petstore.json'), './swagger.json');
 
-      await expect(openapi.run({ key })).resolves.toBe(successfulUpload('swagger.json'));
+      await expect(openapi.run({ key })).resolves.toBe(successfulUpload('swagger.json', 'Swagger'));
 
       expect(console.info).toHaveBeenCalledTimes(1);
 
@@ -130,13 +132,13 @@ describe('rdme openapi', () => {
 
   describe('updates / resyncs', () => {
     it.each([
-      ['Swagger 2.0', 'json', '2.0'],
-      ['Swagger 2.0', 'yaml', '2.0'],
-      ['OpenAPI 3.0', 'json', '3.0'],
-      ['OpenAPI 3.0', 'yaml', '3.0'],
-      ['OpenAPI 3.1', 'json', '3.1'],
-      ['OpenAPI 3.1', 'yaml', '3.1'],
-    ])('should support updating a %s definition (format: %s)', async (_, format, specVersion) => {
+      ['Swagger 2.0', 'json', '2.0', 'Swagger'],
+      ['Swagger 2.0', 'yaml', '2.0', 'Swagger'],
+      ['OpenAPI 3.0', 'json', '3.0', 'OpenAPI'],
+      ['OpenAPI 3.0', 'yaml', '3.0', 'OpenAPI'],
+      ['OpenAPI 3.1', 'json', '3.1', 'OpenAPI'],
+      ['OpenAPI 3.1', 'yaml', '3.1', 'OpenAPI'],
+    ])('should support updating a %s definition (format: %s)', async (_, format, specVersion, type) => {
       const mock = getApiNock()
         .put(`/api/v1/api-specification/${id}`, body => body.match('form-data; name="spec"'))
         .basicAuth({ user: key })
@@ -151,7 +153,7 @@ describe('rdme openapi', () => {
           id,
           version,
         })
-      ).resolves.toBe(successfulUpdate(spec));
+      ).resolves.toBe(successfulUpdate(spec, type));
 
       return mock.done();
     });
@@ -231,7 +233,7 @@ describe('rdme openapi', () => {
 
       const spec = require.resolve('@readme/oas-examples/2.0/json/petstore.json');
 
-      await expect(openapi.run({ spec, key })).resolves.toBe(successfulUpload(spec));
+      await expect(openapi.run({ spec, key })).resolves.toBe(successfulUpload(spec, 'Swagger'));
 
       return mock.done();
     });

--- a/__tests__/cmds/openapi.test.js
+++ b/__tests__/cmds/openapi.test.js
@@ -15,24 +15,24 @@ const key = 'API_KEY';
 const id = '5aa0409b7cf527a93bfb44df';
 const version = '1.0.0';
 const exampleRefLocation = `${config.get('host')}/project/example-project/1.0.1/refs/ex`;
-const successfulMessageBase = specPath => [
+const successfulMessageBase = (specPath, specType) => [
   '',
   `\t${chalk.green(exampleRefLocation)}`,
   '',
-  'To update your OpenAPI or Swagger definition, run the following:',
+  `To update your ${specType} definition, run the following:`,
   '',
   `\t${chalk.green(`rdme openapi ${specPath} --key=${key} --id=1`)}`,
 ];
 const successfulUpload = (specPath, specType = 'OpenAPI') =>
   [
     `You've successfully uploaded a new ${specType} file to your ReadMe project!`,
-    ...successfulMessageBase(specPath),
+    ...successfulMessageBase(specPath, specType),
   ].join('\n');
 
 const successfulUpdate = (specPath, specType = 'OpenAPI') =>
   [
     `You've successfully updated an existing ${specType} file on your ReadMe project!`,
-    ...successfulMessageBase(specPath),
+    ...successfulMessageBase(specPath, specType),
   ].join('\n');
 
 const testWorkingDir = process.cwd();

--- a/__tests__/cmds/openapi.test.js
+++ b/__tests__/cmds/openapi.test.js
@@ -468,7 +468,7 @@ describe('rdme swagger', () => {
   it('should run `rdme openapi`', () => {
     return expect(swagger.run({ spec: '', key, id, version })).rejects.toThrow(
       "We couldn't find an OpenAPI or Swagger definition.\n\n" +
-        'Run `rdme openapi ./path/to/api/definition` to upload an existing definition or `rdme oas init` to create a fresh one!'
+        'Please specify the path to your definition with `rdme openapi ./path/to/api/definition`.'
     );
   });
 });

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -133,7 +133,7 @@ You've successfully updated an OpenAPI file on your ReadMe project!
 
         http://dash.readme.com/project/{your_project}/v1.0/refs/pet
 
-To update your OpenAPI or Swagger definition, run the following:
+To update your OpenAPI definition, run the following:
 
         rdme openapi [path-to-file.json] --key=<<user>> --id=API_DEFINITION_ID
 ```

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -135,7 +135,7 @@ You've successfully updated an OpenAPI file on your ReadMe project!
 
 To update your OpenAPI or Swagger definition, run the following:
 
-        rdme openapi FILE --key=<<user>> --id=API_DEFINITION_ID
+        rdme openapi [path-to-file.json] --key=<<user>> --id=API_DEFINITION_ID
 ```
 
 </details>

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -98,7 +98,7 @@ module.exports = class OpenAPICommand {
             '',
             `\t${chalk.green(`${data.headers.get('location')}`)}`,
             '',
-            'To update your OpenAPI or Swagger definition, run the following:',
+            `To update your ${specType} definition, run the following:`,
             '',
             // eslint-disable-next-line no-underscore-dangle
             `\t${chalk.green(`rdme openapi ${specPath} --key=${key} --id=${body._id}`)}`,

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -102,7 +102,7 @@ module.exports = class OpenAPICommand {
             'To update your OpenAPI or Swagger definition, run the following:',
             '',
             // eslint-disable-next-line no-underscore-dangle
-            `\t${chalk.green(`rdme openapi FILE --key=${key} --id=${body._id}`)}`,
+            `\t${chalk.green(`rdme openapi ${specPath} --key=${key} --id=${body._id}`)}`,
           ].join('\n')
         );
       }

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -232,7 +232,7 @@ module.exports = class OpenAPICommand {
       reject(
         new Error(
           "We couldn't find an OpenAPI or Swagger definition.\n\n" +
-            'Run `rdme openapi ./path/to/api/definition` to upload an existing definition or `rdme oas init` to create a fresh one!'
+            'Please specify the path to your definition with `rdme openapi ./path/to/api/definition`.'
         )
       );
     });

--- a/src/cmds/validate.js
+++ b/src/cmds/validate.js
@@ -61,7 +61,7 @@ module.exports = class ValidateCommand {
 
       reject(
         new Error(
-          "We couldn't find an OpenAPI or Swagger definition.\n\nIf you need help creating one run `rdme oas init`!"
+          "We couldn't find an OpenAPI or Swagger definition.\n\nPlease specify the path to your definition with `rdme validate ./path/to/api/definition`."
         )
       );
     });

--- a/src/cmds/validate.js
+++ b/src/cmds/validate.js
@@ -1,7 +1,7 @@
 const chalk = require('chalk');
 const fs = require('fs');
-const OASNormalize = require('oas-normalize');
 const { debug } = require('../lib/logger');
+const prepareOas = require('../lib/prepareOas');
 
 module.exports = class ValidateCommand {
   constructor() {
@@ -37,20 +37,8 @@ module.exports = class ValidateCommand {
     debug(`opts: ${JSON.stringify(opts)}`);
 
     async function validateSpec(specPath) {
-      const oas = new OASNormalize(specPath, { colorizeErrors: true, enablePaths: true });
-
-      return oas
-        .validate(false)
-        .then(api => {
-          if (api.swagger) {
-            return Promise.resolve(chalk.green(`${specPath} is a valid Swagger API definition!`));
-          }
-          return Promise.resolve(chalk.green(`${specPath} is a valid OpenAPI API definition!`));
-        })
-        .catch(err => {
-          debug(`raw validation error object: ${JSON.stringify(err)}`);
-          return Promise.reject(new Error(err.message));
-        });
+      const { specType } = await prepareOas(specPath);
+      return Promise.resolve(chalk.green(`${specPath} is a valid ${specType} API definition!`));
     }
 
     if (spec) {

--- a/src/lib/prepareOas.js
+++ b/src/lib/prepareOas.js
@@ -17,7 +17,9 @@ module.exports = async function prepare(path, bundle = false) {
     debug(`raw validation error object: ${JSON.stringify(err)}`);
     throw err;
   });
-  debug('spec validated');
+  debug('👇👇👇👇👇 spec validated! logging spec below 👇👇👇👇👇');
+  debug(api);
+  debug('👆👆👆👆👆 finished logging spec 👆👆👆👆👆');
 
   const specType = api.swagger ? 'Swagger' : 'OpenAPI';
   debug(`spec type: ${specType}`);
@@ -25,9 +27,15 @@ module.exports = async function prepare(path, bundle = false) {
   let bundledSpec = '';
 
   if (bundle) {
-    bundledSpec = await oas.bundle().then(res => {
-      return JSON.stringify(res);
-    });
+    bundledSpec = await oas
+      .bundle()
+      .then(res => {
+        return JSON.stringify(res);
+      })
+      .catch(err => {
+        debug(`raw bundling error object: ${JSON.stringify(err)}`);
+        throw err;
+      });
     debug('spec bundled');
   }
 

--- a/src/lib/prepareOas.js
+++ b/src/lib/prepareOas.js
@@ -1,0 +1,35 @@
+const OASNormalize = require('oas-normalize');
+const { debug } = require('./logger');
+
+/**
+ * Normalizes, validates, and (optionally) bundles an OpenAPI definition.
+ *
+ * @param {String} path path to spec file
+ * @param {Boolean} bundle boolean to indicate whether or not to
+ * return a bundled spec (defaults to false)
+ */
+module.exports = async function prepare(path, bundle = false) {
+  debug(`about to normalize spec located at ${path}`);
+  const oas = new OASNormalize(path, { colorizeErrors: true, enablePaths: true });
+  debug('spec normalized');
+
+  const api = await oas.validate(false).catch(err => {
+    debug(`raw validation error object: ${JSON.stringify(err)}`);
+    throw err;
+  });
+  debug('spec validated');
+
+  const specType = api.swagger ? 'Swagger' : 'OpenAPI';
+  debug(`spec type: ${specType}`);
+
+  let bundledSpec = '';
+
+  if (bundle) {
+    bundledSpec = await oas.bundle().then(res => {
+      return JSON.stringify(res);
+    });
+    debug('spec bundled');
+  }
+
+  return { bundledSpec, specType };
+};


### PR DESCRIPTION
| 🚥 Fix RM-3999 |
| :-- |

## 🧰 Changes

When running the `openapi` command successfully, we now include the path to the OpenAPI definition in the success message, as well more tailored messaging for OpenAPI vs. Swagger definitions.

## 🧬 QA & Testing

Do the refactors look good? And do tests pass?
