### PR TITLE
feat: adding support for node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x]
+        node-version:
+          - 14
+          - 16
+          - 18
 
     steps:
       - uses: actions/checkout@v3

--- a/__tests__/lib/isSupportedNodeVersion.test.js
+++ b/__tests__/lib/isSupportedNodeVersion.test.js
@@ -4,11 +4,11 @@ describe('#isSupportedNodeVersion()', () => {
   it('should return true for a supported version of node', () => {
     expect(isSupportedNodeVersion('14.5.1')).toBe(true);
     expect(isSupportedNodeVersion('16.0.0')).toBe(true);
+    expect(isSupportedNodeVersion('18.0.0')).toBe(true);
   });
 
   it('should return false for an unsupported version of node', () => {
     expect(isSupportedNodeVersion('10.0.0')).toBe(false);
     expect(isSupportedNodeVersion('12.0.0')).toBe(false);
-    expect(isSupportedNodeVersion('18.0.0')).toBe(false);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "gray-matter": "^4.0.1",
         "isemail": "^3.1.3",
         "node-fetch": "^2.6.1",
-        "oas-normalize": "^5.2.1",
+        "oas-normalize": "^6.0.0",
         "open": "^8.2.1",
         "parse-link-header": "^2.0.0",
         "read": "^1.0.7",
@@ -35,16 +35,16 @@
         "rdme": "bin/rdme"
       },
       "devDependencies": {
-        "@readme/eslint-config": "^8.6.0",
-        "@readme/oas-examples": "^5.0.0",
+        "@readme/eslint-config": "^8.7.0",
+        "@readme/oas-examples": "^5.1.1",
         "alex": "^10.0.0",
-        "eslint": "^8.12.0",
+        "eslint": "^8.13.0",
         "jest": "^27.5.1",
         "nock": "^13.2.4",
-        "prettier": "^2.6.1"
+        "prettier": "^2.6.2"
       },
       "engines": {
-        "node": "^14 || ^16 || ^17"
+        "node": ">=14"
       }
     },
     "node_modules/@actions/core": {
@@ -673,17 +673,17 @@
       "dev": true
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.22.1.tgz",
-      "integrity": "sha512-/WMkqLYfwCf0waCAMC8Eddt3iAOdghkDF5vmyKEu8pfO66KRFY1L15yks8mfgURiwOAOJpAQ3blvB3Znj6ZwBw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.28.0.tgz",
+      "integrity": "sha512-qXqur4077IrMLZIY0YKpGQvpuSBsiH5dY67HkjINspFgzl/i0rytmSuD8s/hen9+h7Sww3Vg+U01Q/dgxJeFcQ==",
       "dev": true,
       "dependencies": {
         "comment-parser": "1.3.1",
         "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "~2.2.5"
+        "jsdoc-type-pratt-parser": "~3.0.1"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16 || ^17"
+        "node": "^12 || ^14 || ^16 || ^17 || ^18"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -744,9 +744,9 @@
       }
     },
     "node_modules/@humanwhocodes/momoa": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.3.tgz",
-      "integrity": "sha512-SytjS6gJk+LXSWFuEm0V9ASdgxlX/BDq6A+6gfh7TaHM90xppBydjcM3SFaziZP4ikKmhUOhPkDi2KktzElnQQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
+      "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
       "engines": {
         "node": ">=10.10.0"
       }
@@ -1158,9 +1158,9 @@
       }
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.6.tgz",
-      "integrity": "sha512-7JuEYXH+wLERtCdCbkl1NQNC+YjO2YWHD8mPnl6laOuurxvdMA0XzMSZ+OLdXitlyPtHB+Rk6KkMps3AaxXtdg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.5.0.tgz",
+      "integrity": "sha512-dJLAlfN5ahAb6J5t+zCv0YeJsf4mrRHllwBb6pIYZa4yfFKs3lOSAN+i+ChebbpnqCkw7IrwzPz9vzk8p5mCEw==",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
         "@babel/runtime": "^7.17.8",
@@ -1171,43 +1171,43 @@
         "leven": "^3.1.0"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16 || ^17"
+        "node": ">=14"
       },
       "peerDependencies": {
         "ajv": "4.11.8 - 8"
       }
     },
     "node_modules/@readme/eslint-config": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.6.0.tgz",
