### PR TITLE
feat: changelog endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,26 @@ rdme docs:edit <slug> --version={project-version}
 rdme docs:single path-to-markdown-file --version={project-version}
 ```
 
+### Changelogs
+
+#### Syncing a Folder of Markdown to ReadMe
+
+The Markdown files will require YAML front matter with certain ReadMe documentation attributes. Check out [our docs](https://docs.readme.com/docs/rdme#markdown-file-setup) for more info on setting up your front matter.
+
+Passing in a path to a directory will also sync any Markdown files that are located in subdirectories.
+
+```sh
+rdme changelogs path-to-markdown-files
+```
+
+This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about dry run mode [in our docs](https://docs.readme.com/docs/rdme#dry-run-mode).
+
+#### Syncing a Single Markdown File to ReadMe
+
+```sh
+rdme changelogs:single path-to-markdown-file
+```
+
 ### Versions
 
 #### Get All Versions Associated With Your Project

--- a/__tests__/cmds/changelogs.test.js
+++ b/__tests__/cmds/changelogs.test.js
@@ -1,0 +1,628 @@
+const nock = require('nock');
+const chalk = require('chalk');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const frontMatter = require('gray-matter');
+
+const APIError = require('../../src/lib/apiError');
+const getApiNock = require('../get-api-nock');
+
+const ChangelogsCommand = require('../../src/cmds/changelogs');
+const SingleChangelogCommand = require('../../src/cmds/changelogs/single');
+
+const changelogs = new ChangelogsCommand();
+const changelogsSingle = new SingleChangelogCommand();
+
+const fixturesDir = `${__dirname}./../__fixtures__`;
+const key = 'API_KEY';
+
+function hashFileContents(contents) {
+  return crypto.createHash('sha1').update(contents).digest('hex');
+}
+
+describe('rdme changelogs', () => {
+  beforeAll(() => nock.disableNetConnect());
+
+  afterAll(() => nock.cleanAll());
+
+  it('should error if no api key provided', () => {
+    return expect(changelogs.run({})).rejects.toThrow('No project API key provided. Please use `--key`.');
+  });
+
+  it('should error if no folder provided', () => {
+    return expect(changelogs.run({ key, version: '1.0.0' })).rejects.toThrow(
+      'No folder provided. Usage `rdme changelogs <folder> [options]`.'
+    );
+  });
+
+  it('should error if the argument isnt a folder', () => {
+    return expect(changelogs.run({ key, version: '1.0.0', folder: 'not-a-folder' })).rejects.toThrow(
+      "ENOENT: no such file or directory, scandir 'not-a-folder'"
+    );
+  });
+
+  it('should error if the folder contains no markdown files', () => {
+    return expect(changelogs.run({ key, version: '1.0.0', folder: '.github/workflows' })).rejects.toThrow(
+      'We were unable to locate Markdown files in .github/workflows.'
+    );
+  });
+
+  describe('existing changelogs', () => {
+    let simpleDoc;
+    let anotherDoc;
+
+    beforeEach(() => {
+      let fileContents = fs.readFileSync(path.join(fixturesDir, '/existing-docs/simple-doc.md'));
+      simpleDoc = {
+        slug: 'simple-doc',
+        doc: frontMatter(fileContents),
+        hash: hashFileContents(fileContents),
+      };
+
+      fileContents = fs.readFileSync(path.join(fixturesDir, '/existing-docs/subdir/another-doc.md'));
+      anotherDoc = {
+        slug: 'another-doc',
+        doc: frontMatter(fileContents),
+        hash: hashFileContents(fileContents),
+      };
+    });
+
+    it('should fetch changelog and merge with what is returned', () => {
+      expect.assertions(1);
+
+      const getMocks = getApiNock()
+        .get('/api/v1/changelogs/simple-doc')
+        .basicAuth({ user: key })
+        .reply(200, { slug: simpleDoc.slug, lastUpdatedHash: 'anOldHash' })
+        .get('/api/v1/changelogs/another-doc')
+        .basicAuth({ user: key })
+        .reply(200, { slug: anotherDoc.slug, lastUpdatedHash: 'anOldHash' });
+
+      const updateMocks = getApiNock()
+        .put('/api/v1/changelogs/simple-doc', {
+          slug: simpleDoc.slug,
+          body: simpleDoc.doc.content,
+          lastUpdatedHash: simpleDoc.hash,
+          ...simpleDoc.doc.data,
+        })
+        .basicAuth({ user: key })
+        .reply(200, {
+          slug: simpleDoc.slug,
+          body: simpleDoc.doc.content,
+        })
+        .put('/api/v1/changelogs/another-doc', {
+          slug: anotherDoc.slug,
+          body: anotherDoc.doc.content,
+          lastUpdatedHash: anotherDoc.hash,
+          ...anotherDoc.doc.data,
+        })
+        .basicAuth({ user: key })
+        .reply(200, { slug: anotherDoc.slug, body: anotherDoc.doc.content });
+
+      return changelogs.run({ folder: './__tests__/__fixtures__/existing-docs', key }).then(updatedDocs => {
+        // All changelogs should have been updated because their hashes from the GET request were different from what they
+        // are currently.
+        expect(updatedDocs).toBe(
+          [
+            "✏️ successfully updated 'simple-doc' with contents from __tests__/__fixtures__/existing-docs/simple-doc.md",
+            "✏️ successfully updated 'another-doc' with contents from __tests__/__fixtures__/existing-docs/subdir/another-doc.md",
+          ].join('\n')
+        );
+
+        getMocks.done();
+        updateMocks.done();
+      });
+    });
+
+    it('should return changelog update info for dry run', () => {
+      expect.assertions(1);
+
+      const getMocks = getApiNock()
+        .get('/api/v1/changelogs/simple-doc')
+        .basicAuth({ user: key })
+        .reply(200, { slug: simpleDoc.slug, lastUpdatedHash: 'anOldHash' })
+        .get('/api/v1/changelogs/another-doc')
+        .basicAuth({ user: key })
+        .reply(200, { slug: anotherDoc.slug, lastUpdatedHash: 'anOldHash' });
+
+      return changelogs
+        .run({ dryRun: true, folder: './__tests__/__fixtures__/existing-docs', key })
+        .then(updatedDocs => {
+          // All changelogs should have been updated because their hashes from the GET request were different from what they
+          // are currently.
+          expect(updatedDocs).toBe(
+            [
+              `🎭 dry run! This will update 'simple-doc' with contents from __tests__/__fixtures__/existing-docs/simple-doc.md with the following metadata: ${JSON.stringify(
+                simpleDoc.doc.data
+              )}`,
+              `🎭 dry run! This will update 'another-doc' with contents from __tests__/__fixtures__/existing-docs/subdir/another-doc.md with the following metadata: ${JSON.stringify(
+                anotherDoc.doc.data
+              )}`,
+            ].join('\n')
+          );
+
+          getMocks.done();
+        });
+    });
+
+    it('should not send requests for changelogs that have not changed', () => {
+      expect.assertions(1);
+
+      const getMocks = getApiNock()
+        .get('/api/v1/changelogs/simple-doc')
+        .basicAuth({ user: key })
+        .reply(200, { slug: simpleDoc.slug, lastUpdatedHash: simpleDoc.hash })
+        .get('/api/v1/changelogs/another-doc')
+        .basicAuth({ user: key })
+        .reply(200, { slug: anotherDoc.slug, lastUpdatedHash: anotherDoc.hash });
+
+      return changelogs.run({ folder: './__tests__/__fixtures__/existing-docs', key }).then(skippedDocs => {
+        expect(skippedDocs).toBe(
+          [
+            '`simple-doc` was not updated because there were no changes.',
+            '`another-doc` was not updated because there were no changes.',
+          ].join('\n')
+        );
+
+        getMocks.done();
+      });
+    });
+
+    it('should adjust "no changes" message if in dry run', () => {
+      expect.assertions(1);
+
+      const getMocks = getApiNock()
+        .get('/api/v1/changelogs/simple-doc')
+        .basicAuth({ user: key })
+        .reply(200, { slug: simpleDoc.slug, lastUpdatedHash: simpleDoc.hash })
+        .get('/api/v1/changelogs/another-doc')
+        .basicAuth({ user: key })
+        .reply(200, { slug: anotherDoc.slug, lastUpdatedHash: anotherDoc.hash });
+
+      return changelogs
+        .run({ dryRun: true, folder: './__tests__/__fixtures__/existing-docs', key })
+        .then(skippedDocs => {
+          expect(skippedDocs).toBe(
+            [
+              '🎭 dry run! `simple-doc` will not be updated because there were no changes.',
+              '🎭 dry run! `another-doc` will not be updated because there were no changes.',
+            ].join('\n')
+          );
+
+          getMocks.done();
+        });
+    });
+  });
+
+  describe('new changelogs', () => {
+    it('should create new changelog', async () => {
+      const slug = 'new-doc';
+      const doc = frontMatter(fs.readFileSync(path.join(fixturesDir, `/new-docs/${slug}.md`)));
+      const hash = hashFileContents(fs.readFileSync(path.join(fixturesDir, `/new-docs/${slug}.md`)));
+
+      const getMock = getApiNock()
+        .get(`/api/v1/changelogs/${slug}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'CHANGELOG_NOTFOUND',
+          message: `The changelog with the slug '${slug}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        });
+
+      const postMock = getApiNock()
+        .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
+        .basicAuth({ user: key })
+        .reply(201, { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+
+      await expect(changelogs.run({ folder: './__tests__/__fixtures__/new-docs', key })).resolves.toBe(
+        "🌱 successfully created 'new-doc' with contents from __tests__/__fixtures__/new-docs/new-doc.md"
+      );
+
+      getMock.done();
+      postMock.done();
+    });
+
+    it('should return creation info for dry run', async () => {
+      const slug = 'new-doc';
+      const doc = frontMatter(fs.readFileSync(path.join(fixturesDir, `/new-docs/${slug}.md`)));
+
+      const getMock = getApiNock()
+        .get(`/api/v1/changelogs/${slug}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'CHANGELOG_NOTFOUND',
+          message: `The changelog with the slug '${slug}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        });
+
+      await expect(changelogs.run({ dryRun: true, folder: './__tests__/__fixtures__/new-docs', key })).resolves.toBe(
+        `🎭 dry run! This will create 'new-doc' with contents from __tests__/__fixtures__/new-docs/new-doc.md with the following metadata: ${JSON.stringify(
+          doc.data
+        )}`
+      );
+
+      getMock.done();
+    });
+
+    it('should fail if any changelogs are invalid', async () => {
+      const folder = 'failure-docs';
+      const slug = 'fail-doc';
+      const slugTwo = 'new-doc';
+
+      const errorObject = {
+        error: 'CHANGELOG_INVALID',
+        message: "We couldn't save this changelog (Changelog title cannot be blank).",
+        suggestion: 'Make sure all the data is correct, and the body is valid Markdown.',
+        docs: 'fake-metrics-uuid',
+        help: "If you need help, email support@readme.io and include the following link to your API log: 'fake-metrics-uuid'.",
+      };
+      const doc = frontMatter(fs.readFileSync(path.join(fixturesDir, `/${folder}/${slug}.md`)));
+      const docTwo = frontMatter(fs.readFileSync(path.join(fixturesDir, `/${folder}/${slugTwo}.md`)));
+
+      const hash = hashFileContents(fs.readFileSync(path.join(fixturesDir, `/${folder}/${slug}.md`)));
+      const hashTwo = hashFileContents(fs.readFileSync(path.join(fixturesDir, `/${folder}/${slugTwo}.md`)));
+
+      const getMocks = getApiNock()
+        .get(`/api/v1/changelogs/${slug}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'CHANGELOG_NOTFOUND',
+          message: `The changelog with the slug '${slug}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        })
+        .get(`/api/v1/changelogs/${slugTwo}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'CHANGELOG_NOTFOUND',
+          message: `The changelog with the slug '${slugTwo}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        });
+
+      const postMocks = getApiNock()
+        .post('/api/v1/changelogs', { slug: slugTwo, body: docTwo.content, ...docTwo.data, lastUpdatedHash: hashTwo })
+        .basicAuth({ user: key })
+        .reply(201, {
+          metadata: { image: [], title: '', description: '' },
+          title: 'This is the document title',
+          slug: slugTwo,
+          body: 'Body',
+        })
+        .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
+        .basicAuth({ user: key })
+        .reply(400, errorObject);
+
+      const fullDirectory = `__tests__/__fixtures__/${folder}`;
+
+      const formattedErrorObject = {
+        ...errorObject,
+        message: `Error uploading ${chalk.underline(`${fullDirectory}/${slug}.md`)}:\n\n${errorObject.message}`,
+      };
+
+      await expect(changelogs.run({ folder: `./${fullDirectory}`, key })).rejects.toStrictEqual(
+        new APIError(formattedErrorObject)
+      );
+
+      getMocks.done();
+      postMocks.done();
+    });
+  });
+
+  describe('slug metadata', () => {
+    it('should use provided slug', async () => {
+      const slug = 'new-doc-slug';
+      const doc = frontMatter(fs.readFileSync(path.join(fixturesDir, `/slug-docs/${slug}.md`)));
+      const hash = hashFileContents(fs.readFileSync(path.join(fixturesDir, `/slug-docs/${slug}.md`)));
+
+      const getMock = getApiNock()
+        .get(`/api/v1/changelogs/${doc.data.slug}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'CHANGELOG_NOTFOUND',
+          message: `The changelog with the slug '${slug}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        });
+
+      const postMock = getApiNock()
+        .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
+        .basicAuth({ user: key })
+        .reply(201, { slug: doc.data.slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+
+      await expect(changelogs.run({ folder: './__tests__/__fixtures__/slug-docs', key })).resolves.toBe(
+        "🌱 successfully created 'marc-actually-wrote-a-test' with contents from __tests__/__fixtures__/slug-docs/new-doc-slug.md"
+      );
+
+      getMock.done();
+      postMock.done();
+    });
+  });
+});
+
+describe('rdme changelogs:single', () => {
+  beforeAll(() => nock.disableNetConnect());
+
+  afterAll(() => nock.cleanAll());
+
+  it('should error if no api key provided', () => {
+    return expect(changelogsSingle.run({})).rejects.toThrow('No project API key provided. Please use `--key`.');
+  });
+
+  it('should error if no file path provided', () => {
+    return expect(changelogsSingle.run({ key, version: '1.0.0' })).rejects.toThrow(
+      'No file path provided. Usage `rdme changelogs:single <file> [options]`.'
+    );
+  });
+
+  it('should error if the argument is not a markdown file', async () => {
+    await expect(changelogsSingle.run({ key, version: '1.0.0', filePath: 'not-a-markdown-file' })).rejects.toThrow(
+      'The file path specified is not a markdown file.'
+    );
+  });
+
+  describe('new changelogs', () => {
+    it('should create new changelog', async () => {
+      const slug = 'new-doc';
+      const doc = frontMatter(fs.readFileSync(path.join(fixturesDir, `/new-docs/${slug}.md`)));
+      const hash = hashFileContents(fs.readFileSync(path.join(fixturesDir, `/new-docs/${slug}.md`)));
+
+      const getMock = getApiNock()
+        .get(`/api/v1/changelogs/${slug}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'CHANGELOG_NOTFOUND',
+          message: `The changelog with the slug '${slug}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        });
+
+      const postMock = getApiNock()
+        .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
+        .basicAuth({ user: key })
+        .reply(201, { slug, body: doc.content, ...doc.data });
+
+      await expect(
+        changelogsSingle.run({ filePath: './__tests__/__fixtures__/new-docs/new-doc.md', key })
+      ).resolves.toBe(
+        "🌱 successfully created 'new-doc' with contents from ./__tests__/__fixtures__/new-docs/new-doc.md"
+      );
+
+      getMock.done();
+      postMock.done();
+    });
+
+    it('should return creation info for dry run', async () => {
+      const slug = 'new-doc';
+      const doc = frontMatter(fs.readFileSync(path.join(fixturesDir, `/new-docs/${slug}.md`)));
+
+      const getMock = getApiNock()
+        .get(`/api/v1/changelogs/${slug}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'CHANGELOG_NOTFOUND',
+          message: `The changelog with the slug '${slug}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        });
+
+      await expect(
+        changelogsSingle.run({ dryRun: true, filePath: './__tests__/__fixtures__/new-docs/new-doc.md', key })
+      ).resolves.toBe(
+        `🎭 dry run! This will create 'new-doc' with contents from ./__tests__/__fixtures__/new-docs/new-doc.md with the following metadata: ${JSON.stringify(
+          doc.data
+        )}`
+      );
+
+      getMock.done();
+    });
+
+    it('should fail if the changelog is invalid', async () => {
+      const folder = 'failure-docs';
+      const slug = 'fail-doc';
+
+      const errorObject = {
+        error: 'CHANGELOG_INVALID',
+        message: "We couldn't save this changelog (Changelog title cannot be blank).",
+        suggestion: 'Make sure all the data is correct, and the body is valid Markdown.',
+        docs: 'fake-metrics-uuid',
+        help: "If you need help, email support@readme.io and include the following link to your API log: 'fake-metrics-uuid'.",
+      };
+
+      const doc = frontMatter(fs.readFileSync(path.join(fixturesDir, `/${folder}/${slug}.md`)));
+
+      const hash = hashFileContents(fs.readFileSync(path.join(fixturesDir, `/${folder}/${slug}.md`)));
+
+      const getMock = getApiNock()
+        .get(`/api/v1/changelogs/${slug}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'CHANGELOG_NOTFOUND',
+          message: `The changelog with the slug '${slug}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        });
+
+      const postMock = getApiNock()
+        .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
+        .basicAuth({ user: key })
+        .reply(400, errorObject);
+
+      const filePath = './__tests__/__fixtures__/failure-docs/fail-doc.md';
+
+      const formattedErrorObject = {
+        ...errorObject,
+        message: `Error uploading ${chalk.underline(`${filePath}`)}:\n\n${errorObject.message}`,
+      };
+
+      await expect(changelogsSingle.run({ filePath: `${filePath}`, key })).rejects.toStrictEqual(
+        new APIError(formattedErrorObject)
+      );
+
+      getMock.done();
+      postMock.done();
+    });
+
+    it('should fail if some other error when retrieving page slug', async () => {
+      const slug = 'fail-doc';
+
+      const errorObject = {
+        error: 'INTERNAL_ERROR',
+        message: 'Unknown error (yikes)',
+        suggestion: '...a suggestion to resolve the issue...',
+        help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+      };
+
+      const getMock = getApiNock().get(`/api/v1/changelogs/${slug}`).basicAuth({ user: key }).reply(500, errorObject);
+
+      const filePath = './__tests__/__fixtures__/failure-docs/fail-doc.md';
+
+      const formattedErrorObject = {
+        ...errorObject,
+        message: `Error uploading ${chalk.underline(`${filePath}`)}:\n\n${errorObject.message}`,
+      };
+
+      await expect(changelogsSingle.run({ filePath: `${filePath}`, key })).rejects.toStrictEqual(
+        new APIError(formattedErrorObject)
+      );
+
+      getMock.done();
+    });
+  });
+
+  describe('slug metadata', () => {
+    it('should use provided slug', async () => {
+      const slug = 'new-doc-slug';
+      const doc = frontMatter(fs.readFileSync(path.join(fixturesDir, `/slug-docs/${slug}.md`)));
+      const hash = hashFileContents(fs.readFileSync(path.join(fixturesDir, `/slug-docs/${slug}.md`)));
+
+      const getMock = getApiNock()
+        .get(`/api/v1/changelogs/${doc.data.slug}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'CHANGELOG_NOTFOUND',
+          message: `The changelog with the slug '${slug}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        });
+
+      const postMock = getApiNock()
+        .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
+        .basicAuth({ user: key })
+        .reply(201, { slug: doc.data.slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+
+      await expect(
+        changelogsSingle.run({ filePath: './__tests__/__fixtures__/slug-docs/new-doc-slug.md', key })
+      ).resolves.toBe(
+        "🌱 successfully created 'marc-actually-wrote-a-test' with contents from ./__tests__/__fixtures__/slug-docs/new-doc-slug.md"
+      );
+
+      getMock.done();
+      postMock.done();
+    });
+  });
+
+  describe('existing changelogs', () => {
+    let simpleDoc;
+
+    beforeEach(() => {
+      const fileContents = fs.readFileSync(path.join(fixturesDir, '/existing-docs/simple-doc.md'));
+      simpleDoc = {
+        slug: 'simple-doc',
+        doc: frontMatter(fileContents),
+        hash: hashFileContents(fileContents),
+      };
+    });
+
+    it('should fetch changelog and merge with what is returned', () => {
+      const getMock = getApiNock()
+        .get('/api/v1/changelogs/simple-doc')
+        .basicAuth({ user: key })
+        .reply(200, { slug: simpleDoc.slug, lastUpdatedHash: 'anOldHash' });
+
+      const updateMock = getApiNock()
+        .put('/api/v1/changelogs/simple-doc', {
+          slug: simpleDoc.slug,
+          body: simpleDoc.doc.content,
+          lastUpdatedHash: simpleDoc.hash,
+          ...simpleDoc.doc.data,
+        })
+        .basicAuth({ user: key })
+        .reply(200, {
+          slug: simpleDoc.slug,
+          body: simpleDoc.doc.content,
+        });
+
+      return changelogsSingle
+        .run({ filePath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key })
+        .then(updatedDocs => {
+          expect(updatedDocs).toBe(
+            "✏️ successfully updated 'simple-doc' with contents from ./__tests__/__fixtures__/existing-docs/simple-doc.md"
+          );
+
+          getMock.done();
+          updateMock.done();
+        });
+    });
+
+    it('should return changelog update info for dry run', () => {
+      expect.assertions(1);
+
+      const getMock = getApiNock()
+        .get('/api/v1/changelogs/simple-doc')
+        .basicAuth({ user: key })
+        .reply(200, { slug: simpleDoc.slug, lastUpdatedHash: 'anOldHash' });
+
+      return changelogsSingle
+        .run({ dryRun: true, filePath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key })
+        .then(updatedDocs => {
+          // All changelogs should have been updated because their hashes from the GET request were different from what they
+          // are currently.
+          expect(updatedDocs).toBe(
+            [
+              `🎭 dry run! This will update 'simple-doc' with contents from ./__tests__/__fixtures__/existing-docs/simple-doc.md with the following metadata: ${JSON.stringify(
+                simpleDoc.doc.data
+              )}`,
+            ].join('\n')
+          );
+
+          getMock.done();
+        });
+    });
+
+    it('should not send requests for changelogs that have not changed', () => {
+      expect.assertions(1);
+
+      const getMock = getApiNock()
+        .get('/api/v1/changelogs/simple-doc')
+        .basicAuth({ user: key })
+        .reply(200, { slug: simpleDoc.slug, lastUpdatedHash: simpleDoc.hash });
+
+      return changelogsSingle
+        .run({ filePath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key })
+        .then(skippedDocs => {
+          expect(skippedDocs).toBe('`simple-doc` was not updated because there were no changes.');
+
+          getMock.done();
+        });
+    });
+
+    it('should adjust "no changes" message if in dry run', () => {
+      const getMock = getApiNock()
+        .get('/api/v1/changelogs/simple-doc')
+        .basicAuth({ user: key })
+        .reply(200, { slug: simpleDoc.slug, lastUpdatedHash: simpleDoc.hash });
+
+      return changelogsSingle
+        .run({ dryRun: true, filePath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key })
+        .then(skippedDocs => {
+          expect(skippedDocs).toBe('🎭 dry run! `simple-doc` will not be updated because there were no changes.');
+
+          getMock.done();
+        });
+    });
+  });
+});

--- a/__tests__/cmds/docs.test.js
+++ b/__tests__/cmds/docs.test.js
@@ -554,15 +554,15 @@ describe('rdme docs:single', () => {
     return expect(docsSingle.run({})).rejects.toThrow('No project API key provided. Please use `--key`.');
   });
 
-  it('should error if no filepath provided', () => {
+  it('should error if no file path provided', () => {
     return expect(docsSingle.run({ key, version: '1.0.0' })).rejects.toThrow(
-      'No filepath provided. Usage `rdme docs:single <filepath> [options]`.'
+      'No file path provided. Usage `rdme docs:single <file> [options]`.'
     );
   });
 
   it('should error if the argument is not a markdown file', async () => {
-    await expect(docsSingle.run({ key, version: '1.0.0', filepath: 'not-a-markdown-file' })).rejects.toThrow(
-      'The filepath specified is not a markdown file.'
+    await expect(docsSingle.run({ key, version: '1.0.0', filePath: 'not-a-markdown-file' })).rejects.toThrow(
+      'The file path specified is not a markdown file.'
     );
   });
 
@@ -593,7 +593,7 @@ describe('rdme docs:single', () => {
         .reply(200, { version });
 
       await expect(
-        docsSingle.run({ filepath: './__tests__/__fixtures__/new-docs/new-doc.md', key, version })
+        docsSingle.run({ filePath: './__tests__/__fixtures__/new-docs/new-doc.md', key, version })
       ).resolves.toBe(
         "🌱 successfully created 'new-doc' with contents from ./__tests__/__fixtures__/new-docs/new-doc.md"
       );
@@ -623,7 +623,7 @@ describe('rdme docs:single', () => {
         .reply(200, { version });
 
       await expect(
-        docsSingle.run({ dryRun: true, filepath: './__tests__/__fixtures__/new-docs/new-doc.md', key, version })
+        docsSingle.run({ dryRun: true, filePath: './__tests__/__fixtures__/new-docs/new-doc.md', key, version })
       ).resolves.toBe(
         `🎭 dry run! This will create 'new-doc' with contents from ./__tests__/__fixtures__/new-docs/new-doc.md with the following metadata: ${JSON.stringify(
           doc.data
@@ -667,14 +667,14 @@ describe('rdme docs:single', () => {
         .basicAuth({ user: key })
         .reply(200, { version });
 
-      const filepath = './__tests__/__fixtures__/failure-docs/fail-doc.md';
+      const filePath = './__tests__/__fixtures__/failure-docs/fail-doc.md';
 
       const formattedErrorObject = {
         ...errorObject,
-        message: `Error uploading ${chalk.underline(`${filepath}`)}:\n\n${errorObject.message}`,
+        message: `Error uploading ${chalk.underline(`${filePath}`)}:\n\n${errorObject.message}`,
       };
 
-      await expect(docsSingle.run({ filepath: `${filepath}`, key, version })).rejects.toStrictEqual(
+      await expect(docsSingle.run({ filePath: `${filePath}`, key, version })).rejects.toStrictEqual(
         new APIError(formattedErrorObject)
       );
 
@@ -703,14 +703,14 @@ describe('rdme docs:single', () => {
         .basicAuth({ user: key })
         .reply(200, { version });
 
-      const filepath = './__tests__/__fixtures__/failure-docs/fail-doc.md';
+      const filePath = './__tests__/__fixtures__/failure-docs/fail-doc.md';
 
       const formattedErrorObject = {
         ...errorObject,
-        message: `Error uploading ${chalk.underline(`${filepath}`)}:\n\n${errorObject.message}`,
+        message: `Error uploading ${chalk.underline(`${filePath}`)}:\n\n${errorObject.message}`,
       };
 
-      await expect(docsSingle.run({ filepath: `${filepath}`, key, version })).rejects.toStrictEqual(
+      await expect(docsSingle.run({ filePath: `${filePath}`, key, version })).rejects.toStrictEqual(
         new APIError(formattedErrorObject)
       );
 
@@ -746,7 +746,7 @@ describe('rdme docs:single', () => {
         .reply(200, { version });
 
       await expect(
-        docsSingle.run({ filepath: './__tests__/__fixtures__/slug-docs/new-doc-slug.md', key, version })
+        docsSingle.run({ filePath: './__tests__/__fixtures__/slug-docs/new-doc-slug.md', key, version })
       ).resolves.toBe(
         "🌱 successfully created 'marc-actually-wrote-a-test' with contents from ./__tests__/__fixtures__/slug-docs/new-doc-slug.md"
       );
@@ -796,7 +796,7 @@ describe('rdme docs:single', () => {
         .reply(200, { version });
 
       return docsSingle
-        .run({ filepath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
+        .run({ filePath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
         .then(updatedDocs => {
           expect(updatedDocs).toBe(
             "✏️ successfully updated 'simple-doc' with contents from ./__tests__/__fixtures__/existing-docs/simple-doc.md"
@@ -822,7 +822,7 @@ describe('rdme docs:single', () => {
         .reply(200, { version });
 
       return docsSingle
-        .run({ dryRun: true, filepath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
+        .run({ dryRun: true, filePath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
         .then(updatedDocs => {
           // All docs should have been updated because their hashes from the GET request were different from what they
           // are currently.
@@ -853,7 +853,7 @@ describe('rdme docs:single', () => {
         .reply(200, { version });
 
       return docsSingle
-        .run({ filepath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
+        .run({ filePath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
         .then(skippedDocs => {
           expect(skippedDocs).toBe('`simple-doc` was not updated because there were no changes.');
 
@@ -874,7 +874,7 @@ describe('rdme docs:single', () => {
         .reply(200, { version });
 
       return docsSingle
-        .run({ dryRun: true, filepath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
+        .run({ dryRun: true, filePath: './__tests__/__fixtures__/existing-docs/simple-doc.md', key, version })
         .then(skippedDocs => {
           expect(skippedDocs).toBe('🎭 dry run! `simple-doc` will not be updated because there were no changes.');
 

--- a/src/cmds/changelogs/index.js
+++ b/src/cmds/changelogs/index.js
@@ -1,0 +1,81 @@
+const chalk = require('chalk');
+const config = require('config');
+const fs = require('fs');
+const path = require('path');
+
+const { debug } = require('../../lib/logger');
+const pushDoc = require('../../lib/pushDoc');
+
+module.exports = class ChangelogsCommand {
+  constructor() {
+    this.command = 'changelogs';
+    this.usage = 'changelogs <folder> [options]';
+    this.description = 'Sync a folder of Markdown files to your ReadMe project as Changelog posts.';
+    this.category = 'changelogs';
+    this.position = 1;
+
+    this.hiddenArgs = ['folder'];
+    this.args = [
+      {
+        name: 'key',
+        type: String,
+        description: 'Project API key',
+      },
+      {
+        name: 'folder',
+        type: String,
+        defaultOption: true,
+      },
+      {
+        name: 'dryRun',
+        type: Boolean,
+        description: 'Runs the command without creating/updating any changelogs in ReadMe. Useful for debugging.',
+      },
+    ];
+  }
+
+  async run(opts) {
+    const { dryRun, folder, key } = opts;
+
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
+
+    if (!key) {
+      return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
+    }
+
+    if (!folder) {
+      return Promise.reject(new Error(`No folder provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
+    }
+
+    // Find the files to sync
+    const readdirRecursive = folderToSearch => {
+      const filesInFolder = fs.readdirSync(folderToSearch, { withFileTypes: true });
+      const files = filesInFolder
+        .filter(fileHandle => fileHandle.isFile())
+        .map(fileHandle => path.join(folderToSearch, fileHandle.name));
+      const folders = filesInFolder.filter(fileHandle => fileHandle.isDirectory());
+      const subFiles = [].concat(
+        ...folders.map(fileHandle => readdirRecursive(path.join(folderToSearch, fileHandle.name)))
+      );
+      return [...files, ...subFiles];
+    };
+
+    // Strip out non-markdown files
+    const files = readdirRecursive(folder).filter(file => file.endsWith('.md') || file.endsWith('.markdown'));
+
+    debug(`number of files: ${files.length}`);
+
+    if (!files.length) {
+      return Promise.reject(new Error(`We were unable to locate Markdown files in ${folder}.`));
+    }
+
+    const updatedDocs = await Promise.all(
+      files.map(async filename => {
+        return pushDoc(key, undefined, dryRun, filename, this.category);
+      })
+    );
+
+    return chalk.green(updatedDocs.join('\n'));
+  }
+};

--- a/src/cmds/changelogs/single.js
+++ b/src/cmds/changelogs/single.js
@@ -1,0 +1,56 @@
+const chalk = require('chalk');
+const config = require('config');
+
+const { debug } = require('../../lib/logger');
+const pushDoc = require('../../lib/pushDoc');
+
+module.exports = class SingleChangelogCommand {
+  constructor() {
+    this.command = 'changelogs:single';
+    this.usage = 'changelogs:single <file> [options]';
+    this.description = 'Sync a single Markdown file to your ReadMe project as a Changelog post.';
+    this.category = 'changelogs';
+    this.position = 3;
+
+    this.hiddenArgs = ['filePath'];
+    this.args = [
+      {
+        name: 'key',
+        type: String,
+        description: 'Project API key',
+      },
+      {
+        name: 'filePath',
+        type: String,
+        defaultOption: true,
+      },
+      {
+        name: 'dryRun',
+        type: Boolean,
+        description: 'Runs the command without creating/updating any changelogs in ReadMe. Useful for debugging.',
+      },
+    ];
+  }
+
+  async run(opts) {
+    const { dryRun, filePath, key } = opts;
+    debug(`command: ${this.command}`);
+    debug(`opts: ${JSON.stringify(opts)}`);
+
+    if (!key) {
+      return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
+    }
+
+    if (!filePath) {
+      return Promise.reject(new Error(`No file path provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
+    }
+
+    if (filePath.endsWith('.md') === false || !filePath.endsWith('.markdown') === false) {
+      return Promise.reject(new Error('The file path specified is not a markdown file.'));
+    }
+
+    const createdDoc = await pushDoc(key, undefined, dryRun, filePath, this.category);
+
+    return chalk.green(createdDoc);
+  }
+};

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -85,7 +85,7 @@ module.exports = class DocsCommand {
 
     const updatedDocs = await Promise.all(
       files.map(async filename => {
-        return pushDoc(key, selectedVersion, dryRun, filename);
+        return pushDoc(key, selectedVersion, dryRun, filename, this.category);
       })
     );
 

--- a/src/cmds/docs/single.js
+++ b/src/cmds/docs/single.js
@@ -8,12 +8,12 @@ const pushDoc = require('../../lib/pushDoc');
 module.exports = class SingleDocCommand {
   constructor() {
     this.command = 'docs:single';
-    this.usage = 'docs:single <filepath> [options]';
+    this.usage = 'docs:single <file> [options]';
     this.description = 'Sync a single Markdown file to your ReadMe project.';
     this.category = 'docs';
     this.position = 3;
 
-    this.hiddenArgs = ['filepath'];
+    this.hiddenArgs = ['filePath'];
     this.args = [
       {
         name: 'key',
@@ -26,7 +26,7 @@ module.exports = class SingleDocCommand {
         description: 'Project version',
       },
       {
-        name: 'filepath',
+        name: 'filePath',
         type: String,
         defaultOption: true,
       },
@@ -39,7 +39,7 @@ module.exports = class SingleDocCommand {
   }
 
   async run(opts) {
-    const { dryRun, filepath, key, version } = opts;
+    const { dryRun, filePath, key, version } = opts;
     debug(`command: ${this.command}`);
     debug(`opts: ${JSON.stringify(opts)}`);
 
@@ -47,12 +47,12 @@ module.exports = class SingleDocCommand {
       return Promise.reject(new Error('No project API key provided. Please use `--key`.'));
     }
 
-    if (!filepath) {
-      return Promise.reject(new Error(`No filepath provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
+    if (!filePath) {
+      return Promise.reject(new Error(`No file path provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
     }
 
-    if (filepath.endsWith('.md') === false || !filepath.endsWith('.markdown') === false) {
-      return Promise.reject(new Error('The filepath specified is not a markdown file.'));
+    if (filePath.endsWith('.md') === false || !filePath.endsWith('.markdown') === false) {
+      return Promise.reject(new Error('The file path specified is not a markdown file.'));
     }
 
     // TODO: should we allow version selection at all here?
@@ -62,7 +62,7 @@ module.exports = class SingleDocCommand {
 
     debug(`selectedVersion: ${selectedVersion}`);
 
-    const createdDoc = await pushDoc(key, selectedVersion, dryRun, filepath, this.category);
+    const createdDoc = await pushDoc(key, selectedVersion, dryRun, filePath, this.category);
 
     return chalk.green(createdDoc);
   }

--- a/src/cmds/docs/single.js
+++ b/src/cmds/docs/single.js
@@ -62,7 +62,7 @@ module.exports = class SingleDocCommand {
 
     debug(`selectedVersion: ${selectedVersion}`);
 
-    const createdDoc = await pushDoc(key, selectedVersion, dryRun, filepath);
+    const createdDoc = await pushDoc(key, selectedVersion, dryRun, filepath, this.category);
 
     return chalk.green(createdDoc);
   }

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -68,10 +68,6 @@ exports.list = () => {
 
 exports.getCategories = () => {
   return {
-    admin: {
-      description: 'Administration',
-      commands: [],
-    },
     apis: {
       description: 'Upload OpenAPI/Swagger definitions',
       commands: [],
@@ -80,12 +76,20 @@ exports.getCategories = () => {
       description: 'Documentation',
       commands: [],
     },
-    versions: {
-      description: 'Versions',
+    changelogs: {
+      description: 'Changelog',
       commands: [],
     },
     categories: {
       description: 'Categories',
+      commands: [],
+    },
+    versions: {
+      description: 'Versions',
+      commands: [],
+    },
+    admin: {
+      description: 'Administration',
       commands: [],
     },
     utilities: {

--- a/src/lib/pushDoc.js
+++ b/src/lib/pushDoc.js
@@ -18,10 +18,11 @@ const { debug } = require('./logger');
  * @param {String} selectedVersion the project version
  * @param {Boolean} dryRun boolean indicating dry run mode
  * @param {String} filepath path to the Markdown file
+ * @param {String} type module within ReadMe to update (e.g. docs, changelogs, etc.)
  *  (file extension must end in `.md` or `.markdown`)
  * @returns {Promise<String>} a string containing the result
  */
-module.exports = async function pushDoc(key, selectedVersion, dryRun, filepath) {
+module.exports = async function pushDoc(key, selectedVersion, dryRun, filepath, type) {
   debug(`reading file ${filepath}`);
   const file = fs.readFileSync(filepath, 'utf8');
   const matter = grayMatter(file);
@@ -31,16 +32,14 @@ module.exports = async function pushDoc(key, selectedVersion, dryRun, filepath) 
   const slug = matter.data.slug || path.basename(filepath).replace(path.extname(filepath), '').toLowerCase();
   const hash = crypto.createHash('sha1').update(file).digest('hex');
 
-  function createDoc(err) {
-    if (err.error !== 'DOC_NOTFOUND') return Promise.reject(new APIError(err));
-
+  function createDoc() {
     if (dryRun) {
       return `🎭 dry run! This will create '${slug}' with contents from ${filepath} with the following metadata: ${JSON.stringify(
         matter.data
       )}`;
     }
 
-    return fetch(`${config.get('host')}/api/v1/docs`, {
+    return fetch(`${config.get('host')}/api/v1/${type}`, {
       method: 'post',
       headers: cleanHeaders(key, {
         'x-readme-version': selectedVersion,
@@ -70,7 +69,7 @@ module.exports = async function pushDoc(key, selectedVersion, dryRun, filepath) 
       )}`;
     }
 
-    return fetch(`${config.get('host')}/api/v1/docs/${slug}`, {
+    return fetch(`${config.get('host')}/api/v1/${type}/${slug}`, {
       method: 'put',
       headers: cleanHeaders(key, {
         'x-readme-version': selectedVersion,
@@ -88,22 +87,23 @@ module.exports = async function pushDoc(key, selectedVersion, dryRun, filepath) 
       .then(res => `✏️ successfully updated '${res.slug}' with contents from ${filepath}`);
   }
 
-  return fetch(`${config.get('host')}/api/v1/docs/${slug}`, {
+  return fetch(`${config.get('host')}/api/v1/${type}/${slug}`, {
     method: 'get',
     headers: cleanHeaders(key, {
       'x-readme-version': selectedVersion,
       Accept: 'application/json',
     }),
   })
-    .then(res => res.json())
-    .then(res => {
-      debug(`GET /docs/:slug API response for ${slug}: ${JSON.stringify(res)}`);
-      if (res.error) {
+    .then(async res => {
+      const body = await res.json();
+      debug(`GET /${type}/:slug API response for ${slug}: ${JSON.stringify(body)}`);
+      if (!res.ok) {
+        if (res.status !== 404) return Promise.reject(new APIError(body));
         debug(`error retrieving data for ${slug}, creating doc`);
-        return createDoc(res);
+        return createDoc(body);
       }
       debug(`data received for ${slug}, updating doc`);
-      return updateDoc(res);
+      return updateDoc(body);
     })
     .catch(err => {
       // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
| 🚥 Fix #278  RM-4888 |
| :-- |

## 🧰 Changes

Adds `changelogs` and `changelogs:single` endpoints. Per the refactors in #540, this is a really lightweight wrapper around existing functionality.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
