### PR TITLE
fix(docs/single): support files with `.markdown` extension

### DIFF
--- a/__tests__/cmds/changelogs.test.js
+++ b/__tests__/cmds/changelogs.test.js
@@ -361,9 +361,9 @@ describe('rdme changelogs:single', () => {
     );
   });
 
-  it('should error if the argument is not a markdown file', async () => {
+  it('should error if the argument is not a Markdown file', async () => {
     await expect(changelogsSingle.run({ key, filePath: 'not-a-markdown-file' })).rejects.toThrow(
-      'The file path specified is not a markdown file.'
+      'The file path specified is not a Markdown file.'
     );
   });
 

--- a/__tests__/cmds/changelogs.test.js
+++ b/__tests__/cmds/changelogs.test.js
@@ -32,19 +32,19 @@ describe('rdme changelogs', () => {
   });
 
   it('should error if no folder provided', () => {
-    return expect(changelogs.run({ key, version: '1.0.0' })).rejects.toThrow(
+    return expect(changelogs.run({ key })).rejects.toThrow(
       'No folder provided. Usage `rdme changelogs <folder> [options]`.'
     );
   });
 
-  it('should error if the argument isnt a folder', () => {
-    return expect(changelogs.run({ key, version: '1.0.0', folder: 'not-a-folder' })).rejects.toThrow(
+  it('should error if the argument is not a folder', () => {
+    return expect(changelogs.run({ key, folder: 'not-a-folder' })).rejects.toThrow(
       "ENOENT: no such file or directory, scandir 'not-a-folder'"
     );
   });
 
   it('should error if the folder contains no markdown files', () => {
-    return expect(changelogs.run({ key, version: '1.0.0', folder: '.github/workflows' })).rejects.toThrow(
+    return expect(changelogs.run({ key, folder: '.github/workflows' })).rejects.toThrow(
       'We were unable to locate Markdown files in .github/workflows.'
     );
   });
@@ -356,13 +356,13 @@ describe('rdme changelogs:single', () => {
   });
 
   it('should error if no file path provided', () => {
-    return expect(changelogsSingle.run({ key, version: '1.0.0' })).rejects.toThrow(
+    return expect(changelogsSingle.run({ key })).rejects.toThrow(
       'No file path provided. Usage `rdme changelogs:single <file> [options]`.'
     );
   });
 
   it('should error if the argument is not a markdown file', async () => {
-    await expect(changelogsSingle.run({ key, version: '1.0.0', filePath: 'not-a-markdown-file' })).rejects.toThrow(
+    await expect(changelogsSingle.run({ key, filePath: 'not-a-markdown-file' })).rejects.toThrow(
       'The file path specified is not a markdown file.'
     );
   });

--- a/__tests__/cmds/changelogs.test.js
+++ b/__tests__/cmds/changelogs.test.js
@@ -367,6 +367,12 @@ describe('rdme changelogs:single', () => {
     );
   });
 
+  it('should support .markdown files but error if file path cannot be found', async () => {
+    await expect(changelogsSingle.run({ key, filePath: 'non-existent-file.markdown' })).rejects.toThrow(
+      'ENOENT: no such file or directory'
+    );
+  });
+
   describe('new changelogs', () => {
     it('should create new changelog', async () => {
       const slug = 'new-doc';

--- a/__tests__/cmds/custompages.test.js
+++ b/__tests__/cmds/custompages.test.js
@@ -402,9 +402,9 @@ describe('rdme custompages:single', () => {
     );
   });
 
-  it('should error if the argument is not a markdown file', async () => {
+  it('should error if the argument is not a Markdown file', async () => {
     await expect(customPagesSingle.run({ key, filePath: 'not-a-markdown-file' })).rejects.toStrictEqual(
-      new Error('The file path specified is not a markdown or HTML file.')
+      new Error('The file path specified is not a Markdown or HTML file.')
     );
   });
 

--- a/__tests__/cmds/docs.test.js
+++ b/__tests__/cmds/docs.test.js
@@ -564,9 +564,9 @@ describe('rdme docs:single', () => {
     );
   });
 
-  it('should error if the argument is not a markdown file', async () => {
+  it('should error if the argument is not a Markdown file', async () => {
     await expect(docsSingle.run({ key, version: '1.0.0', filePath: 'not-a-markdown-file' })).rejects.toThrow(
-      'The file path specified is not a markdown file.'
+      'The file path specified is not a Markdown file.'
     );
   });
 

--- a/__tests__/cmds/docs.test.js
+++ b/__tests__/cmds/docs.test.js
@@ -570,6 +570,14 @@ describe('rdme docs:single', () => {
     );
   });
 
+  it('should support .markdown files but error if file path cannot be found', async () => {
+    const versionMock = getApiNock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
+    await expect(docsSingle.run({ key, version: '1.0.0', filePath: 'non-existent-file.markdown' })).rejects.toThrow(
+      'ENOENT: no such file or directory'
+    );
+    versionMock.done();
+  });
+
   describe('new docs', () => {
     it('should create new doc', async () => {
       const slug = 'new-doc';

--- a/__tests__/cmds/docs.test.js
+++ b/__tests__/cmds/docs.test.js
@@ -49,7 +49,7 @@ describe('rdme docs', () => {
     );
   });
 
-  it('should error if the argument isnt a folder', async () => {
+  it('should error if the argument is not a folder', async () => {
     const versionMock = getApiNock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
 
     await expect(docs.run({ key, version: '1.0.0', folder: 'not-a-folder' })).rejects.toThrow(

--- a/src/cmds/changelogs/index.js
+++ b/src/cmds/changelogs/index.js
@@ -62,7 +62,9 @@ module.exports = class ChangelogsCommand {
     };
 
     // Strip out non-markdown files
-    const files = readdirRecursive(folder).filter(file => file.endsWith('.md') || file.endsWith('.markdown'));
+    const files = readdirRecursive(folder).filter(
+      file => file.toLowerCase().endsWith('.md') || file.toLowerCase().endsWith('.markdown')
+    );
 
     debug(`number of files: ${files.length}`);
 

--- a/src/cmds/changelogs/single.js
+++ b/src/cmds/changelogs/single.js
@@ -45,7 +45,7 @@ module.exports = class SingleChangelogCommand {
       return Promise.reject(new Error(`No file path provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
     }
 
-    if (!(filePath.endsWith('.md') || filePath.endsWith('.markdown'))) {
+    if (!(filePath.toLowerCase().endsWith('.md') || filePath.toLowerCase().endsWith('.markdown'))) {
       return Promise.reject(new Error('The file path specified is not a Markdown file.'));
     }
 

--- a/src/cmds/changelogs/single.js
+++ b/src/cmds/changelogs/single.js
@@ -45,7 +45,7 @@ module.exports = class SingleChangelogCommand {
       return Promise.reject(new Error(`No file path provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
     }
 
-    if (filePath.endsWith('.md') === false || !filePath.endsWith('.markdown') === false) {
+    if (!(filePath.endsWith('.md') || filePath.endsWith('.markdown'))) {
       return Promise.reject(new Error('The file path specified is not a markdown file.'));
     }
 

--- a/src/cmds/changelogs/single.js
+++ b/src/cmds/changelogs/single.js
@@ -46,7 +46,7 @@ module.exports = class SingleChangelogCommand {
     }
 
     if (!(filePath.endsWith('.md') || filePath.endsWith('.markdown'))) {
-      return Promise.reject(new Error('The file path specified is not a markdown file.'));
+      return Promise.reject(new Error('The file path specified is not a Markdown file.'));
     }
 
     const createdDoc = await pushDoc(key, undefined, dryRun, filePath, this.cmdCategory);

--- a/src/cmds/custompages/index.js
+++ b/src/cmds/custompages/index.js
@@ -63,7 +63,10 @@ module.exports = class CustomPagesCommand {
 
     // Strip out non-markdown files
     const files = readdirRecursive(folder).filter(
-      file => file.endsWith('.html') || file.endsWith('.md') || file.endsWith('.markdown')
+      file =>
+        file.toLowerCase().endsWith('.html') ||
+        file.toLowerCase().endsWith('.md') ||
+        file.toLowerCase().endsWith('.markdown')
     );
 
     debug(`number of files: ${files.length}`);

--- a/src/cmds/custompages/single.js
+++ b/src/cmds/custompages/single.js
@@ -45,7 +45,13 @@ module.exports = class SingleCustomPageCommand {
       return Promise.reject(new Error(`No file path provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
     }
 
-    if (!(filePath.endsWith('.html') || filePath.endsWith('.md') || filePath.endsWith('.markdown'))) {
+    if (
+      !(
+        filePath.toLowerCase().endsWith('.html') ||
+        filePath.toLowerCase().endsWith('.md') ||
+        filePath.toLowerCase().endsWith('.markdown')
+      )
+    ) {
       return Promise.reject(new Error('The file path specified is not a Markdown or HTML file.'));
     }
 

--- a/src/cmds/custompages/single.js
+++ b/src/cmds/custompages/single.js
@@ -46,7 +46,7 @@ module.exports = class SingleCustomPageCommand {
     }
 
     if (!(filePath.endsWith('.html') || filePath.endsWith('.md') || filePath.endsWith('.markdown'))) {
-      return Promise.reject(new Error('The file path specified is not a markdown or HTML file.'));
+      return Promise.reject(new Error('The file path specified is not a Markdown or HTML file.'));
     }
 
     const createdDoc = await pushDoc(key, undefined, dryRun, filePath, this.cmdCategory);

--- a/src/cmds/docs/index.js
+++ b/src/cmds/docs/index.js
@@ -75,7 +75,9 @@ module.exports = class DocsCommand {
     };
 
     // Strip out non-markdown files
-    const files = readdirRecursive(folder).filter(file => file.endsWith('.md') || file.endsWith('.markdown'));
+    const files = readdirRecursive(folder).filter(
+      file => file.toLowerCase().endsWith('.md') || file.toLowerCase().endsWith('.markdown')
+    );
 
     debug(`number of files: ${files.length}`);
 

--- a/src/cmds/docs/single.js
+++ b/src/cmds/docs/single.js
@@ -52,7 +52,7 @@ module.exports = class SingleDocCommand {
     }
 
     if (!(filePath.endsWith('.md') || filePath.endsWith('.markdown'))) {
-      return Promise.reject(new Error('The file path specified is not a markdown file.'));
+      return Promise.reject(new Error('The file path specified is not a Markdown file.'));
     }
 
     // TODO: should we allow version selection at all here?

--- a/src/cmds/docs/single.js
+++ b/src/cmds/docs/single.js
@@ -51,7 +51,7 @@ module.exports = class SingleDocCommand {
       return Promise.reject(new Error(`No file path provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
     }
 
-    if (filePath.endsWith('.md') === false || !filePath.endsWith('.markdown') === false) {
+    if (!(filePath.endsWith('.md') || filePath.endsWith('.markdown'))) {
       return Promise.reject(new Error('The file path specified is not a markdown file.'));
     }
 

--- a/src/cmds/docs/single.js
+++ b/src/cmds/docs/single.js
@@ -51,7 +51,7 @@ module.exports = class SingleDocCommand {
       return Promise.reject(new Error(`No file path provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
     }
 
-    if (!(filePath.endsWith('.md') || filePath.endsWith('.markdown'))) {
+    if (!(filePath.toLowerCase().endsWith('.md') || filePath.toLowerCase().endsWith('.markdown'))) {
       return Promise.reject(new Error('The file path specified is not a Markdown file.'));
     }
 


### PR DESCRIPTION
| 🚥 Fix #546  |
| :-- |

## 🧰 Changes

Fixes an issue where our single commands had faulty conditional logic and therefore weren't working on `.markdown` files properly.

Also leans up a few tests, see https://github.com/readmeio/rdme/commit/21ba907ca774230366ff2fee6d872babe02137ef

## 🧬 QA & Testing

Do the test changes look good and do they pass?