-      "integrity": "sha512-uFIx5gkuVQ0Y1sgYPrb5l7LKKFg/APCdnm8qYyJk0dI4Wtd5yA3ieElcqfrcrPPPABDz6zrlyyByUTi9gm0ywg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.7.0.tgz",
+      "integrity": "sha512-8mv4PIXMcSs7b/Xo9xSkHLwO1flWSBm9F0iFOfD3ETCEh6aaU3vq+du+8cGw0bR9Mv+8jU7lRxxNYkvuT6VEew==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.18.0",
-        "@typescript-eslint/parser": "^5.18.0",
+        "@typescript-eslint/eslint-plugin": "^5.20.0",
+        "@typescript-eslint/parser": "^5.20.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.1.0",
         "eslint-import-resolver-typescript": "^2.7.1",
         "eslint-plugin-chai-expect": "^3.0.0",
         "eslint-plugin-chai-friendly": "^0.7.2",
         "eslint-plugin-eslint-comments": "^3.1.2",
-        "eslint-plugin-import": "^2.18.2",
-        "eslint-plugin-jest": "^26.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-jest": "^26.1.4",
         "eslint-plugin-jest-dom": "^4.0.0",
         "eslint-plugin-jest-formatting": "^3.0.0",
-        "eslint-plugin-jsdoc": "^39.1.0",
+        "eslint-plugin-jsdoc": "^39.2.5",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-mocha": "^10.0.3",
+        "eslint-plugin-mocha": "^10.0.4",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-react-hooks": "^4.2.0",
-        "eslint-plugin-testing-library": "^5.2.1",
+        "eslint-plugin-testing-library": "^5.3.1",
         "eslint-plugin-unicorn": "^42.0.0",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16 || ^17"
+        "node": ">=14"
       },
       "peerDependencies": {
         "eslint": "^8.0.0",
@@ -1242,27 +1242,27 @@
       }
     },
     "node_modules/@readme/oas-examples": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.0.0.tgz",
-      "integrity": "sha512-fGaQXRLqRIaOILefLECyPD5zgnRBL9TnE0W41X4AM9GA61rZHgS2e7zOyIw3Sj3Dvl8MgiyyMI0zfhseje2cGg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.1.1.tgz",
+      "integrity": "sha512-S+VQ7ZTdSl8UyPrKR4ht+yAvZloT+2wN5T8gaPfcDPQKEe0iaGBk4C64oi2L6UVdBFtHpyobeMCmohBGMu4nsA==",
       "dev": true
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.1.1.tgz",
-      "integrity": "sha512-BnDajIQrw9FdtQhsa05Wyui/qdlU/ou9urWGjmXZLUNcFV5/nSJQUkg4L3eziPZOvLYgKHvyze79OgY5ZEOc0Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.2.0.tgz",
+      "integrity": "sha512-t5E+cCln50GSsOx0GuT+GLnkG6Ux7I6V1vWJ48jvW7Rxs6jMkJrVYMu5MIhJ3ihylrFspxJ6aSACzj7yVr6Dow==",
       "dependencies": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.4.6",
+        "@readme/better-ajv-errors": "^1.5.0",
         "@readme/json-schema-ref-parser": "^1.1.0",
         "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16 || ^17"
