### PR TITLE
refactor: rename `category` to `cmdCategory` in `Command` class

### DIFF
--- a/__tests__/lib/commands.test.js
+++ b/__tests__/lib/commands.test.js
@@ -15,7 +15,7 @@ describe('utils', () => {
           expect(typeof cmd.command === 'string' && cmd.command.length !== 0).toBe(true);
           expect(typeof cmd.usage === 'string' && cmd.usage.length !== 0).toBe(true);
           expect(typeof cmd.description === 'string' && cmd.usage.description !== 0).toBe(true);
-          expect(typeof cmd.category === 'string' && cmd.usage.category !== 0).toBe(true);
+          expect(typeof cmd.cmdCategory === 'string' && cmd.usage.cmdCategory !== 0).toBe(true);
           expect(typeof cmd.position === 'number' && cmd.usage.position !== 0).toBe(true);
           expect(Array.isArray(cmd.args)).toBe(true);
           expect(typeof cmd.run === 'function').toBe(true);

--- a/bin/rdme
+++ b/bin/rdme
@@ -1,5 +1,4 @@
 #! /usr/bin/env node
-/* eslint-disable no-console */
 const chalk = require('chalk');
 const core = require('@actions/core');
 
@@ -18,12 +17,14 @@ updateNotifier({ pkg }).notify();
  */
 if (!isSupportedNodeVersion(process.version)) {
   const message = `We're sorry, this release of rdme does not support Node.js ${process.version}. We support the following versions: ${pkg.engines.node}`;
+  // eslint-disable-next-line no-console
   console.error(chalk.red(`\n${message}\n`));
   process.exit(1);
 }
 
 require('../src')(process.argv.slice(2))
   .then(msg => {
+    // eslint-disable-next-line no-console
     if (msg) console.log(msg);
     return process.exit(0);
   })
@@ -46,6 +47,7 @@ require('../src')(process.argv.slice(2))
       return core.setFailed(message);
     }
 
+    // eslint-disable-next-line no-console
     console.error(chalk.red(`\n${message}\n`));
     return process.exit(1);
   });

