### PR TITLE
feat(config): add ability to override host + hub

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,0 +1,1 @@
+{ "host": "README_HOST", "hub": "README_HUB" }

--- a/config/default.js
+++ b/config/default.js
@@ -2,5 +2,5 @@ module.exports = {
   // eslint-disable-next-line global-require
   cli: require('../package.json').name,
   host: 'https://dash.readme.com',
-  hub: 'https://{project}.readme.io',
+  hub: 'https://{project}.readme.io', // this is only used for the `open` command
 };


### PR DESCRIPTION
## 🧰 Changes

Per internal discussion, this adds env variable support for setting the `host` and `hub` config variables.

## 🧬 QA & Testing

Confirmed that the `config.host` value is updated properly when passing in the `README_HOST` env variable:

![image](https://user-images.githubusercontent.com/8854718/179237860-d86b4d2b-d256-4983-891d-32c6df9a4ff2.png)