+        "node": ">=14"
       },
       "peerDependencies": {
         "openapi-types": ">=7"
@@ -1617,14 +1617,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.19.0.tgz",
-      "integrity": "sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz",
+      "integrity": "sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/type-utils": "5.19.0",
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/type-utils": "5.20.0",
+        "@typescript-eslint/utils": "5.20.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -1650,14 +1650,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.19.0.tgz",
-      "integrity": "sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.20.0.tgz",
+      "integrity": "sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -1677,13 +1677,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.19.0.tgz",
-      "integrity": "sha512-Fz+VrjLmwq5fbQn5W7cIJZ066HxLMKvDEmf4eu1tZ8O956aoX45jAuBB76miAECMTODyUxH61AQM7q4/GOMQ5g==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz",
+      "integrity": "sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0"
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1694,12 +1694,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.19.0.tgz",
-      "integrity": "sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz",
+      "integrity": "sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/utils": "5.20.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -1720,9 +1720,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.19.0.tgz",
-      "integrity": "sha512-zR1ithF4Iyq1wLwkDcT+qFnhs8L5VUtjgac212ftiOP/ZZUOCuuF2DeGiZZGQXGoHA50OreZqLH5NjDcDqn34w==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.20.0.tgz",
+      "integrity": "sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1733,13 +1733,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.19.0.tgz",
-      "integrity": "sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz",
+      "integrity": "sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -1760,15 +1760,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.19.0.tgz",
-      "integrity": "sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.20.0.tgz",
+      "integrity": "sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -1784,12 +1784,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.19.0.tgz",
-      "integrity": "sha512-Ym7zZoMDZcAKWsULi2s7UMLREdVQdScPQ/fKWMYefarCztWlHPFVJo8racf8R0Gc8FAEJ2eD4of8As1oFtnQlQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz",
+      "integrity": "sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.19.0",
+        "@typescript-eslint/types": "5.20.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -3438,9 +3438,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
-      "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
+      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.2.1",
@@ -3569,14 +3569,13 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz",
-      "integrity": "sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
+      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
       "dev": true,
       "dependencies": {
         "debug": "^3.2.7",
-        "find-up": "^2.1.0",
-        "pkg-dir": "^2.0.0"
+        "find-up": "^2.1.0"
       },
       "engines": {
         "node": ">=4"
@@ -3678,9 +3677,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.3.tgz",
-      "integrity": "sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.4",
@@ -3688,14 +3687,14 @@
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.1",
+        "eslint-module-utils": "^2.7.3",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.0",
+        "is-core-module": "^2.8.1",
         "is-glob": "^4.0.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "object.values": "^1.1.5",
-        "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.11.0"
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
       },
       "engines": {
         "node": ">=4"
@@ -3732,15 +3731,15 @@
       "dev": true
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.0.0.tgz",
-      "integrity": "sha512-Fvs0YgJ/nw9FTrnqTuMGVrkozkd07jkQzWm0ajqyHlfcsdkxGfAuv30fgfWHOnHiCr9+1YQ365CcDX7vrNhqQg==",
+      "version": "26.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.4.tgz",
+      "integrity": "sha512-wgqxujmqc2qpvZqMFWCh6Cniqc8lWpapvXt9j/19DmBDqeDaYhJrSRezYR1SKyemvjx+9e9kny/dgRahraHImA==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.0.0",
@@ -3787,21 +3786,21 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "39.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.0.tgz",
-      "integrity": "sha512-K3db93cbgx27ISjktNwFDkuLx7CYAGdhnBRmttTSUCEKhtmxCTjvxuiidxHh4FCfZaFCKqTSH2PiJ8Lsq9xUPA==",
+      "version": "39.2.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.5.tgz",
+      "integrity": "sha512-SdSgpiLx90PaFTKljH/KDuz+NU80m4s8SFwzcHuOGuZNZ1MSMSSufMUJMqH538hTvTjWeix5SYYx9PO+qx6lHg==",
       "dev": true,
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.22.1",
+        "@es-joy/jsdoccomment": "~0.28.0",
         "comment-parser": "1.3.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
         "esquery": "^1.4.0",
-        "semver": "^7.3.6",
+        "semver": "^7.3.7",
         "spdx-expression-parse": "^3.0.1"
       },
       "engines": {
-        "node": "^14 || ^16 || ^17"
+        "node": "^14 || ^16 || ^17 || ^18"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
@@ -3852,13 +3851,13 @@
       "dev": true
     },
     "node_modules/eslint-plugin-mocha": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.3.tgz",
-      "integrity": "sha512-9mM7PZGxfejpjey+MrG0Cu3Lc8MyA5E2s7eUCdHXgS4SY/H9zLuwa7wVAjnEaoDjbBilA+0bPEB+iMO7lBUPcg==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz",
+      "integrity": "sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^3.0.0",
-        "ramda": "^0.27.1"
+        "ramda": "^0.28.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -6514,9 +6513,9 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
-      "integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.0.1.tgz",
+      "integrity": "sha512-vqMCdAFVIiFhVgBYE/X8naf3L/7qiJsaYWTfUJZZZ124dR3OUz9HrmaMUGpYIYAN4VSuodf6gIZY0e8ktPw9cg==",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
@@ -6942,7 +6941,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -8268,9 +8266,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -8543,17 +8541,17 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.2.1.tgz",
-      "integrity": "sha512-/bAW97kGr+f7jq7xumaBZA6Tvrx41SOGuE98QQ1B9tTroibizs+qb6hhINvb5yh751b9QR+ZLy0HzOu2VV4gbQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-6.0.0.tgz",
+      "integrity": "sha512-BYVM3tpl4J5uVAN0EXeFaBKfwMufpCziIfEkU8tfer579p+RKj3qlXaF+rblvTZh4vEmnjNLR4ULmciHfDPF8w==",
       "dependencies": {
-        "@readme/openapi-parser": "^2.1.1",
+        "@readme/openapi-parser": "^2.2.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16 || ^17"
+        "node": ">=14"
       }
     },
     "node_modules/oas-normalize/node_modules/argparse": {
@@ -8787,9 +8785,9 @@
       }
     },
     "node_modules/openapi-types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-10.0.0.tgz",
