### PR TITLE
fix(openapi): clearer copy, smol refactors

### DIFF
--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -141,11 +141,10 @@ module.exports = class OpenAPICommand {
 
       function createSpec() {
         options.method = 'post';
-        const text = 'Creating your API docs in ReadMe...';
-        spinner.start(text);
+        spinner.start('Creating your API docs in ReadMe...');
         return fetch(`${config.get('host')}/api/v1/api-specification`, options).then(res => {
           if (res.ok) {
-            spinner.succeed(`${text} done! 🦉`);
+            spinner.succeed(`${spinner.text} done! 🦉`);
             return success(res);
           }
           spinner.fail();
@@ -156,11 +155,10 @@ module.exports = class OpenAPICommand {
       function updateSpec(specId) {
         isUpdate = true;
         options.method = 'put';
-        const text = 'Updating your API docs in ReadMe...';
-        spinner.start(text);
+        spinner.start('Updating your API docs in ReadMe...');
         return fetch(`${config.get('host')}/api/v1/api-specification/${specId}`, options).then(res => {
           if (res.ok) {
-            spinner.succeed(`${text} done! 🦉`);
+            spinner.succeed(`${spinner.text} done! 🦉`);
             return success(res);
           }
           spinner.fail();

--- a/src/lib/prepareOas.js
+++ b/src/lib/prepareOas.js
@@ -10,8 +10,7 @@ const ora = require('ora');
  * return a bundled spec (defaults to false)
  */
 module.exports = async function prepare(path, bundle = false) {
-  const text = `Validating API definition located at ${path}...`;
-  const spinner = ora({ text, ...oraOptions() }).start();
+  const spinner = ora({ text: `Validating API definition located at ${path}...`, ...oraOptions() }).start();
 
   debug(`about to normalize spec located at ${path}`);
   const oas = new OASNormalize(path, { colorizeErrors: true, enablePaths: true });
@@ -22,7 +21,7 @@ module.exports = async function prepare(path, bundle = false) {
     debug(`raw validation error object: ${JSON.stringify(err)}`);
     throw err;
   });
-  spinner.succeed(`${text} done! ✅`);
+  spinner.succeed(`${spinner.text} done! ✅`);
 
   debug('👇👇👇👇👇 spec validated! logging spec below 👇👇👇👇👇');
   debug(api);

--- a/src/lib/streamSpecToRegistry.js
+++ b/src/lib/streamSpecToRegistry.js
@@ -7,8 +7,6 @@ const fs = require('fs');
 const ora = require('ora');
 const { file: tmpFile } = require('tmp-promise');
 
-const text = 'Uploading API Definition to ReadMe...';
-
 /**
  * Uploads a spec to the API registry for usage in ReadMe
  *
@@ -16,7 +14,7 @@ const text = 'Uploading API Definition to ReadMe...';
  * @returns {String} a UUID in the API registry
  */
 module.exports = async function streamSpecToRegistry(spec) {
-  const spinner = ora({ text, ...oraOptions() }).start();
+  const spinner = ora({ text: 'Staging your API definition for upload...', ...oraOptions() }).start();
   // Create a temporary file to write the bundled spec to,
   // which we will then stream into the form data body
   const { path } = await tmpFile({ prefix: 'rdme-openapi-', postfix: '.json' });
@@ -39,7 +37,7 @@ module.exports = async function streamSpecToRegistry(spec) {
   return fetch(`${config.get('host')}/api/v1/api-registry`, options)
     .then(res => handleRes(res))
     .then(body => {
-      spinner.succeed(`${text} done! 🚀`);
+      spinner.succeed(`${spinner.text} done! 🚀`);
       return body.registryUUID;
     })
     .catch(e => {


### PR DESCRIPTION
## 🧰 Changes

Per feedback from @gratcliff, updating the language from this:

```
Uploading API Definition to ReadMe...
```

to this:

```
Staging your API definition for upload...
```

as part of this, I made some tiny refactors to match the spinner patterns I saw @erunion use in [the `api` codebase](https://github.com/readmeio/api/blob/fc25a5ec1602115514d34a090602d9db313aad7b/packages/api/src/cli/commands/install.ts#L108-L114).

## 🧬 QA & Testing

No functional changes, just the copy change detailed above. Let me know what you think!
