### PR TITLE
feat: upgrading oas-normalize to pull in its new TS typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "isemail": "^3.1.3",
         "mime-types": "^2.1.35",
         "node-fetch": "^2.6.1",
-        "oas-normalize": "^6.0.0",
+        "oas-normalize": "^7.0.0",
         "open": "^8.2.1",
         "ora": "^5.4.1",
         "parse-link-header": "^2.0.0",
@@ -9446,13 +9446,14 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-6.0.0.tgz",
-      "integrity": "sha512-BYVM3tpl4J5uVAN0EXeFaBKfwMufpCziIfEkU8tfer579p+RKj3qlXaF+rblvTZh4vEmnjNLR4ULmciHfDPF8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-7.0.0.tgz",
+      "integrity": "sha512-K/ChGYwdXPR1Vl0fnIdeAmEeQIw/MV90QmRL3DLsRGIS27/VaDn+ChMZ0GvTrE2lxjlDiGkm8cgKqS95F2jQNQ==",
       "dependencies": {
         "@readme/openapi-parser": "^2.2.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
+        "openapi-types": "^12.0.0",
         "swagger2openapi": "^7.0.8"
       },
       "engines": {
@@ -9664,10 +9665,9 @@
       }
     },
     "node_modules/openapi-types": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.0.tgz",
-      "integrity": "sha512-GB+QO6o1hAtKsb8tP3/FTD5jpkdKrf42L4Gel9UySngMurzr+Q9pO+dtnmySQCzoCEfJr39IH6bveEn71xNcVg==",
-      "peer": true
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+      "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw=="
     },
     "node_modules/ora": {
       "version": "5.4.1",
@@ -19689,13 +19689,14 @@
       }
     },
     "oas-normalize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-6.0.0.tgz",
-      "integrity": "sha512-BYVM3tpl4J5uVAN0EXeFaBKfwMufpCziIfEkU8tfer579p+RKj3qlXaF+rblvTZh4vEmnjNLR4ULmciHfDPF8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-7.0.0.tgz",
+      "integrity": "sha512-K/ChGYwdXPR1Vl0fnIdeAmEeQIw/MV90QmRL3DLsRGIS27/VaDn+ChMZ0GvTrE2lxjlDiGkm8cgKqS95F2jQNQ==",
       "requires": {
         "@readme/openapi-parser": "^2.2.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
+        "openapi-types": "^12.0.0",
         "swagger2openapi": "^7.0.8"
       },
       "dependencies": {
@@ -19846,10 +19847,9 @@
       }
     },
     "openapi-types": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.0.tgz",
-      "integrity": "sha512-GB+QO6o1hAtKsb8tP3/FTD5jpkdKrf42L4Gel9UySngMurzr+Q9pO+dtnmySQCzoCEfJr39IH6bveEn71xNcVg==",
-      "peer": true
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+      "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw=="
     },
     "ora": {
       "version": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "isemail": "^3.1.3",
     "mime-types": "^2.1.35",
     "node-fetch": "^2.6.1",
-    "oas-normalize": "^6.0.0",
+    "oas-normalize": "^7.0.0",
     "open": "^8.2.1",
     "ora": "^5.4.1",
     "parse-link-header": "^2.0.0",

--- a/src/.sink.d.ts
+++ b/src/.sink.d.ts
@@ -1,4 +1,3 @@
 // These packages don't have any TS types so we need to declare a module in order to use them.
 declare module '@npmcli/ci-detect';
 declare module 'editor';
-declare module 'oas-normalize';

--- a/src/lib/prepareOas.ts
+++ b/src/lib/prepareOas.ts
@@ -1,9 +1,8 @@
 import fs from 'fs';
 
 import chalk from 'chalk';
-import ora from 'ora';
-
 import OASNormalize from 'oas-normalize';
+import ora from 'ora';
 
 import { debug, info, oraOptions } from './logger';
 
@@ -69,7 +68,7 @@ export default async function prepareOas(path: string, command: 'openapi' | 'val
   let bundledSpec = '';
 
   if (command === 'openapi') {
-    bundledSpec = await oas.bundle().then((res: Record<string, unknown>) => {
+    bundledSpec = await oas.bundle().then(res => {
       return JSON.stringify(res);
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,7 @@
     "outDir": "dist/",
     "paths": {
       "@npmcli/ci-detect": [".sink.d.ts"],
-      "editor": [".sink.d.ts"],
-      "oas-normalize": [".sink.d.ts"]
+      "editor": [".sink.d.ts"]
     },
     "resolveJsonModule": true,
     "target": "ES5"


### PR DESCRIPTION
## 🧰 Changes

I rewrote [oas-normalize](https://npm.im/oas-normalize) last night in TypeScript (https://github.com/readmeio/oas-normalize/pull/210) so we no longer need to have a typing sinkhole exclusion for it.