-      "integrity": "sha512-Y8xOCT2eiKGYDzMW9R4x5cmfc3vGaaI4EL2pwhDmodWw1HlK18YcZ4uJxc7Rdp7/gGzAygzH9SXr6GKYIXbRcQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.0.tgz",
+      "integrity": "sha512-GB+QO6o1hAtKsb8tP3/FTD5jpkdKrf42L4Gel9UySngMurzr+Q9pO+dtnmySQCzoCEfJr39IH6bveEn71xNcVg==",
       "peer": true
     },
     "node_modules/optionator": {
@@ -9064,18 +9062,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -9103,9 +9089,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
-      "integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -9308,10 +9294,14 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
-      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
-      "dev": true
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -9994,17 +9984,17 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-      "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dependencies": {
-        "lru-cache": "^7.4.0"
+        "lru-cache": "^6.0.0"
       },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
-        "node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+        "node": ">=10"
       }
     },
     "node_modules/semver-diff": {
@@ -10024,14 +10014,6 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
-      "integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/shebang-command": {
@@ -11807,8 +11789,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -12348,14 +12329,14 @@
       "dev": true
     },
     "@es-joy/jsdoccomment": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.22.1.tgz",
-      "integrity": "sha512-/WMkqLYfwCf0waCAMC8Eddt3iAOdghkDF5vmyKEu8pfO66KRFY1L15yks8mfgURiwOAOJpAQ3blvB3Znj6ZwBw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.28.0.tgz",
+      "integrity": "sha512-qXqur4077IrMLZIY0YKpGQvpuSBsiH5dY67HkjINspFgzl/i0rytmSuD8s/hen9+h7Sww3Vg+U01Q/dgxJeFcQ==",
       "dev": true,
       "requires": {
         "comment-parser": "1.3.1",
         "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "~2.2.5"
+        "jsdoc-type-pratt-parser": "~3.0.1"
       }
     },
     "@eslint/eslintrc": {
@@ -12409,9 +12390,9 @@
       }
     },
     "@humanwhocodes/momoa": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.3.tgz",
-      "integrity": "sha512-SytjS6gJk+LXSWFuEm0V9ASdgxlX/BDq6A+6gfh7TaHM90xppBydjcM3SFaziZP4ikKmhUOhPkDi2KktzElnQQ=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
+      "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA=="
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
@@ -12734,9 +12715,9 @@
       }
     },
     "@readme/better-ajv-errors": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.6.tgz",
-      "integrity": "sha512-7JuEYXH+wLERtCdCbkl1NQNC+YjO2YWHD8mPnl6laOuurxvdMA0XzMSZ+OLdXitlyPtHB+Rk6KkMps3AaxXtdg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.5.0.tgz",
+      "integrity": "sha512-dJLAlfN5ahAb6J5t+zCv0YeJsf4mrRHllwBb6pIYZa4yfFKs3lOSAN+i+ChebbpnqCkw7IrwzPz9vzk8p5mCEw==",
       "requires": {
         "@babel/code-frame": "^7.16.0",
         "@babel/runtime": "^7.17.8",
@@ -12748,31 +12729,31 @@
       }
     },
     "@readme/eslint-config": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.6.0.tgz",
