### PR TITLE
fix: quieter log outputs when installing GHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Set up rdme
-      run: npm install --silent && npm run build
+      run: npm install --silent --no-save && npm run build --silent
       shell: bash
       working-directory: ${{ github.action_path }}
     - name: Execute rdme command


### PR DESCRIPTION
## 🧰 Changes

As part of #560, we [added a `build` step](https://github.com/readmeio/rdme/pull/560/commits/bee05e6a558e672271bae2132b6726084d5ccb99) when setting up the GitHub Actions environment. But this in turn made the logs a bit noisy:

<img width="913" alt="image" src="https://user-images.githubusercontent.com/8854718/184023979-512a8e11-2332-493a-873e-bfb0f7c15507.png">

This makes a small update to our Actions workflow so we're not outputting `tsc` build logs that the user doesn't need to know about:

<img width="912" alt="Screen Shot 2022-08-10 at 4 32 49 PM" src="https://user-images.githubusercontent.com/8854718/184024219-b5571411-29ee-4506-9c6c-9e953f071c0f.png">

I also added `--no-save` to our `npm install` step since there's no point in updating the lockfile. Not sure if it's faster to do this vs. `npm ci`. At some point it might be cool to look into caching our dependencies but this seems okay for now.

## 🧬 QA & Testing

Do the GitHub Action dry runs continue to run as expected? And do the logs look cleaner?
