### PR TITLE
perf(openapi): upload improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: '/'
     schedule:
       interval: monthly
     reviewers:
@@ -13,7 +13,7 @@ updates:
       prefix-development: chore(deps-dev)
 
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
       interval: monthly
     open-pull-requests-limit: 10
@@ -28,11 +28,13 @@ updates:
       # All of these packages are now ESM-only and can't be used here without a rewrite.
       - dependency-name: chalk
         versions:
-          - ">= 5"
+          - '>= 5'
       - dependency-name: configstore
         versions:
-          - ">= 6"
+          - '>= 6'
       - dependency-name: node-fetch
         versions:
-          - ">= 3"
-
+          - '>= 3'
+      - dependency-name: ora
+        versions:
+          - '>= 6'

--- a/__tests__/cmds/openapi.test.js
+++ b/__tests__/cmds/openapi.test.js
@@ -43,6 +43,8 @@ const getCommandOutput = () => {
   return [console.warn.mock.calls.join('\n\n'), console.info.mock.calls.join('\n\n')].filter(Boolean).join('\n\n');
 };
 
+const getRandomRegistryId = () => Math.random().toString(36).substring(2);
+
 describe('rdme openapi', () => {
   beforeAll(() => nock.disableNetConnect());
 
@@ -69,14 +71,18 @@ describe('rdme openapi', () => {
       ['OpenAPI 3.1', 'json', '3.1', 'OpenAPI'],
       ['OpenAPI 3.1', 'yaml', '3.1', 'OpenAPI'],
     ])('should support uploading a %s definition (format: %s)', async (_, format, specVersion, type) => {
+      const registryUUID = getRandomRegistryId();
+
       const mock = getApiNock()
+        .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
+        .reply(201, { registryUUID, spec: { openapi: specVersion } })
         .get('/api/v1/api-specification')
         .basicAuth({ user: key })
         .reply(200, [])
         .get(`/api/v1/version/${version}`)
         .basicAuth({ user: key })
         .reply(200, { version: '1.0.0' })
-        .post('/api/v1/api-specification', body => body.match('form-data; name="spec"'))
+        .post('/api/v1/api-specification', { registryUUID })
         .basicAuth({ user: key })
         .reply(201, { _id: 1 }, { location: exampleRefLocation });
 
@@ -98,17 +104,21 @@ describe('rdme openapi', () => {
     it('should discover and upload an API definition if none is provided', async () => {
       promptHandler.createOasPrompt.mockResolvedValue({ option: 'create' });
 
+      const registryUUID = getRandomRegistryId();
+
       const mock = getApiNock()
         .get('/api/v1/version')
         .basicAuth({ user: key })
         .reply(200, [{ version }])
+        .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
+        .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
         .post('/api/v1/version')
         .basicAuth({ user: key })
         .reply(200, { from: '1.0.1', version: '1.0.1' })
         .get('/api/v1/api-specification')
         .basicAuth({ user: key })
         .reply(200, [])
-        .post('/api/v1/api-specification', body => body.match('form-data; name="spec"'))
+        .post('/api/v1/api-specification', { registryUUID })
         .delayConnection(1000)
         .basicAuth({ user: key })
         .reply(201, { _id: 1 }, { location: exampleRefLocation });
@@ -139,8 +149,12 @@ describe('rdme openapi', () => {
       ['OpenAPI 3.1', 'json', '3.1', 'OpenAPI'],
       ['OpenAPI 3.1', 'yaml', '3.1', 'OpenAPI'],
     ])('should support updating a %s definition (format: %s)', async (_, format, specVersion, type) => {
+      const registryUUID = getRandomRegistryId();
+
       const mock = getApiNock()
-        .put(`/api/v1/api-specification/${id}`, body => body.match('form-data; name="spec"'))
+        .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
+        .reply(201, { registryUUID, spec: { openapi: specVersion } })
+        .put(`/api/v1/api-specification/${id}`, { registryUUID })
         .basicAuth({ user: key })
         .reply(201, { _id: 1 }, { location: exampleRefLocation });
 
@@ -159,8 +173,12 @@ describe('rdme openapi', () => {
     });
 
     it('should return warning if providing `id` and `version`', async () => {
+      const registryUUID = getRandomRegistryId();
+
       const mock = getApiNock()
-        .put(`/api/v1/api-specification/${id}`, body => body.match('form-data; name="spec"'))
+        .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
+        .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
+        .put(`/api/v1/api-specification/${id}`, { registryUUID })
         .basicAuth({ user: key })
         .reply(201, { _id: 1 }, { location: exampleRefLocation });
 
@@ -217,6 +235,8 @@ describe('rdme openapi', () => {
         newVersion: '1.0.1',
       });
 
+      const registryUUID = getRandomRegistryId();
+
       const mock = getApiNock()
         .get('/api/v1/version')
         .basicAuth({ user: key })
@@ -224,10 +244,12 @@ describe('rdme openapi', () => {
         .post('/api/v1/version')
         .basicAuth({ user: key })
         .reply(200, { from: '1.0.0', version: '1.0.1' })
+        .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
+        .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
         .get('/api/v1/api-specification')
         .basicAuth({ user: key })
         .reply(200, [])
-        .post('/api/v1/api-specification', body => body.match('form-data; name="spec"'))
+        .post('/api/v1/api-specification', { registryUUID })
         .basicAuth({ user: key })
         .reply(201, { _id: 1 }, { location: exampleRefLocation });
 
@@ -241,19 +263,22 @@ describe('rdme openapi', () => {
 
   it('should bundle and upload the expected content', async () => {
     let requestBody = null;
+    const registryUUID = getRandomRegistryId();
     const mock = getApiNock()
-      .get('/api/v1/api-specification')
-      .basicAuth({ user: key })
-      .reply(200, [])
       .get(`/api/v1/version/${version}`)
       .basicAuth({ user: key })
       .reply(200, { version: '1.0.0' })
-      .post('/api/v1/api-specification', body => {
+      .post('/api/v1/api-registry', body => {
         requestBody = body.substring(body.indexOf('{'), body.lastIndexOf('}') + 1);
         requestBody = JSON.parse(requestBody);
 
         return body.match('form-data; name="spec"');
       })
+      .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
+      .get('/api/v1/api-specification')
+      .basicAuth({ user: key })
+      .reply(200, [])
+      .post('/api/v1/api-specification', { registryUUID })
       .basicAuth({ user: key })
       .reply(201, { _id: 1 }, { location: exampleRefLocation });
 
@@ -270,19 +295,22 @@ describe('rdme openapi', () => {
 
   it('should use specified working directory and upload the expected content', async () => {
     let requestBody = null;
+    const registryUUID = getRandomRegistryId();
     const mock = getApiNock()
-      .get('/api/v1/api-specification')
-      .basicAuth({ user: key })
-      .reply(200, [])
       .get(`/api/v1/version/${version}`)
       .basicAuth({ user: key })
       .reply(200, { version: '1.0.0' })
-      .post('/api/v1/api-specification', body => {
+      .post('/api/v1/api-registry', body => {
         requestBody = body.substring(body.indexOf('{'), body.lastIndexOf('}') + 1);
         requestBody = JSON.parse(requestBody);
 
         return body.match('form-data; name="spec"');
       })
+      .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
+      .get('/api/v1/api-specification')
+      .basicAuth({ user: key })
+      .reply(200, [])
+      .post('/api/v1/api-specification', { registryUUID })
       .basicAuth({ user: key })
       .reply(201, { _id: 1 }, { location: exampleRefLocation });
 
@@ -367,14 +395,18 @@ describe('rdme openapi', () => {
         help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
       };
 
+      const registryUUID = getRandomRegistryId();
+
       const mock = getApiNock()
         .get(`/api/v1/version/${version}`)
         .basicAuth({ user: key })
         .reply(200, { version: '1.0.0' })
+        .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
+        .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
         .get('/api/v1/api-specification')
         .basicAuth({ user: key })
         .reply(200, [])
-        .post('/api/v1/api-specification', body => body.match('form-data; name="spec"'))
+        .post('/api/v1/api-specification', { registryUUID })
         .delayConnection(1000)
         .basicAuth({ user: key })
         .reply(500, errorObject);
@@ -399,14 +431,18 @@ describe('rdme openapi', () => {
         help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
       };
 
+      const registryUUID = getRandomRegistryId();
+
       const mock = getApiNock()
         .get(`/api/v1/version/${version}`)
         .basicAuth({ user: key })
         .reply(200, { version: '1.0.0' })
+        .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
+        .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
         .get('/api/v1/api-specification')
         .basicAuth({ user: key })
         .reply(200, [])
-        .post('/api/v1/api-specification', body => body.match('form-data; name="spec"'))
+        .post('/api/v1/api-specification', { registryUUID })
         .delayConnection(1000)
         .basicAuth({ user: key })
         .reply(400, errorObject);
@@ -419,14 +455,18 @@ describe('rdme openapi', () => {
     });
 
     it('should error if API errors (generic upload error)', async () => {
+      const registryUUID = getRandomRegistryId();
+
       const mock = getApiNock()
         .get(`/api/v1/version/${version}`)
         .basicAuth({ user: key })
         .reply(200, { version: '1.0.0' })
+        .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
+        .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
         .get('/api/v1/api-specification')
         .basicAuth({ user: key })
         .reply(200, [])
-        .post('/api/v1/api-specification', body => body.match('form-data; name="spec"'))
+        .post('/api/v1/api-specification', { registryUUID })
         .delayConnection(1000)
         .basicAuth({ user: key })
         .reply(400, 'some non-JSON upload error');
@@ -439,14 +479,18 @@ describe('rdme openapi', () => {
     });
 
     it('should error if API errors (request timeout)', async () => {
+      const registryUUID = getRandomRegistryId();
+
       const mock = getApiNock()
         .get(`/api/v1/version/${version}`)
         .basicAuth({ user: key })
         .reply(200, { version: '1.0.0' })
+        .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
+        .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
         .get('/api/v1/api-specification')
         .basicAuth({ user: key })
         .reply(200, [])
-        .post('/api/v1/api-specification', body => body.match('form-data; name="spec"'))
+        .post('/api/v1/api-specification', { registryUUID })
         .delayConnection(1000)
         .basicAuth({ user: key })
         .reply(400, '<html></html>');

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "node-fetch": "^2.6.1",
         "oas-normalize": "^6.0.0",
         "open": "^8.2.1",
+        "ora": "^5.4.1",
         "parse-link-header": "^2.0.0",
         "read": "^1.0.7",
         "semver": "^7.0.0",
@@ -2285,6 +2286,75 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bl/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/boxen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
@@ -2387,6 +2457,29 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -2658,6 +2751,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-table": {
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
@@ -2685,6 +2800,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clone-response": {
@@ -3135,6 +3258,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "dependencies": {
+        "clone": "^1.0.2"
       }
     },
     "node_modules/defer-to-connect": {
@@ -5080,6 +5211,25 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -5440,6 +5590,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -5580,6 +5738,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-weakref": {
       "version": "1.0.1",
@@ -6897,6 +7066,21 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.0.1",
@@ -8234,7 +8418,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -8717,7 +8900,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -8749,6 +8931,28 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.0.tgz",
       "integrity": "sha512-GB+QO6o1hAtKsb8tP3/FTD5jpkdKrf42L4Gel9UySngMurzr+Q9pO+dtnmySQCzoCEfJr39IH6bveEn71xNcVg==",
       "peer": true
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/p-cancelable": {
       "version": "1.1.0",
@@ -9805,6 +10009,18 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dependencies": {
         "lowercase-keys": "^1.0.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/retext-english": {
@@ -11224,8 +11440,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/uvu": {
       "version": "0.5.3",
@@ -11455,6 +11670,14 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/web-namespaces": {
@@ -13396,6 +13619,46 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "boxen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
@@ -13466,6 +13729,15 @@
       "requires": {
         "once": "^1.3.3",
         "sliced": "^1.0.1"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -13648,6 +13920,19 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
     },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-spinners": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g=="
+    },
     "cli-table": {
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
@@ -13672,6 +13957,11 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
     },
     "clone-response": {
       "version": "1.0.2",
@@ -14009,6 +14299,14 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "requires": {
+        "clone": "^1.0.2"
+      }
     },
     "defer-to-connect": {
       "version": "1.1.3",
@@ -15453,6 +15751,11 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -15685,6 +15988,11 @@
         "is-path-inside": "^3.0.2"
       }
     },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
+    },
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -15768,6 +16076,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
     },
     "is-weakref": {
       "version": "1.0.1",
@@ -16797,6 +17110,15 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      }
+    },
     "longest-streak": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.0.1.tgz",
@@ -17680,8 +18002,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -18053,7 +18374,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -18073,6 +18393,22 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.0.tgz",
       "integrity": "sha512-GB+QO6o1hAtKsb8tP3/FTD5jpkdKrf42L4Gel9UySngMurzr+Q9pO+dtnmySQCzoCEfJr39IH6bveEn71xNcVg==",
       "peer": true
+    },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      }
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -18851,6 +19187,15 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "requires": {
         "lowercase-keys": "^1.0.0"
+      }
+    },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "retext-english": {
@@ -19958,8 +20303,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uvu": {
       "version": "0.5.3",
@@ -20129,6 +20473,14 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "requires": {
+        "defaults": "^1.0.3"
       }
     },
     "web-namespaces": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "node-fetch": "^2.6.1",
     "oas-normalize": "^6.0.0",
     "open": "^8.2.1",
+    "ora": "^5.4.1",
     "parse-link-header": "^2.0.0",
     "read": "^1.0.7",
     "semver": "^7.0.0",

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -3,9 +3,10 @@ const chalk = require('chalk');
 const { cleanHeaders } = require('../lib/fetch');
 const config = require('config');
 const fs = require('fs');
-const { debug } = require('../lib/logger');
+const { debug, oraOptions } = require('../lib/logger');
 const fetch = require('../lib/fetch');
 const { getProjectVersion } = require('../lib/versionSelect');
+const ora = require('ora');
 const parse = require('parse-link-header');
 const prepareOas = require('../lib/prepareOas');
 const { prompt } = require('enquirer');
@@ -54,6 +55,7 @@ module.exports = class OpenAPICommand {
     const { key, id, spec, version, workingDirectory } = opts;
     let selectedVersion;
     let isUpdate;
+    const spinner = ora({ ...oraOptions() });
 
     debug(`command: ${this.command}`);
     debug(`opts: ${JSON.stringify(opts)}`);
@@ -138,8 +140,14 @@ module.exports = class OpenAPICommand {
 
       function createSpec() {
         options.method = 'post';
+        const text = 'Creating the docs for your API specification in ReadMe...';
+        spinner.start(text);
         return fetch(`${config.get('host')}/api/v1/api-specification`, options).then(res => {
-          if (res.ok) return success(res);
+          if (res.ok) {
+            spinner.succeed(`${text} done! 🦉`);
+            return success(res);
+          }
+          spinner.fail();
           return error(res);
         });
       }
@@ -147,8 +155,14 @@ module.exports = class OpenAPICommand {
       function updateSpec(specId) {
         isUpdate = true;
         options.method = 'put';
+        const text = 'Updating the docs for your API specification in ReadMe...';
+        spinner.start(text);
         return fetch(`${config.get('host')}/api/v1/api-specification/${specId}`, options).then(res => {
-          if (res.ok) return success(res);
+          if (res.ok) {
+            spinner.succeed(`${text} done! 🦉`);
+            return success(res);
+          }
+          spinner.fail();
           return error(res);
         });
       }

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -140,7 +140,7 @@ module.exports = class OpenAPICommand {
 
       function createSpec() {
         options.method = 'post';
-        const text = 'Creating the docs for your API specification in ReadMe...';
+        const text = 'Creating your API docs in ReadMe...';
         spinner.start(text);
         return fetch(`${config.get('host')}/api/v1/api-specification`, options).then(res => {
           if (res.ok) {
@@ -155,7 +155,7 @@ module.exports = class OpenAPICommand {
       function updateSpec(specId) {
         isUpdate = true;
         options.method = 'put';
-        const text = 'Updating the docs for your API specification in ReadMe...';
+        const text = 'Updating your API docs in ReadMe...';
         spinner.start(text);
         return fetch(`${config.get('host')}/api/v1/api-specification/${specId}`, options).then(res => {
           if (res.ok) {

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -17,6 +17,7 @@ module.exports.oraOptions = function oraOptions() {
   // Disables spinner in tests so it doesn't pollute test output
   const opts = { isSilent: process.env.NODE_ENV === 'testing' };
   // Cleans up ora output so it prints nicely alongside debug logs
+  /* istanbul ignore next */
   if (debugPackage.enabled) opts.isEnabled = false;
   return opts;
 };

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -12,3 +12,11 @@ module.exports.debug = function debug(input) {
   if (isGHA() && process.env.NODE_ENV !== 'testing') core.debug(`rdme: ${input}`);
   return debugPackage(input);
 };
+
+module.exports.oraOptions = function oraOptions() {
+  // Disables spinner in tests so it doesn't pollute test output
+  const opts = { isSilent: process.env.NODE_ENV === 'testing' };
+  // Cleans up ora output so it prints nicely alongside debug logs
+  if (debugPackage.enabled) opts.isEnabled = false;
+  return opts;
+};

--- a/src/lib/prepareOas.js
+++ b/src/lib/prepareOas.js
@@ -1,8 +1,6 @@
-const { debug } = require('./logger');
+const { debug, oraOptions } = require('./logger');
 const OASNormalize = require('oas-normalize');
 const ora = require('ora');
-
-const testing = process.env.NODE_ENV === 'testing';
 
 /**
  * Normalizes, validates, and (optionally) bundles an OpenAPI definition.
@@ -13,7 +11,7 @@ const testing = process.env.NODE_ENV === 'testing';
  */
 module.exports = async function prepare(path, bundle = false) {
   const text = `Validating API definition located at ${path}...`;
-  const spinner = ora({ isSilent: testing, text }).start();
+  const spinner = ora({ text, ...oraOptions() }).start();
 
   debug(`about to normalize spec located at ${path}`);
   const oas = new OASNormalize(path, { colorizeErrors: true, enablePaths: true });

--- a/src/lib/prepareOas.js
+++ b/src/lib/prepareOas.js
@@ -1,5 +1,8 @@
-const OASNormalize = require('oas-normalize');
 const { debug } = require('./logger');
+const OASNormalize = require('oas-normalize');
+const ora = require('ora');
+
+const testing = process.env.NODE_ENV === 'testing';
 
 /**
  * Normalizes, validates, and (optionally) bundles an OpenAPI definition.
@@ -9,14 +12,20 @@ const { debug } = require('./logger');
  * return a bundled spec (defaults to false)
  */
 module.exports = async function prepare(path, bundle = false) {
+  const text = `Validating API definition located at ${path}...`;
+  const spinner = ora({ isSilent: testing, text }).start();
+
   debug(`about to normalize spec located at ${path}`);
   const oas = new OASNormalize(path, { colorizeErrors: true, enablePaths: true });
   debug('spec normalized');
 
   const api = await oas.validate(false).catch(err => {
+    spinner.fail();
     debug(`raw validation error object: ${JSON.stringify(err)}`);
     throw err;
   });
+  spinner.succeed(`${text} done!`);
+
   debug('👇👇👇👇👇 spec validated! logging spec below 👇👇👇👇👇');
   debug(api);
   debug('👆👆👆👆👆 finished logging spec 👆👆👆👆👆');

--- a/src/lib/prepareOas.js
+++ b/src/lib/prepareOas.js
@@ -22,7 +22,7 @@ module.exports = async function prepare(path, bundle = false) {
     debug(`raw validation error object: ${JSON.stringify(err)}`);
     throw err;
   });
-  spinner.succeed(`${text} done!`);
+  spinner.succeed(`${text} done! ✅`);
 
   debug('👇👇👇👇👇 spec validated! logging spec below 👇👇👇👇👇');
   debug(api);

--- a/src/lib/streamSpecToRegistry.js
+++ b/src/lib/streamSpecToRegistry.js
@@ -1,0 +1,51 @@
+const { handleRes } = require('./fetch');
+const config = require('config');
+const { debug } = require('./logger');
+const fetch = require('./fetch');
+const FormData = require('form-data');
+const fs = require('fs');
+const ora = require('ora');
+const { file: tmpFile } = require('tmp-promise');
+
+const testing = process.env.NODE_ENV === 'testing';
+
+const text = 'Uploading API Definition to ReadMe...';
+
+/**
+ * Uploads a spec to the API registry for usage in ReadMe
+ *
+ * @param {String} spec path to a bundled/validated spec file
+ * @returns {String} a UUID in the API registry
+ */
+module.exports = async function streamSpecToRegistry(spec) {
+  const spinner = ora({ isSilent: testing, text }).start();
+  // Create a temporary file to write the bundled spec to,
+  // which we will then stream into the form data body
+  const { path } = await tmpFile({ prefix: 'rdme-openapi-', postfix: '.json' });
+  debug(`creating temporary file at ${path}`);
+  await fs.writeFileSync(path, spec);
+  const stream = fs.createReadStream(path);
+
+  debug('file and stream created, streaming into form data payload');
+  const formData = new FormData();
+  formData.append('spec', stream);
+
+  const options = {
+    body: formData,
+    headers: {
+      Accept: 'application/json',
+    },
+    method: 'POST',
+  };
+
+  return fetch(`${config.get('host')}/api/v1/api-registry`, options)
+    .then(res => handleRes(res))
+    .then(body => {
+      spinner.stopAndPersist({ symbol: '🚀', text: `${text} done!` });
+      return body.registryUUID;
+    })
+    .catch(e => {
+      spinner.fail();
+      throw e;
+    });
+};

--- a/src/lib/streamSpecToRegistry.js
+++ b/src/lib/streamSpecToRegistry.js
@@ -39,7 +39,7 @@ module.exports = async function streamSpecToRegistry(spec) {
   return fetch(`${config.get('host')}/api/v1/api-registry`, options)
     .then(res => handleRes(res))
     .then(body => {
-      spinner.stopAndPersist({ symbol: '🚀', text: `${text} done!` });
+      spinner.succeed(`${text} done! 🚀`);
       return body.registryUUID;
     })
     .catch(e => {

--- a/src/lib/streamSpecToRegistry.js
+++ b/src/lib/streamSpecToRegistry.js
@@ -1,13 +1,11 @@
 const { handleRes } = require('./fetch');
 const config = require('config');
-const { debug } = require('./logger');
+const { debug, oraOptions } = require('./logger');
 const fetch = require('./fetch');
 const FormData = require('form-data');
 const fs = require('fs');
 const ora = require('ora');
 const { file: tmpFile } = require('tmp-promise');
-
-const testing = process.env.NODE_ENV === 'testing';
 
 const text = 'Uploading API Definition to ReadMe...';
 
@@ -18,7 +16,7 @@ const text = 'Uploading API Definition to ReadMe...';
  * @returns {String} a UUID in the API registry
  */
 module.exports = async function streamSpecToRegistry(spec) {
-  const spinner = ora({ isSilent: testing, text }).start();
+  const spinner = ora({ text, ...oraOptions() }).start();
   // Create a temporary file to write the bundled spec to,
   // which we will then stream into the form data body
   const { path } = await tmpFile({ prefix: 'rdme-openapi-', postfix: '.json' });


### PR DESCRIPTION
| 🚥 Fix RM-4367 |
| :-- |

_(hopefully) fixes #499_ 

## 🧰 Changes

- [x] Behind-the-scenes improvements to `openapi` command to support new two-part spec upload process 🚀 
- [x] Updated test coverage to reflect these changes[^1] 📈 
- [x] Introduced [`ora`](https://github.com/sindresorhus/ora/tree/v5.4.1) into the mix so users can have better visibility into the validation/upload process 🧭 

<details>
<summary><b>Previous TODOs (archived)</b></summary>

- [x] Function for uploading spec to registry 🚀 
- [x] Loading spinners for validation ✅  
- [x] Updates to `openapi` command to support new process ✨ 
- [x] Base config for `ora` loading spinners 🧭 
- [x] Tests 🧪  

</details>

## 🧬 QA & Testing

Do tests pass? You can also test this command with a project of your own by checking out this branch and running:
```sh
bin/rdme openapi __tests__/__fixtures__/ref-oas/petstore.json --key=<api key>
```

[^1]: I did a lot of test coverage/cleanup work as part of these changes, but that blew up the diff and scope of this PR so any changes unrelated to this new `openapi` process can be found in [#520](https://github.com/readmeio/rdme/pull/520).