-      "integrity": "sha512-uFIx5gkuVQ0Y1sgYPrb5l7LKKFg/APCdnm8qYyJk0dI4Wtd5yA3ieElcqfrcrPPPABDz6zrlyyByUTi9gm0ywg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.7.0.tgz",
+      "integrity": "sha512-8mv4PIXMcSs7b/Xo9xSkHLwO1flWSBm9F0iFOfD3ETCEh6aaU3vq+du+8cGw0bR9Mv+8jU7lRxxNYkvuT6VEew==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/eslint-plugin": "^5.18.0",
-        "@typescript-eslint/parser": "^5.18.0",
+        "@typescript-eslint/eslint-plugin": "^5.20.0",
+        "@typescript-eslint/parser": "^5.20.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.1.0",
         "eslint-import-resolver-typescript": "^2.7.1",
         "eslint-plugin-chai-expect": "^3.0.0",
         "eslint-plugin-chai-friendly": "^0.7.2",
         "eslint-plugin-eslint-comments": "^3.1.2",
-        "eslint-plugin-import": "^2.18.2",
-        "eslint-plugin-jest": "^26.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-jest": "^26.1.4",
         "eslint-plugin-jest-dom": "^4.0.0",
         "eslint-plugin-jest-formatting": "^3.0.0",
-        "eslint-plugin-jsdoc": "^39.1.0",
+        "eslint-plugin-jsdoc": "^39.2.5",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-mocha": "^10.0.3",
+        "eslint-plugin-mocha": "^10.0.4",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-react-hooks": "^4.2.0",
-        "eslint-plugin-testing-library": "^5.2.1",
+        "eslint-plugin-testing-library": "^5.3.1",
         "eslint-plugin-unicorn": "^42.0.0",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
       }
@@ -12804,20 +12785,20 @@
       }
     },
     "@readme/oas-examples": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.0.0.tgz",
-      "integrity": "sha512-fGaQXRLqRIaOILefLECyPD5zgnRBL9TnE0W41X4AM9GA61rZHgS2e7zOyIw3Sj3Dvl8MgiyyMI0zfhseje2cGg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.1.1.tgz",
+      "integrity": "sha512-S+VQ7ZTdSl8UyPrKR4ht+yAvZloT+2wN5T8gaPfcDPQKEe0iaGBk4C64oi2L6UVdBFtHpyobeMCmohBGMu4nsA==",
       "dev": true
     },
     "@readme/openapi-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.1.1.tgz",
-      "integrity": "sha512-BnDajIQrw9FdtQhsa05Wyui/qdlU/ou9urWGjmXZLUNcFV5/nSJQUkg4L3eziPZOvLYgKHvyze79OgY5ZEOc0Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.2.0.tgz",
+      "integrity": "sha512-t5E+cCln50GSsOx0GuT+GLnkG6Ux7I6V1vWJ48jvW7Rxs6jMkJrVYMu5MIhJ3ihylrFspxJ6aSACzj7yVr6Dow==",
       "requires": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.4.6",
+        "@readme/better-ajv-errors": "^1.5.0",
         "@readme/json-schema-ref-parser": "^1.1.0",
         "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
@@ -13151,14 +13132,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.19.0.tgz",
-      "integrity": "sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.20.0.tgz",
+      "integrity": "sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/type-utils": "5.19.0",
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/type-utils": "5.20.0",
+        "@typescript-eslint/utils": "5.20.0",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -13168,52 +13149,52 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.19.0.tgz",
-      "integrity": "sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.20.0.tgz",
+      "integrity": "sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.19.0.tgz",
-      "integrity": "sha512-Fz+VrjLmwq5fbQn5W7cIJZ066HxLMKvDEmf4eu1tZ8O956aoX45jAuBB76miAECMTODyUxH61AQM7q4/GOMQ5g==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.20.0.tgz",
+      "integrity": "sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0"
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.19.0.tgz",
-      "integrity": "sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.20.0.tgz",
+      "integrity": "sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.19.0",
+        "@typescript-eslint/utils": "5.20.0",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.19.0.tgz",
-      "integrity": "sha512-zR1ithF4Iyq1wLwkDcT+qFnhs8L5VUtjgac212ftiOP/ZZUOCuuF2DeGiZZGQXGoHA50OreZqLH5NjDcDqn34w==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.20.0.tgz",
+      "integrity": "sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.19.0.tgz",
-      "integrity": "sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.20.0.tgz",
+      "integrity": "sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/visitor-keys": "5.19.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/visitor-keys": "5.20.0",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -13222,26 +13203,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.19.0.tgz",
-      "integrity": "sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.20.0.tgz",
+      "integrity": "sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.19.0",
-        "@typescript-eslint/types": "5.19.0",
-        "@typescript-eslint/typescript-estree": "5.19.0",
+        "@typescript-eslint/scope-manager": "5.20.0",
+        "@typescript-eslint/types": "5.20.0",
+        "@typescript-eslint/typescript-estree": "5.20.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.19.0.tgz",
-      "integrity": "sha512-Ym7zZoMDZcAKWsULi2s7UMLREdVQdScPQ/fKWMYefarCztWlHPFVJo8racf8R0Gc8FAEJ2eD4of8As1oFtnQlQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.20.0.tgz",
+      "integrity": "sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.19.0",
+        "@typescript-eslint/types": "5.20.0",
         "eslint-visitor-keys": "^3.0.0"
       }
     },