--- a/src/cmds/categories/create.js
+++ b/src/cmds/categories/create.js
@@ -11,7 +11,7 @@ module.exports = class CategoriesCreateCommand {
     this.command = 'categories:create';
     this.usage = 'categories:create <title> [options]';
     this.description = 'Create a category with the specified title and guide in your ReadMe project';
-    this.category = 'categories';
+    this.cmdCategory = 'categories';
     this.position = 2;
 
     this.hiddenargs = ['title'];

--- a/src/cmds/categories/index.js
+++ b/src/cmds/categories/index.js
@@ -7,7 +7,7 @@ module.exports = class CategoriesCommand {
     this.command = 'categories';
     this.usage = 'categories [options]';
     this.description = 'Get all categories in your ReadMe project';
-    this.category = 'categories';
+    this.cmdCategory = 'categories';
     this.position = 1;
 
     this.args = [

--- a/src/cmds/changelogs/index.js
+++ b/src/cmds/changelogs/index.js
@@ -11,7 +11,7 @@ module.exports = class ChangelogsCommand {
     this.command = 'changelogs';
     this.usage = 'changelogs <folder> [options]';
     this.description = 'Sync a folder of Markdown files to your ReadMe project as Changelog posts.';
-    this.category = 'changelogs';
+    this.cmdCategory = 'changelogs';
     this.position = 1;
 
     this.hiddenArgs = ['folder'];
@@ -72,7 +72,7 @@ module.exports = class ChangelogsCommand {
 
     const updatedDocs = await Promise.all(
       files.map(async filename => {
-        return pushDoc(key, undefined, dryRun, filename, this.category);
+        return pushDoc(key, undefined, dryRun, filename, this.cmdCategory);
       })
     );
 

--- a/src/cmds/changelogs/single.js
+++ b/src/cmds/changelogs/single.js
@@ -9,7 +9,7 @@ module.exports = class SingleChangelogCommand {
     this.command = 'changelogs:single';
     this.usage = 'changelogs:single <file> [options]';
     this.description = 'Sync a single Markdown file to your ReadMe project as a Changelog post.';
-    this.category = 'changelogs';
+    this.cmdCategory = 'changelogs';
     this.position = 3;
 
     this.hiddenArgs = ['filePath'];
@@ -49,7 +49,7 @@ module.exports = class SingleChangelogCommand {
       return Promise.reject(new Error('The file path specified is not a markdown file.'));
     }
 
-    const createdDoc = await pushDoc(key, undefined, dryRun, filePath, this.category);
+    const createdDoc = await pushDoc(key, undefined, dryRun, filePath, this.cmdCategory);
 
     return chalk.green(createdDoc);
   }

--- a/src/cmds/docs/edit.js
+++ b/src/cmds/docs/edit.js
@@ -17,7 +17,7 @@ module.exports = class EditDocsCommand {
     this.command = 'docs:edit';
     this.usage = 'docs:edit <slug> [options]';
     this.description = 'Edit a single file from your ReadMe project without saving locally.';
-    this.category = 'docs';
+    this.cmdCategory = 'docs';
     this.position = 2;
 
     this.hiddenArgs = ['slug'];

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -12,7 +12,7 @@ module.exports = class DocsCommand {
     this.command = 'docs';
     this.usage = 'docs <folder> [options]';
     this.description = 'Sync a folder of Markdown files to your ReadMe project.';
-    this.category = 'docs';
+    this.cmdCategory = 'docs';
     this.position = 1;
 
     this.hiddenArgs = ['folder'];
@@ -85,7 +85,7 @@ module.exports = class DocsCommand {
 
     const updatedDocs = await Promise.all(
       files.map(async filename => {
-        return pushDoc(key, selectedVersion, dryRun, filename, this.category);
+        return pushDoc(key, selectedVersion, dryRun, filename, this.cmdCategory);
       })
     );
 

--- a/src/cmds/docs/single.js
+++ b/src/cmds/docs/single.js
@@ -10,7 +10,7 @@ module.exports = class SingleDocCommand {
     this.command = 'docs:single';
     this.usage = 'docs:single <file> [options]';
     this.description = 'Sync a single Markdown file to your ReadMe project.';
-    this.category = 'docs';
+    this.cmdCategory = 'docs';
     this.position = 3;
 
     this.hiddenArgs = ['filePath'];
@@ -62,7 +62,7 @@ module.exports = class SingleDocCommand {
 
     debug(`selectedVersion: ${selectedVersion}`);
 
-    const createdDoc = await pushDoc(key, selectedVersion, dryRun, filePath, this.category);
+    const createdDoc = await pushDoc(key, selectedVersion, dryRun, filePath, this.cmdCategory);
 
     return chalk.green(createdDoc);
   }

--- a/src/cmds/login.js
+++ b/src/cmds/login.js
@@ -15,7 +15,7 @@ module.exports = class LoginCommand {
     this.command = 'login';
     this.usage = 'login [options]';
     this.description = 'Login to a ReadMe project.';
-    this.category = 'admin';
+    this.cmdCategory = 'admin';
     this.position = 1;
 
     this.args = [

--- a/src/cmds/logout.js
+++ b/src/cmds/logout.js
@@ -7,7 +7,7 @@ module.exports = class LogoutCommand {
     this.command = 'logout';
     this.usage = 'logout';
     this.description = 'Logs the currently authenticated user out of ReadMe.';
-    this.category = 'admin';
+    this.cmdCategory = 'admin';
     this.position = 2;
 
     this.args = [];

--- a/src/cmds/oas.js
+++ b/src/cmds/oas.js
@@ -5,7 +5,7 @@ module.exports = class OASCommand {
     this.command = 'oas';
     this.usage = 'oas';
     this.description = 'Helpful OpenAPI generation tooling. [inactive]';
-    this.category = 'utilities';
+    this.cmdCategory = 'utilities';
     this.position = 1;
 
     this.args = [];

--- a/src/cmds/open.js
+++ b/src/cmds/open.js
@@ -9,7 +9,7 @@ module.exports = class OpenCommand {
     this.command = 'open';
     this.usage = 'open';
     this.description = 'Open your current ReadMe project in the browser.';
-    this.category = 'utilities';
+    this.cmdCategory = 'utilities';
     this.position = 2;
 
     this.args = [];

--- a/src/cmds/openapi.js
+++ b/src/cmds/openapi.js
@@ -19,7 +19,7 @@ module.exports = class OpenAPICommand {
     this.command = 'openapi';
     this.usage = 'openapi [file] [options]';
     this.description = 'Upload, or resync, your OpenAPI/Swagger definition to ReadMe.';
-    this.category = 'apis';
+    this.cmdCategory = 'apis';
     this.position = 1;
 
     this.hiddenArgs = ['token', 'spec'];

--- a/src/cmds/validate.js
+++ b/src/cmds/validate.js
@@ -8,7 +8,7 @@ module.exports = class ValidateCommand {
     this.command = 'validate';
     this.usage = 'validate [file] [options]';
     this.description = 'Validate your OpenAPI/Swagger definition.';
-    this.category = 'apis';
+    this.cmdCategory = 'apis';
     this.position = 2;
 
     this.hiddenArgs = ['spec'];

--- a/src/cmds/versions/create.js
+++ b/src/cmds/versions/create.js
@@ -11,7 +11,7 @@ module.exports = class CreateVersionCommand {
     this.command = 'versions:create';
     this.usage = 'versions:create --version=<version> [options]';
     this.description = 'Create a new version for your project.';
-    this.category = 'versions';
+    this.cmdCategory = 'versions';
     this.position = 2;
 
     this.hiddenArgs = ['version'];

--- a/src/cmds/versions/delete.js
+++ b/src/cmds/versions/delete.js
@@ -9,7 +9,7 @@ module.exports = class DeleteVersionCommand {
     this.command = 'versions:delete';
     this.usage = 'versions:delete --version=<version> [options]';
     this.description = 'Delete a version associated with your ReadMe project.';
-    this.category = 'versions';
+    this.cmdCategory = 'versions';
     this.position = 4;
 
     this.hiddenArgs = ['version'];

--- a/src/cmds/versions/index.js
+++ b/src/cmds/versions/index.js
@@ -11,7 +11,7 @@ module.exports = class VersionsCommand {
     this.command = 'versions';
     this.usage = 'versions [options]';
     this.description = 'List versions available in your project or get a version by SemVer (https://semver.org/).';
-    this.category = 'versions';
+    this.cmdCategory = 'versions';
     this.position = 1;
 
     this.args = [

--- a/src/cmds/versions/update.js
+++ b/src/cmds/versions/update.js
@@ -11,7 +11,7 @@ module.exports = class UpdateVersionCommand {
     this.command = 'versions:update';
     this.usage = 'versions:update --version=<version> [options]';
     this.description = 'Update an existing version for your project.';
-    this.category = 'versions';
+    this.cmdCategory = 'versions';
     this.position = 3;
 
     this.args = [

--- a/src/cmds/whoami.js
+++ b/src/cmds/whoami.js
@@ -8,7 +8,7 @@ module.exports = class WhoAmICommand {
     this.command = 'whoami';
     this.usage = 'whoami';
     this.description = 'Displays the current user and project authenticated with ReadMe.';
-    this.category = 'admin';
+    this.cmdCategory = 'admin';
     this.position = 3;
 
     this.args = [];

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -22,7 +22,7 @@ exports.listByCategory = () => {
   const categories = exports.getCategories();
   const cmds = exports.list();
   cmds.forEach(c => {
-    categories[c.command.category].commands.push({
+    categories[c.command.cmdCategory].commands.push({
       name: c.command.command,
       description: c.command.description,
       position: c.command.position,
@@ -32,9 +32,9 @@ exports.listByCategory = () => {
   return categories;
 };
 
-exports.getSimilar = (category, excludeCommand) => {
+exports.getSimilar = (cmdCategory, excludeCommand) => {
   const categories = exports.listByCategory();
-  return categories[category].commands.filter(cmd => cmd.name !== excludeCommand);
+  return categories[cmdCategory].commands.filter(cmd => cmd.name !== excludeCommand);
 };
 
 exports.list = () => {

--- a/src/lib/help.js
+++ b/src/lib/help.js
@@ -67,7 +67,7 @@ exports.commandUsage = cmd => {
     },
   ];
 
-  const similarCommands = commands.getSimilar(cmd.category, cmd.command);
+  const similarCommands = commands.getSimilar(cmd.cmdCategory, cmd.command);
   if (similarCommands.length) {
     helpContent.push({
       header: 'Related commands',


### PR DESCRIPTION
| 🚥 Fix RM-4913 |
| :-- |

## 🧰 Changes

Per feedback from Jon, renames a field our `Command` class from `category` to `cmdCategory`. It's a bit confusing given the "category" terminology in the ReadMe and `rdme` ecosystem.

Also made a tiny ESLint disable change in our `bin/rdme` file—see https://github.com/readmeio/rdme/commit/3fbf38f45bb3212d1efa65ab76f09ed7fa22033e for the reasoning.

## 🧬 QA & Testing

I ran any commands that I think would be affected (e.g. `bin/rdme`, `bin/rdme openapi --help`, etc.) and tests are passing now... our test suite is pretty comprehensive so I can't think of anything else that would break, but fingers crossed 😬 
