### PR TITLE
feat: add retag-release workflow to add a vX.Y.Z tag for our GitHub Action

### DIFF
--- a/.github/workflows/retag-release.yaml
+++ b/.github/workflows/retag-release.yaml
@@ -1,0 +1,53 @@
+# This script adds a "vX.Y.Z" tag to every new release.
+#
+# Our releases are tagged like "1.2.3" but we want people to be able to write
+# GitHub Action workflows to say "uses: readmeio/readme@v1.2.3" because that's
+# the usual GitHub convention.
+
+name: retag-release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  retag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6.1.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const oldTag = context.payload.release.tag_name;
+            if (!oldTag.match(/^[0-9]+\.[0-9]+\.[0-9]+$/)) {
+              console.log('Not retagging this release: This script will only retag releases that use');
+              console.log(`semantic versioning, like "1.2.3", but this release's tag is "${oldTag}".`);
+              return;
+            }
+            const newTag = `v${oldTag}`;
+            console.log(`Retagging release "${oldTag}" as "${newTag}".`);
+
+            const oldRef = await github.rest.git.getRef({
+              owner,
+              repo,
+              ref: `tags/${oldTag}`,
+            });
+            if (oldRef.status < 200 || oldRef.status >= 400) {
+              console.log(oldRef);
+              throw new Error(`GitHub API call returned HTTP status code ${oldRef.status}`);
+            }
+            const sha = oldRef.data.object.sha;
+            console.log(`Found tag "${oldTag}"; commit hash is ${sha}`);
+
+            console.log(`Creating tag "${newTag}" pointing to commit hash ${sha}...`);
+            const newRef = await github.rest.git.createRef({
+              owner,
+              repo,
+              ref: `refs/tags/${newTag}`,
+              sha,
+            });
+            if (newRef.status < 200 || newRef.status >= 400) {
+              console.log(newRef);
+              throw new Error(`GitHub API call returned HTTP status code ${newRef.status}`);
+            }
+            console.log('Successfully retagged this release.');

--- a/.github/workflows/retag-release.yaml
+++ b/.github/workflows/retag-release.yaml
@@ -14,40 +14,7 @@ jobs:
   retag-release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/github-script@v6
         with:
-          script: |
-            const { owner, repo } = context.repo;
-            const oldTag = context.payload.release.tag_name;
-            if (!oldTag.match(/^[0-9]+\.[0-9]+\.[0-9]+$/)) {
-              console.log('Not retagging this release: This script will only retag releases that use');
-              console.log(`semantic versioning, like "1.2.3", but this release's tag is "${oldTag}".`);
-              return;
-            }
-            const newTag = `v${oldTag}`;
-            console.log(`Retagging release "${oldTag}" as "${newTag}".`);
-
-            const oldRef = await github.rest.git.getRef({
-              owner,
-              repo,
-              ref: `tags/${oldTag}`,
-            });
-            if (oldRef.status < 200 || oldRef.status >= 400) {
-              console.log(oldRef);
-              throw new Error(`GitHub API call returned HTTP status code ${oldRef.status}`);
-            }
-            const sha = oldRef.data.object.sha;
-            console.log(`Found tag "${oldTag}"; commit hash is ${sha}`);
-
-            console.log(`Creating tag "${newTag}" pointing to commit hash ${sha}...`);
-            const newRef = await github.rest.git.createRef({
-              owner,
-              repo,
-              ref: `refs/tags/${newTag}`,
-              sha,
-            });
-            if (newRef.status < 200 || newRef.status >= 400) {
-              console.log(newRef);
-              throw new Error(`GitHub API call returned HTTP status code ${newRef.status}`);
-            }
-            console.log('Successfully retagged this release.');
+          script: require('./bin/retag-release.js')(github, context);

--- a/.github/workflows/retag-release.yaml
+++ b/.github/workflows/retag-release.yaml
@@ -14,7 +14,7 @@ jobs:
   retag-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6.1.0