@@ -14465,9 +14446,9 @@
       }
     },
     "eslint": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
-      "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
+      "integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.2.1",
@@ -14650,14 +14631,13 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz",
-      "integrity": "sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
+      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
       "dev": true,
       "requires": {
         "debug": "^3.2.7",
-        "find-up": "^2.1.0",
-        "pkg-dir": "^2.0.0"
+        "find-up": "^2.1.0"
       },
       "dependencies": {
         "debug": {
@@ -14723,9 +14703,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.3.tgz",
-      "integrity": "sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.4",
@@ -14733,14 +14713,14 @@
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.1",
+        "eslint-module-utils": "^2.7.3",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.0",
+        "is-core-module": "^2.8.1",
         "is-glob": "^4.0.3",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "object.values": "^1.1.5",
-        "resolve": "^1.20.0",
-        "tsconfig-paths": "^3.11.0"
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
       },
       "dependencies": {
         "debug": {
@@ -14770,9 +14750,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.0.0.tgz",
-      "integrity": "sha512-Fvs0YgJ/nw9FTrnqTuMGVrkozkd07jkQzWm0ajqyHlfcsdkxGfAuv30fgfWHOnHiCr9+1YQ365CcDX7vrNhqQg==",
+      "version": "26.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.4.tgz",
+      "integrity": "sha512-wgqxujmqc2qpvZqMFWCh6Cniqc8lWpapvXt9j/19DmBDqeDaYhJrSRezYR1SKyemvjx+9e9kny/dgRahraHImA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
@@ -14797,17 +14777,17 @@
       "requires": {}
     },
     "eslint-plugin-jsdoc": {
-      "version": "39.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.0.tgz",
-      "integrity": "sha512-K3db93cbgx27ISjktNwFDkuLx7CYAGdhnBRmttTSUCEKhtmxCTjvxuiidxHh4FCfZaFCKqTSH2PiJ8Lsq9xUPA==",
+      "version": "39.2.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.5.tgz",
+      "integrity": "sha512-SdSgpiLx90PaFTKljH/KDuz+NU80m4s8SFwzcHuOGuZNZ1MSMSSufMUJMqH538hTvTjWeix5SYYx9PO+qx6lHg==",
       "dev": true,
       "requires": {
-        "@es-joy/jsdoccomment": "~0.22.1",
+        "@es-joy/jsdoccomment": "~0.28.0",
         "comment-parser": "1.3.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
         "esquery": "^1.4.0",
-        "semver": "^7.3.6",
+        "semver": "^7.3.7",
         "spdx-expression-parse": "^3.0.1"
       },
       "dependencies": {
@@ -14848,13 +14828,13 @@
       }
     },
     "eslint-plugin-mocha": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.3.tgz",
-      "integrity": "sha512-9mM7PZGxfejpjey+MrG0Cu3Lc8MyA5E2s7eUCdHXgS4SY/H9zLuwa7wVAjnEaoDjbBilA+0bPEB+iMO7lBUPcg==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz",
+      "integrity": "sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",
-        "ramda": "^0.27.1"
+        "ramda": "^0.28.0"
       }
     },
     "eslint-plugin-node": {
@@ -16722,9 +16702,9 @@
       }
     },
     "jsdoc-type-pratt-parser": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
