### PR TITLE
feat: support `.yml` when auto-detecting OAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,14 @@ rdme openapi [path-to-file.json] --version={project-version}
 
 #### Omitting the File Path
 
-If you run `rdme` within a directory that contains your OpenAPI or Swagger definition, you can omit the file path. We will then look for a file with the following names, and upload that: `openapi.json`, `openapi.yaml`, `swagger.json`, and `swagger.yaml`.
+If you run `rdme` within a directory that contains your OpenAPI or Swagger definition, you can omit the file path. We will then look for a file with the following names, and upload that:
+
+- `openapi.json`
+- `openapi.yaml`
+- `openapi.yml`
+- `swagger.json`
+- `swagger.yaml`
+- `swagger.yml`
 
 ```sh
 rdme openapi

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -218,7 +218,7 @@ module.exports = class OpenAPICommand {
     // If the user didn't supply an API specification, let's try to locate what they've got, and upload
     // that. If they don't have any, let's let the user know how they can get one going.
     return new Promise((resolve, reject) => {
-      ['swagger.json', 'swagger.yaml', 'openapi.json', 'openapi.yaml'].forEach(file => {
+      ['swagger.json', 'swagger.yaml', 'swagger.yml', 'openapi.json', 'openapi.yaml', 'openapi.yml'].forEach(file => {
         debug(`looking for definition with filename: ${file}`);
         if (!fs.existsSync(file)) {
           debug(`${file} not found`);

--- a/src/cmds/validate.js
+++ b/src/cmds/validate.js
@@ -48,7 +48,7 @@ module.exports = class ValidateCommand {
     // If the user didn't supply an API specification, let's try to locate what they've got, and validate that. If they
     // don't have any, let's let the user know how they can get one going.
     return new Promise((resolve, reject) => {
-      ['swagger.json', 'swagger.yaml', 'openapi.json', 'openapi.yaml'].forEach(file => {
+      ['swagger.json', 'swagger.yaml', 'swagger.yml', 'openapi.json', 'openapi.yaml', 'openapi.yml'].forEach(file => {
         debug(`looking for definition with filename: ${file}`);
         if (!fs.existsSync(file)) {
           debug(`${file} not found`);


### PR DESCRIPTION
## 🧰 Changes

Super small change to support `openapi.yml` and `swagger.yml` in our OAS auto-detection for the `openapi` and `validate` commands. We previously only supported `.json` and `.yaml` file extensions.

## 🧬 QA & Testing

Do the docs and the tiny code changes look good?
