### PR TITLE
fix: upgrading oas-normalize to support openapi 3.1 $ref + description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "gray-matter": "^4.0.1",
         "isemail": "^3.1.3",
         "node-fetch": "^2.6.1",
-        "oas-normalize": "^5.1.2",
+        "oas-normalize": "^5.2.0",
         "open": "^8.2.1",
         "parse-link-header": "^2.0.0",
         "read": "^1.0.7",
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz",
-      "integrity": "sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -1167,12 +1167,12 @@
       }
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.4.tgz",
-      "integrity": "sha512-qQQ8A9NB1gyqmmUbizJFBiOolwXd8iv5SV9HoyM0807YNVHKzbQ7snBR0WMSIw9xkJszqOAaFzpXg/P12sMmxA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.5.tgz",
+      "integrity": "sha512-a3YAAP1bEs9yytoqCy9Kj6VuWJ7WocVxedRcxImdkwTP6NBjtbY/IdBwHakll2DZ1yMOZAAozRebD09Xgfqrsg==",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
-        "@babel/runtime": "^7.17.7",
+        "@babel/runtime": "^7.17.8",
         "@humanwhocodes/momoa": "^2.0.3",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
@@ -1224,9 +1224,9 @@
       }
     },
     "node_modules/@readme/json-schema-ref-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
-      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.1.0.tgz",
+      "integrity": "sha512-T0DxTMSEfOQHAlpI68LqYCwSFfP3u0w7E6zXWf16YphmAgWSOhLKuvnMSLXAlh27uxwclRekIvQf8AAUoQSDiw==",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -1257,16 +1257,16 @@
       "dev": true
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.0.4.tgz",
-      "integrity": "sha512-Wf//6/n41UyUVIDE+NwnBsvv2XdzT8McXqj14jWXr1HwHWvHWDTs9uwSwU9nca4IQKclT1fWDo3l3CFw/N8hlg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.1.0.tgz",
+      "integrity": "sha512-93HDSz0bzBWvG1RyWC0gfupTlqWJB+k5OvD05LB+37cGi7VSiSDH4mGPLiLP410+kXQLN3X1FwWVIhnW2f4DhQ==",
       "dependencies": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.4.4",
-        "@readme/json-schema-ref-parser": "^1.0.0",
-        "ajv": "^8.10.0",
+        "@readme/better-ajv-errors": "^1.4.5",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
@@ -1278,9 +1278,9 @@
       }
     },
     "node_modules/@readme/openapi-parser/node_modules/ajv": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
-      "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -8781,11 +8781,11 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.1.2.tgz",
-      "integrity": "sha512-q6rb9WcxtAp6t0WAPnVj711OPZj/CHhaeGpA5GabR7br5RMChFsKZrUl+3RvhGAxgqrR4YyUjYTpif7kKkItNg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.2.0.tgz",
+      "integrity": "sha512-xgbNgaFtsK388B9Wh1yE03TaivPXwSl3oMZBHa1ix8g2ZAal7ogl1mj4hRISPGPUgfDt57IQ9JQwdsGJufYRnw==",
       "dependencies": {
-        "@readme/openapi-parser": "^2.0.4",
+        "@readme/openapi-parser": "^2.1.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -12450,9 +12450,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz",
-      "integrity": "sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -12913,12 +12913,12 @@
       }
     },
     "@readme/better-ajv-errors": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.4.tgz",
-      "integrity": "sha512-qQQ8A9NB1gyqmmUbizJFBiOolwXd8iv5SV9HoyM0807YNVHKzbQ7snBR0WMSIw9xkJszqOAaFzpXg/P12sMmxA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.5.tgz",
+      "integrity": "sha512-a3YAAP1bEs9yytoqCy9Kj6VuWJ7WocVxedRcxImdkwTP6NBjtbY/IdBwHakll2DZ1yMOZAAozRebD09Xgfqrsg==",
       "requires": {
         "@babel/code-frame": "^7.16.0",
-        "@babel/runtime": "^7.17.7",
+        "@babel/runtime": "^7.17.8",
         "@humanwhocodes/momoa": "^2.0.3",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
@@ -12957,9 +12957,9 @@
       }
     },
     "@readme/json-schema-ref-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
-      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.1.0.tgz",
+      "integrity": "sha512-T0DxTMSEfOQHAlpI68LqYCwSFfP3u0w7E6zXWf16YphmAgWSOhLKuvnMSLXAlh27uxwclRekIvQf8AAUoQSDiw==",
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -12989,24 +12989,24 @@
       "dev": true
     },
     "@readme/openapi-parser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.0.4.tgz",
-      "integrity": "sha512-Wf//6/n41UyUVIDE+NwnBsvv2XdzT8McXqj14jWXr1HwHWvHWDTs9uwSwU9nca4IQKclT1fWDo3l3CFw/N8hlg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.1.0.tgz",
+      "integrity": "sha512-93HDSz0bzBWvG1RyWC0gfupTlqWJB+k5OvD05LB+37cGi7VSiSDH4mGPLiLP410+kXQLN3X1FwWVIhnW2f4DhQ==",
       "requires": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.4.4",
-        "@readme/json-schema-ref-parser": "^1.0.0",
-        "ajv": "^8.10.0",
+        "@readme/better-ajv-errors": "^1.4.5",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
-          "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -18472,11 +18472,11 @@
       }
     },
     "oas-normalize": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.1.2.tgz",
-      "integrity": "sha512-q6rb9WcxtAp6t0WAPnVj711OPZj/CHhaeGpA5GabR7br5RMChFsKZrUl+3RvhGAxgqrR4YyUjYTpif7kKkItNg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.2.0.tgz",
+      "integrity": "sha512-xgbNgaFtsK388B9Wh1yE03TaivPXwSl3oMZBHa1ix8g2ZAal7ogl1mj4hRISPGPUgfDt57IQ9JQwdsGJufYRnw==",
       "requires": {
-        "@readme/openapi-parser": "^2.0.4",
+        "@readme/openapi-parser": "^2.1.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gray-matter": "^4.0.1",
     "isemail": "^3.1.3",
     "node-fetch": "^2.6.1",
-    "oas-normalize": "^5.1.2",
+    "oas-normalize": "^5.2.0",
     "open": "^8.2.1",
     "parse-link-header": "^2.0.0",
     "read": "^1.0.7",


### PR DESCRIPTION
| 🚥 Fix RM-3826 |
| :-- |

## 🧰 Changes

This updates `oas-normalize`, and `@readme/openapi-parser` and `@readme/json-schema-ref-parser`, to add support for OpenAPI 3.1 `$ref` pointers being alongside `description` properties. This fix was done by @DanielOaks in https://github.com/readmeio/json-schema-ref-parser/pull/2.

## 🧬 QA & Testing

The update is pretty well tested in `@readme/json-schema-ref-parser`, and the new builds I did of `@readme/openapi-parser` and `oas-normalize` are passing, so if tests here should remain unchanged.