-      "integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.0.1.tgz",
+      "integrity": "sha512-vqMCdAFVIiFhVgBYE/X8naf3L/7qiJsaYWTfUJZZZ124dR3OUz9HrmaMUGpYIYAN4VSuodf6gIZY0e8ktPw9cg==",
       "dev": true
     },
     "jsdom": {
@@ -17059,7 +17039,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -17934,9 +17913,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -18156,11 +18135,11 @@
       }
     },
     "oas-normalize": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.2.1.tgz",
-      "integrity": "sha512-/bAW97kGr+f7jq7xumaBZA6Tvrx41SOGuE98QQ1B9tTroibizs+qb6hhINvb5yh751b9QR+ZLy0HzOu2VV4gbQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-6.0.0.tgz",
+      "integrity": "sha512-BYVM3tpl4J5uVAN0EXeFaBKfwMufpCziIfEkU8tfer579p+RKj3qlXaF+rblvTZh4vEmnjNLR4ULmciHfDPF8w==",
       "requires": {
-        "@readme/openapi-parser": "^2.1.1",
+        "@readme/openapi-parser": "^2.2.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -18335,9 +18314,9 @@
       }
     },
     "openapi-types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-10.0.0.tgz",
-      "integrity": "sha512-Y8xOCT2eiKGYDzMW9R4x5cmfc3vGaaI4EL2pwhDmodWw1HlK18YcZ4uJxc7Rdp7/gGzAygzH9SXr6GKYIXbRcQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.0.tgz",
+      "integrity": "sha512-GB+QO6o1hAtKsb8tP3/FTD5jpkdKrf42L4Gel9UySngMurzr+Q9pO+dtnmySQCzoCEfJr39IH6bveEn71xNcVg==",
       "peer": true
     },
     "optionator": {
@@ -18547,15 +18526,6 @@
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
       "dev": true
     },
-    "pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "dev": true,
-      "requires": {
-        "find-up": "^2.1.0"
-      }
-    },
     "pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -18574,9 +18544,9 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prettier": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
-      "integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -18724,9 +18694,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
-      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
       "dev": true
     },
     "rc": {
@@ -19228,18 +19198,11 @@
       }
     },
     "semver": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-      "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "requires": {
-        "lru-cache": "^7.4.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "7.8.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
-          "integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg=="
-        }
+        "lru-cache": "^6.0.0"
       }
     },
     "semver-diff": {
@@ -20634,8 +20597,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "author": "ReadMe <support@readme.io> (https://readme.com)",
   "engines": {
-    "node": "^14 || ^16 || ^17"
+    "node": ">=14"
   },
   "bin": {
     "rdme": "bin/rdme"
@@ -48,7 +48,7 @@
     "gray-matter": "^4.0.1",
     "isemail": "^3.1.3",
     "node-fetch": "^2.6.1",
-    "oas-normalize": "^5.2.1",
+    "oas-normalize": "^6.0.0",
     "open": "^8.2.1",
     "parse-link-header": "^2.0.0",
     "read": "^1.0.7",
@@ -57,13 +57,13 @@
     "update-notifier": "^5.1.0"
   },
   "devDependencies": {
-    "@readme/eslint-config": "^8.6.0",
-    "@readme/oas-examples": "^5.0.0",
+    "@readme/eslint-config": "^8.7.0",
+    "@readme/oas-examples": "^5.1.1",
     "alex": "^10.0.0",
-    "eslint": "^8.12.0",
+    "eslint": "^8.13.0",
     "jest": "^27.5.1",
     "nock": "^13.2.4",
-    "prettier": "^2.6.1"
+    "prettier": "^2.6.2"
   },
   "scripts": {
     "lint": "eslint . bin/rdme bin/set-version-output",

--- a/src/lib/getNodeVersion.js
+++ b/src/lib/getNodeVersion.js
@@ -2,7 +2,7 @@ const pkg = require('../../package.json');
 
 /**
  * @example 14
- * @returns {String} The maximum major Node.js version specified in the package.json
+ * @returns {String} The major Node.js version specified in the package.json
  */
 module.exports = function getNodeVersion() {
   const { node } = pkg.engines;


### PR DESCRIPTION
## 🧰 Changes

Node 18 hit GM yesterday so we need to support it.

Instead of changing our `engines` requirements to be inclusive we're now going to allow Node 14+, and going forward will revise this when LTS releases get EOL'd.

## 🧬 QA & Testing

Tests on Node 18 should be passing.