### PR TITLE
fix: our broken set-version-output script

### DIFF
--- a/bin/set-version-output
+++ b/bin/set-version-output
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-const getNodeVersion = require('../src/lib/getNodeVersion');
+const { getNodeVersion } = require('../src/lib/nodeVersionUtils');
 const pkg = require('../package.json');
 
 const name1 = 'RDME_VERSION';

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prettier": "^2.6.1"
   },
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint . bin/rdme bin/set-version-output",
     "lint-docs": "alex .",
     "pretest": "npm run lint && npm run lint-docs",
     "prettier": "prettier --list-different --write \"./**/**.js\"",


### PR DESCRIPTION
## 🧰 Changes

* [x] Updates an outdated import in our `set-version-output` script for our workflow.
* [x] Adds `bin/*` files into ESLint
