### PR TITLE
feat: add `docs:single`

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,15 +153,16 @@ rdme docs path-to-markdown-files --version={project-version}
 
 This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about dry run mode [in our docs](https://docs.readme.com/docs/rdme#dry-run-mode).
 
-#### Syncing a Single Markdown File to ReadMe
-```sh
-rdme docs:single path-to-markdown-file --version={project-version}
-```
-
 #### Edit a Single ReadMe Doc on Your Local Machine
 
 ```sh
 rdme docs:edit <slug> --version={project-version}
+```
+
+#### Syncing a Single Markdown File to ReadMe
+
+```sh
+rdme docs:single path-to-markdown-file --version={project-version}
 ```
 
 ### Versions

--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ rdme docs path-to-markdown-files --version={project-version}
 
 This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about dry run mode [in our docs](https://docs.readme.com/docs/rdme#dry-run-mode).
 
-#### Syncing a single Markdown File to ReadMe
+#### Syncing a Single Markdown File to ReadMe
 ```sh
-rdme docs:create path-to-markdown-file --version={project-version}
+rdme docs:single path-to-markdown-file --version={project-version}
 ```
 
 #### Edit a Single ReadMe Doc on Your Local Machine

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ rdme docs path-to-markdown-files --version={project-version}
 
 This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about dry run mode [in our docs](https://docs.readme.com/docs/rdme#dry-run-mode).
 
+#### Syncing a single Markdown File to ReadMe
+```sh
+rdme docs:create path-to-markdown-file --version={project-version}
+```
+
 #### Edit a Single ReadMe Doc on Your Local Machine
 
 ```sh

--- a/__tests__/cmds/docs.test.js
+++ b/__tests__/cmds/docs.test.js
@@ -560,7 +560,7 @@ describe('rdme docs:single', () => {
     );
   });
 
-  it('should error if the argument isnt a folder', async () => {
+  it('should error if the argument is not a markdown file', async () => {
     await expect(docsSingle.run({ key, version: '1.0.0', filepath: 'not-a-markdown-file' })).rejects.toThrow(
       'The filepath specified is not a markdown file.'
     );

--- a/__tests__/cmds/docs.test.js
+++ b/__tests__/cmds/docs.test.js
@@ -554,6 +554,18 @@ describe('rdme docs:create', () => {
     return expect(docsCreate.run({})).rejects.toThrow('No project API key provided. Please use `--key`.');
   });
 
+  it('should error if no filepath provided', () => {
+    return expect(docsCreate.run({ key, version: '1.0.0' })).rejects.toThrow(
+      'No filepath provided. Usage `rdme docs:create <filepath> [options]`.'
+    );
+  });
+
+  it('should error if the argument isnt a folder', async () => {
+    await expect(docsCreate.run({ key, version: '1.0.0', filepath: 'not-a-markdown-file' })).rejects.toThrow(
+      'The filepath specified is not a markdown file.'
+    );
+  });
+
   describe('new docs', () => {
     it('should create new doc', async () => {
       const slug = 'new-doc';
@@ -590,6 +602,124 @@ describe('rdme docs:create', () => {
       postMock.done();
       versionMock.done();
     });
+
+    it('should return creation info for dry run', async () => {
+      const slug = 'new-doc';
+      const doc = frontMatter(fs.readFileSync(path.join(fixturesDir, `/new-docs/${slug}.md`)));
+
+      const getMock = getNockWithVersionHeader(version)
+        .get(`/api/v1/docs/${slug}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'DOC_NOTFOUND',
+          message: `The doc with the slug '${slug}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        });
+
+      const versionMock = getApiNock()
+        .get(`/api/v1/version/${version}`)
+        .basicAuth({ user: key })
+        .reply(200, { version });
+
+      await expect(
+        docsCreate.run({ dryRun: true, filepath: './__tests__/__fixtures__/new-docs/new-doc.md', key, version })
+      ).resolves.toBe(
+        `🎭 dry run! This will create 'new-doc' with contents from ./__tests__/__fixtures__/new-docs/new-doc.md with the following metadata: ${JSON.stringify(
+          doc.data
+        )}`
+      );
+
+      getMock.done();
+      versionMock.done();
+    });
+
+    it('should fail if the doc is invalid', async () => {
+      const folder = 'failure-docs';
+      const slug = 'fail-doc';
+
+      const errorObject = {
+        error: 'DOC_INVALID',
+        message: "We couldn't save this doc (Path `category` is required.).",
+      };
+
+      const doc = frontMatter(fs.readFileSync(path.join(fixturesDir, `/${folder}/${slug}.md`)));
+
+      const hash = hashFileContents(fs.readFileSync(path.join(fixturesDir, `/${folder}/${slug}.md`)));
+
+      const getMock = getNockWithVersionHeader(version)
+        .get(`/api/v1/docs/${slug}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'DOC_NOTFOUND',
+          message: `The doc with the slug '${slug}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        });
+
+      const postMock = getNockWithVersionHeader(version)
+        .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
+        .basicAuth({ user: key })
+        .reply(400, errorObject);
+
+      const versionMock = getApiNock()
+        .get(`/api/v1/version/${version}`)
+        .basicAuth({ user: key })
+        .reply(200, { version });
+
+      const filepath = './__tests__/__fixtures__/failure-docs/fail-doc.md';
+
+      const formattedErrorObject = {
+        ...errorObject,
+        message: `Error uploading ${chalk.underline(`${filepath}`)}:\n\n${errorObject.message}`,
+      };
+
+      await expect(docsCreate.run({ filepath: `${filepath}`, key, version })).rejects.toStrictEqual(
+        new APIError(formattedErrorObject)
+      );
+
+      getMock.done();
+      postMock.done();
+      versionMock.done();
+    });
+  });
+
+  describe('slug metadata', () => {
+    it('should use provided slug', async () => {
+      const slug = 'new-doc-slug';
+      const doc = frontMatter(fs.readFileSync(path.join(fixturesDir, `/slug-docs/${slug}.md`)));
+      const hash = hashFileContents(fs.readFileSync(path.join(fixturesDir, `/slug-docs/${slug}.md`)));
+
+      const getMock = getApiNock()
+        .get(`/api/v1/docs/${doc.data.slug}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'DOC_NOTFOUND',
+          message: `The doc with the slug '${slug}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        });
+
+      const postMock = getApiNock()
+        .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
+        .basicAuth({ user: key })
+        .reply(201, { slug: doc.data.slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+
+      const versionMock = getApiNock()
+        .get(`/api/v1/version/${version}`)
+        .basicAuth({ user: key })
+        .reply(200, { version });
+
+      await expect(
+        docsCreate.run({ filepath: './__tests__/__fixtures__/slug-docs/new-doc-slug.md', key, version })
+      ).resolves.toBe(
+        "🌱 successfully created 'marc-actually-wrote-a-test' with contents from ./__tests__/__fixtures__/slug-docs/new-doc-slug.md"
+      );
+
+      getMock.done();
+      postMock.done();
+      versionMock.done();
+    });
   });
 
   describe('existing docs', () => {
@@ -605,12 +735,12 @@ describe('rdme docs:create', () => {
     });
 
     it('should fetch doc and merge with what is returned', () => {
-      const getMocks = getNockWithVersionHeader(version)
+      const getMock = getNockWithVersionHeader(version)
         .get('/api/v1/docs/simple-doc')
         .basicAuth({ user: key })
         .reply(200, { category, slug: simpleDoc.slug, lastUpdatedHash: 'anOldHash' });
 
-      const updateMocks = getNockWithVersionHeader(version)
+      const updateMock = getNockWithVersionHeader(version)
         .put('/api/v1/docs/simple-doc', {
           category,
           slug: simpleDoc.slug,
@@ -637,8 +767,83 @@ describe('rdme docs:create', () => {
             "✏️ successfully updated 'simple-doc' with contents from ./__tests__/__fixtures__/existing-docs/simple-doc.md"
           );
 
-          getMocks.done();
-          updateMocks.done();
+          getMock.done();
+          updateMock.done();
+          versionMock.done();
+        });
+    });
+
+    it('should return doc update info for dry run', () => {
+      expect.assertions(1);
+
+      const getMock = getNockWithVersionHeader(version)
+        .get('/api/v1/docs/simple-doc')
+        .basicAuth({ user: key })
+        .reply(200, { category, slug: simpleDoc.slug, lastUpdatedHash: 'anOldHash' });
+
+      const versionMock = getApiNock()
+        .get(`/api/v1/version/${version}`)
+        .basicAuth({ user: key })
+        .reply(200, { version });
+
+      return docsCreate
+        .run({ dryRun: true, filepath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
+        .then(updatedDocs => {
+          // All docs should have been updated because their hashes from the GET request were different from what they
+          // are currently.
+          expect(updatedDocs).toBe(
+            [
+              `🎭 dry run! This will update 'simple-doc' with contents from ./__tests__/__fixtures__/existing-docs/simple-doc.md with the following metadata: ${JSON.stringify(
+                simpleDoc.doc.data
+              )}`,
+            ].join('\n')
+          );
+
+          getMock.done();
+          versionMock.done();
+        });
+    });
+
+    it('should not send requests for docs that have not changed', () => {
+      expect.assertions(1);
+
+      const getMock = getNockWithVersionHeader(version)
+        .get('/api/v1/docs/simple-doc')
+        .basicAuth({ user: key })
+        .reply(200, { category, slug: simpleDoc.slug, lastUpdatedHash: simpleDoc.hash });
+
+      const versionMock = getApiNock()
+        .get(`/api/v1/version/${version}`)
+        .basicAuth({ user: key })
+        .reply(200, { version });
+
+      return docsCreate
+        .run({ filepath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
+        .then(skippedDocs => {
+          expect(skippedDocs).toBe('`simple-doc` was not updated because there were no changes.');
+
+          getMock.done();
+          versionMock.done();
+        });
+    });
+
+    it('should adjust "no changes" message if in dry run', () => {
+      const getMock = getNockWithVersionHeader(version)
+        .get('/api/v1/docs/simple-doc')
+        .basicAuth({ user: key })
+        .reply(200, { category, slug: simpleDoc.slug, lastUpdatedHash: simpleDoc.hash });
+
+      const versionMock = getApiNock()
+        .get(`/api/v1/version/${version}`)
+        .basicAuth({ user: key })
+        .reply(200, { version });
+
+      return docsCreate
+        .run({ dryRun: true, filepath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
+        .then(skippedDocs => {
+          expect(skippedDocs).toBe('🎭 dry run! `simple-doc` will not be updated because there were no changes.');
+
+          getMock.done();
           versionMock.done();
         });
     });

--- a/__tests__/cmds/docs.test.js
+++ b/__tests__/cmds/docs.test.js
@@ -10,11 +10,11 @@ const getApiNock = require('../get-api-nock');
 
 const DocsCommand = require('../../src/cmds/docs');
 const DocsEditCommand = require('../../src/cmds/docs/edit');
-const DocsCreateCommand = require('../../src/cmds/docs/create');
+const DocsSingleCommand = require('../../src/cmds/docs/single');
 
 const docs = new DocsCommand();
 const docsEdit = new DocsEditCommand();
-const docsCreate = new DocsCreateCommand();
+const docsSingle = new DocsSingleCommand();
 
 const fixturesDir = `${__dirname}./../__fixtures__`;
 const key = 'API_KEY';
@@ -545,23 +545,23 @@ describe('rdme docs:edit', () => {
   });
 });
 
-describe('rdme docs:create', () => {
+describe('rdme docs:single', () => {
   beforeAll(() => nock.disableNetConnect());
 
   afterAll(() => nock.cleanAll());
 
   it('should error if no api key provided', () => {
-    return expect(docsCreate.run({})).rejects.toThrow('No project API key provided. Please use `--key`.');
+    return expect(docsSingle.run({})).rejects.toThrow('No project API key provided. Please use `--key`.');
   });
 
   it('should error if no filepath provided', () => {
-    return expect(docsCreate.run({ key, version: '1.0.0' })).rejects.toThrow(
-      'No filepath provided. Usage `rdme docs:create <filepath> [options]`.'
+    return expect(docsSingle.run({ key, version: '1.0.0' })).rejects.toThrow(
+      'No filepath provided. Usage `rdme docs:single <filepath> [options]`.'
     );
   });
 
   it('should error if the argument isnt a folder', async () => {
-    await expect(docsCreate.run({ key, version: '1.0.0', filepath: 'not-a-markdown-file' })).rejects.toThrow(
+    await expect(docsSingle.run({ key, version: '1.0.0', filepath: 'not-a-markdown-file' })).rejects.toThrow(
       'The filepath specified is not a markdown file.'
     );
   });
@@ -593,7 +593,7 @@ describe('rdme docs:create', () => {
         .reply(200, { version });
 
       await expect(
-        docsCreate.run({ filepath: './__tests__/__fixtures__/new-docs/new-doc.md', key, version })
+        docsSingle.run({ filepath: './__tests__/__fixtures__/new-docs/new-doc.md', key, version })
       ).resolves.toBe(
         "🌱 successfully created 'new-doc' with contents from ./__tests__/__fixtures__/new-docs/new-doc.md"
       );
@@ -623,7 +623,7 @@ describe('rdme docs:create', () => {
         .reply(200, { version });
 
       await expect(
-        docsCreate.run({ dryRun: true, filepath: './__tests__/__fixtures__/new-docs/new-doc.md', key, version })
+        docsSingle.run({ dryRun: true, filepath: './__tests__/__fixtures__/new-docs/new-doc.md', key, version })
       ).resolves.toBe(
         `🎭 dry run! This will create 'new-doc' with contents from ./__tests__/__fixtures__/new-docs/new-doc.md with the following metadata: ${JSON.stringify(
           doc.data
@@ -674,7 +674,7 @@ describe('rdme docs:create', () => {
         message: `Error uploading ${chalk.underline(`${filepath}`)}:\n\n${errorObject.message}`,
       };
 
-      await expect(docsCreate.run({ filepath: `${filepath}`, key, version })).rejects.toStrictEqual(
+      await expect(docsSingle.run({ filepath: `${filepath}`, key, version })).rejects.toStrictEqual(
         new APIError(formattedErrorObject)
       );
 
@@ -711,7 +711,7 @@ describe('rdme docs:create', () => {
         .reply(200, { version });
 
       await expect(
-        docsCreate.run({ filepath: './__tests__/__fixtures__/slug-docs/new-doc-slug.md', key, version })
+        docsSingle.run({ filepath: './__tests__/__fixtures__/slug-docs/new-doc-slug.md', key, version })
       ).resolves.toBe(
         "🌱 successfully created 'marc-actually-wrote-a-test' with contents from ./__tests__/__fixtures__/slug-docs/new-doc-slug.md"
       );
@@ -760,7 +760,7 @@ describe('rdme docs:create', () => {
         .basicAuth({ user: key })
         .reply(200, { version });
 
-      return docsCreate
+      return docsSingle
         .run({ filepath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
         .then(updatedDocs => {
           expect(updatedDocs).toBe(
@@ -786,7 +786,7 @@ describe('rdme docs:create', () => {
         .basicAuth({ user: key })
         .reply(200, { version });
 
-      return docsCreate
+      return docsSingle
         .run({ dryRun: true, filepath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
         .then(updatedDocs => {
           // All docs should have been updated because their hashes from the GET request were different from what they
@@ -817,7 +817,7 @@ describe('rdme docs:create', () => {
         .basicAuth({ user: key })
         .reply(200, { version });
 
-      return docsCreate
+      return docsSingle
         .run({ filepath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
         .then(skippedDocs => {
           expect(skippedDocs).toBe('`simple-doc` was not updated because there were no changes.');
@@ -838,7 +838,7 @@ describe('rdme docs:create', () => {
         .basicAuth({ user: key })
         .reply(200, { version });
 
-      return docsCreate
+      return docsSingle
         .run({ dryRun: true, filepath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
         .then(skippedDocs => {
           expect(skippedDocs).toBe('🎭 dry run! `simple-doc` will not be updated because there were no changes.');

--- a/src/cmds/docs/create.js
+++ b/src/cmds/docs/create.js
@@ -1,0 +1,140 @@
+const chalk = require('chalk');
+const fs = require('fs');
+const path = require('path');
+const config = require('config');
+const crypto = require('crypto');
+const frontMatter = require('gray-matter');
+const { promisify } = require('util');
+const { getProjectVersion } = require('../../lib/versionSelect');
+const fetch = require('../../lib/fetch');
+const { cleanHeaders, handleRes } = require('../../lib/fetch');
+const { debug } = require('../../lib/logger');
+
+const readFile = promisify(fs.readFile);
+
+module.exports = class CreateDocCommand {
+  constructor() {
+    this.command = 'docs:create';
+    this.usage = 'docs:create <filepath> [options]';
+    this.description = 'Sync a single markdown file to your ReadMe project.';
+    this.category = 'docs';
+    this.position = 1;
+
+    this.hiddenArgs = ['filepath'];
+    this.args = [
+      {
+        name: 'key',
+        type: String,
+        description: 'Project API key',
+      },
+      {
+        name: 'version',
+        type: String,
+        description: 'Project version',
+      },
+      {
+        name: 'filepath',
+        type: String,
+        defaultOption: true,
+      },
+    ];
+  }
+
+  async run(opts) {
+    const { filepath, key, version } = opts;
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
+
+    if (!key) {
+      return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
+    }
+
+    if (!filepath) {
+      return Promise.reject(new Error(`No filepath provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
+    }
+
+    if (filepath.endsWith('.md') === false || !filepath.endsWith('.markdown') === false) {
+      return Promise.reject(new Error('The filepath specified is not a markdown file.'));
+    }
+
+    // TODO: should we allow version selection at all here?
+    // Let's revisit this once we re-evaluate our category logic in the API.
+    // Ideally we should ignore this parameter entirely if the category is included.
+    const selectedVersion = await getProjectVersion(version, key, false);
+
+    debug(`selectedVersion: ${selectedVersion}`);
+
+    debug(`reading file ${filepath}`);
+    const file = await readFile(filepath, 'utf8');
+    const matter = frontMatter(file);
+    debug(`frontmatter for ${filepath}: ${JSON.stringify(matter)}`);
+
+    // Stripping the subdirectories and markdown extension from the filename and lowercasing to get the default slug.
+    const slug = matter.data.slug || path.basename(filepath).replace(path.extname(filepath), '').toLowerCase();
+    const hash = crypto.createHash('sha1').update(file).digest('hex');
+
+    function createDoc(err) {
+      if (err.error !== 'DOC_NOTFOUND') return Promise.reject(err);
+      return fetch(`${config.get('host')}/api/v1/docs`, {
+        method: 'post',
+        headers: cleanHeaders(key, {
+          'x-readme-version': selectedVersion,
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({
+          slug,
+          body: matter.content,
+          ...matter.data,
+          lastUpdatedHash: hash,
+        }),
+      })
+        .then(res => handleRes(res))
+        .then(res => `🌱 successfully created '${res.slug}' with contents from ${filepath}`);
+    }
+
+    function updateDoc(existingDoc) {
+      return fetch(`${config.get('host')}/api/v1/docs/${slug}`, {
+        method: 'put',
+        headers: cleanHeaders(key, {
+          'x-readme-version': selectedVersion,
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify(
+          Object.assign(existingDoc, {
+            body: matter.content,
+            ...matter.data,
+            lastUpdatedHash: hash,
+          })
+        ),
+      })
+        .then(res => handleRes(res))
+        .then(res => `✏️ successfully updated '${res.slug}' with contents from ${filepath}`);
+    }
+
+    debug(`creating doc for ${slug}`);
+    const createdDoc = await fetch(`${config.get('host')}/api/v1/docs/${slug}`, {
+      method: 'get',
+      headers: cleanHeaders(key, {
+        'x-readme-version': selectedVersion,
+        Accept: 'application/json',
+      }),
+    })
+      .then(res => res.json())
+      .then(res => {
+        debug(`GET /docs/:slug API response for ${slug}: ${JSON.stringify(res)}`);
+        if (res.error) {
+          debug(`error retrieving data for ${slug}, creating doc`);
+          return createDoc(res);
+        }
+        debug(`data received for ${slug}, updating doc`);
+        return updateDoc(res);
+      })
+      .catch(err => {
+        // eslint-disable-next-line no-param-reassign
+        err.message = `Error uploading ${chalk.underline(filepath)}:\n\n${err.message}`;
+        throw err;
+      });
+
+    return chalk.green(createdDoc);
+  }
+};

--- a/src/cmds/docs/single.js
+++ b/src/cmds/docs/single.js
@@ -12,10 +12,10 @@ const { debug } = require('../../lib/logger');
 
 const readFile = promisify(fs.readFile);
 
-module.exports = class CreateDocCommand {
+module.exports = class SingleDocCommand {
   constructor() {
-    this.command = 'docs:create';
-    this.usage = 'docs:create <filepath> [options]';
+    this.command = 'docs:single';
+    this.usage = 'docs:single <filepath> [options]';
     this.description = 'Sync a single markdown file to your ReadMe project.';
     this.category = 'docs';
     this.position = 1;

--- a/src/cmds/docs/single.js
+++ b/src/cmds/docs/single.js
@@ -18,7 +18,7 @@ module.exports = class SingleDocCommand {
     this.usage = 'docs:single <filepath> [options]';
     this.description = 'Sync a single markdown file to your ReadMe project.';
     this.category = 'docs';
-    this.position = 1;
+    this.position = 3;
 
     this.hiddenArgs = ['filepath'];
     this.args = [


### PR DESCRIPTION
| 🚥 Fix RM-XXX |
| :-- |

## 🧰 Changes

- add doc:create command to allow a single markdown file to be synced rather than only supporting an entire directory.
- updated markdown and doc test to reflect changes

## 🧬 QA & Testing

The `doc:create` command can be ran with the `--filepath` attribute being set to a specific markdown file-path and that file will be synced. If the slug already exists then the chance will not be merged.