### PR TITLE
ci: optimize test runs and add docs syncing dry run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,7 @@
 name: Sync `documentation` directory to ReadMe
 
-# Run workflow for every push to the `main` branch
-on:
-  push:
-    branches:
-      - main
+# Run workflow for every push
+on: push
 
 jobs:
   sync:
@@ -44,7 +41,17 @@ jobs:
       # we run the `rdme` GitHub Action to sync the Markdown file
       # in the `documentation` directory.
       # Here's the page we're syncing: https://docs.readme.com/docs/rdme
+
+      # First we're going to perform a dry run of syncing process.
+      # We do this on every push to ensure that an actual sync will work properly
+      - name: Sync docs to ReadMe (dry run)
+        uses: ./
+        with:
+          rdme: docs ./documentation --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=2.0 --dryRun
+
+      # And finally, we perform an actual sync to ReadMe if we're on the main branch
       - name: Sync docs to ReadMe
+        if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
         # We use the `main` branch as ref for GitHub Action
         # This is NOT recommended, as it can break your workflows without notice!
         # We recommend specifying a fixed version, i.e. @7.0


### PR DESCRIPTION
## 🧰 Changes

- [x] Makes some tiny optimizations [our CI workflow `on` events](https://github.com/readmeio/rdme/blob/66791a6968d1e33fc21388be4b08313cd06dd85a/.github/workflows/ci.yml#L4-L7) so we're not running our CI twice for every push in a PR.
- [x] Performs a dry run of our docs syncing workflow on every push. This is so we can avoid what happened yesterday in [this workflow](https://github.com/readmeio/rdme/runs/7755364437?check_suite_focus=true) where our sync failed but we didn't realize it was merged into `main`.

## 🧬 QA & Testing

Are tests still running on every push to the PR, but with fewer duplicate workflow runs? And is [the docs syncing workflow](https://github.com/readmeio/rdme/runs/7775815962?check_suite_focus=true) running as expected and properly skipping over the actual syncing step?
