### PR TITLE
feat: better error-handling for non-JSON responses

### DIFF
--- a/__tests__/cmds/openapi.test.js
+++ b/__tests__/cmds/openapi.test.js
@@ -535,7 +535,11 @@ describe('rdme openapi', () => {
 
       await expect(
         openapi.run({ spec: require.resolve('@readme/oas-examples/2.0/json/petstore.json'), key, version })
-      ).rejects.toStrictEqual(new Error('There was an error uploading!'));
+      ).rejects.toStrictEqual(
+        new Error(
+          'Yikes, something went wrong! Please try uploading your spec again and if the problem persists, get in touch with our support team at support@readme.io.'
+        )
+      );
 
       return mock.done();
     });
@@ -555,7 +559,7 @@ describe('rdme openapi', () => {
         .post('/api/v1/api-specification', { registryUUID })
         .delayConnection(1000)
         .basicAuth({ user: key })
-        .reply(400, '<html></html>');
+        .reply(400, '<title>Application Error</title>');
 
       await expect(
         openapi.run({ spec: require.resolve('@readme/oas-examples/2.0/json/petstore.json'), key, version })

--- a/__tests__/cmds/openapi.test.js
+++ b/__tests__/cmds/openapi.test.js
@@ -559,7 +559,7 @@ describe('rdme openapi', () => {
         .post('/api/v1/api-specification', { registryUUID })
         .delayConnection(1000)
         .basicAuth({ user: key })
-        .reply(400, '<title>Application Error</title>');
+        .reply(500, '<title>Application Error</title>');
 
       await expect(
         openapi.run({ spec: require.resolve('@readme/oas-examples/2.0/json/petstore.json'), key, version })

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "form-data": "^4.0.0",
         "gray-matter": "^4.0.1",
         "isemail": "^3.1.3",
+        "mime-types": "^2.1.35",
         "node-fetch": "^2.6.1",
         "oas-normalize": "^6.0.0",
         "open": "^8.2.1",
@@ -8395,19 +8396,19 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dependencies": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -18011,16 +18012,16 @@
       }
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "form-data": "^4.0.0",
     "gray-matter": "^4.0.1",
     "isemail": "^3.1.3",
+    "mime-types": "^2.1.35",
     "node-fetch": "^2.6.1",
     "oas-normalize": "^6.0.0",
     "open": "^8.2.1",


### PR DESCRIPTION
| 🚥 Fix RM-4868 |
| :-- |

## 🧰 Changes

Right now, if we receive an error response from the API when running the `openapi` command, we have some not-so-great error handling where if the response body isn't JSON, we basically just write it off as a timeout error: https://github.com/readmeio/rdme/blob/862d4009257ddbbc553cbe67fe8a4ebb1b7bec7c/src/cmds/openapi.js#L111-L129

Our debug logs in this situation aren't helpful either: since we blindly use `res.json()` to parse the response body, our debug logs consistently return an unhelpful `Unexpected token < in JSON` error.

In this PR, our approach to parsing the response from our API has been improved to better allow us to understand non-JSON response bodies. We now do some smarter inspection of the response to determine whether or not it's a timeout. It probably is in most cases, but now we can actually inspect the response body and determine that.

In order to do this, I refactored our generic `handleRes` handler to dynamically handle JSON and non-JSON responses better. I was able to eliminate some duplicate code and the `openapi` command now leverages uses `handleRes` for error-handling.

## 🧬 QA & Testing

Do tests pass and do the changes look good?

If you want to try this out with an OAS file that timeouts consistently, check out [this comment](https://linear.app/readme-io/issue/RM-4464#comment-21c5b027). I confirmed locally with that file that the timeout error is thrown properly.

<img width="802" alt="Screen Shot 2022-07-20 at 5 54 49 PM" src="https://user-images.githubusercontent.com/8854718/180096275-c2dda13f-1472-477a-a0d6-19d1b62fa3a0.png">

I also confirmed that the debug logs now properly log non-JSON response bodies properly:

<img width="749" alt="image" src="https://user-images.githubusercontent.com/8854718/180097100-b51fc10d-c122-4e31-bf81-cef03f145139.png">