### PR TITLE
ci: run tests on `pull_request` event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
## 🧰 Changes

Per [GitHub's docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), "by default, a workflow only runs when a `pull_request` event's activity type is `opened`, [`synchronize`](https://github.community/t/what-is-a-pull-request-synchronize-event/14784), or `reopened`".

This should hopefully get tests running for [outside contributors](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks).

## 🧬 QA & Testing

Do tests continue to run properly?