+      - uses: actions/github-script@v6
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/bin/retag-release.js
+++ b/bin/retag-release.js
@@ -1,10 +1,11 @@
+/* eslint-disable no-console */
 module.exports = async (github, context) => {
   const { owner, repo } = context.repo;
   const oldTag = context.payload.release.tag_name;
   if (!oldTag.match(/^[0-9]+\.[0-9]+\.[0-9]+$/)) {
     console.log('Not retagging this release: This script will only retag releases that use');
     console.log(`semantic versioning, like "1.2.3", but this release's tag is "${oldTag}".`);
-    return;
+    return {};
   }
   const newTag = `v${oldTag}`;
   console.log(`Retagging release "${oldTag}" as "${newTag}".`);
@@ -36,6 +37,6 @@ module.exports = async (github, context) => {
   return {
     original_tag: oldTag,
     new_tag: newTag,
-    sha
+    sha,
   };
-}
+};

--- a/bin/retag-release.js
+++ b/bin/retag-release.js
@@ -1,0 +1,41 @@
+module.exports = async (github, context) => {
+  const { owner, repo } = context.repo;
+  const oldTag = context.payload.release.tag_name;
+  if (!oldTag.match(/^[0-9]+\.[0-9]+\.[0-9]+$/)) {
+    console.log('Not retagging this release: This script will only retag releases that use');
+    console.log(`semantic versioning, like "1.2.3", but this release's tag is "${oldTag}".`);
+    return;
+  }
+  const newTag = `v${oldTag}`;
+  console.log(`Retagging release "${oldTag}" as "${newTag}".`);
+
+  const oldRef = await github.rest.git.getRef({
+    owner,
+    repo,
+    ref: `tags/${oldTag}`,
+  });
+  if (oldRef.status < 200 || oldRef.status >= 400) {
+    console.log(oldRef);
+    throw new Error(`GitHub API call returned HTTP status code ${oldRef.status}`);
+  }
+  const sha = oldRef.data.object.sha;
+  console.log(`Found tag "${oldTag}"; commit hash is ${sha}`);
+
+  console.log(`Creating tag "${newTag}" pointing to commit hash ${sha}...`);
+  const newRef = await github.rest.git.createRef({
+    owner,
+    repo,
+    ref: `refs/tags/${newTag}`,
+    sha,
+  });
+  if (newRef.status < 200 || newRef.status >= 400) {
+    console.log(newRef);
+    throw new Error(`GitHub API call returned HTTP status code ${newRef.status}`);
+  }
+  console.log('Successfully retagged this release.');
+  return {
+    original_tag: oldTag,
+    new_tag: newTag,
+    sha
+  };
+}


### PR DESCRIPTION
| 🚥 Fix RM-4840 |
| :-- |

## 🧰 Changes

The **rdme** GitHub Action required people to write workflows with the line `uses: readmeio/rdme@1.2.3` but GitHub's convention is for action versions to be tagged `v1.2.3`. Because of this some users have written `uses: readme/rdme@v1.2.3` and of course they expect that to work.

This workflow looks for releases created with a tag like `1.2.3` and adds a second tag like `v1.2.3`. It uses [actions/github-script](https://github.com/actions/github-script) which is the simplest way to run a short script in a GitHub workflow. There were some existing third-party actions for adding a tag to a repo, but I didn't really want to rely on a third-party script for something so simple. (Admittedly this was going to be a one-liner but with input validation and HTTP error checking it got a bit longer.)

## 🧬 QA & Testing

Ran this on a little test project and it worked as expected:

<img width="1332" alt="Screen Shot 2022-07-28 at 11 15 10 AM" src="https://user-images.githubusercontent.com/313895/181609803-0dbe04f8-7bfe-408d-9157-7a6ca3872146.png">

Exits early when the tag doesn't follow semantic versioning style, so that we don't create tags like `vv1.2.3` or `vdeprecated`.

<img width="1332" alt="Screen Shot 2022-07-28 at 11 15 01 AM" src="https://user-images.githubusercontent.com/313895/181609826-539658b2-262f-4955-8529-94a761883b31.png">