### PR TITLE
fix: unsupported version error message having double "v"s

### DIFF
--- a/__tests__/bin.test.js
+++ b/__tests__/bin.test.js
@@ -21,7 +21,7 @@ describe('bin', () => {
       await new Promise(done => {
         exec(`node ${__dirname}/../bin/rdme`, (error, stdout, stderr) => {
           expect(stderr).toContain(
-            `We're sorry, this release of rdme does not support Node.js v${process.version}. We support the following versions: ${pkg.engines.node}`
+            `We're sorry, this release of rdme does not support Node.js ${process.version}. We support the following versions: ${pkg.engines.node}`
           );
           done();
         });

--- a/bin/rdme
+++ b/bin/rdme
@@ -17,7 +17,7 @@ updateNotifier({ pkg }).notify();
  * stop if we're being run with any Node version that we don't explicitly support.
  */
 if (!isSupportedNodeVersion(process.version)) {
-  const message = `We're sorry, this release of rdme does not support Node.js v${process.version}. We support the following versions: ${pkg.engines.node}`;
+  const message = `We're sorry, this release of rdme does not support Node.js ${process.version}. We support the following versions: ${pkg.engines.node}`;
   console.error(chalk.red(`\n${message}\n`));
   process.exit(1);
 }


### PR DESCRIPTION
| 🚥 Fix RM-4182 |
| :-- |

## 🧰 Changes

Our "sorry your Node version is unsupported" error message has two `v`'s in it because `process.version` contains one already.

```
> process.version
'v14.19.1'
```

![c626285d-652c-4f14-a7d0-0283b3c90379](https://user-images.githubusercontent.com/33762/163072405-971df53e-ecc9-4fa7-b689-00e69790d2e7.png)