### PR TITLE
refactor: migrate from `enquirer` to `prompts`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ npm run build
 If you need to debug commands quicker and re-building TS everytime is becoming cumbersome, you can use the debug command, like so:
 
 ```sh
-npm run debug:bin -- validate __tests__/__fixtures__/ref-oas/petstore.json
+npm run debug -- validate __tests__/__fixtures__/ref-oas/petstore.json
 ```
 
 ## Running GitHub Actions Locally 🐳

--- a/__tests__/cmds/__snapshots__/login.test.ts.snap
+++ b/__tests__/cmds/__snapshots__/login.test.ts.snap
@@ -2,4 +2,6 @@
 
 exports[`rdme login should post to /login on the API 1`] = `"Successfully logged in as user@example.com to the subdomain project."`;
 
+exports[`rdme login should post to /login on the API if passing in project via opt 1`] = `"Successfully logged in as user@example.com to the subdomain project."`;
+
 exports[`rdme login should send 2fa token if provided 1`] = `"Successfully logged in as user@example.com to the subdomain project."`;

--- a/__tests__/cmds/openapi.test.ts
+++ b/__tests__/cmds/openapi.test.ts
@@ -8,8 +8,8 @@ import SwaggerCommand from '../../src/cmds/swagger';
 import APIError from '../../src/lib/apiError';
 import getAPIMock from '../helpers/get-api-mock';
 
-// // eslint-disable-next-line @typescript-eslint/no-var-requires
-// const promptHandler = require('../../src/lib/prompts');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const promptHandler = require('../../src/lib/prompts');
 
 const openapi = new OpenAPICommand();
 const swagger = new SwaggerCommand();
@@ -428,11 +428,11 @@ describe('rdme openapi', () => {
       return mock.done();
     });
 
-    it.only('should request a version list if version is not found', async () => {
-      // promptHandler.generatePrompts.mockResolvedValue({
-      //   option: 'create',
-      //   newVersion: '1.0.1',
-      // });
+    it('should request a version list if version is not found', async () => {
+      promptHandler.generatePrompts.mockResolvedValue({
+        option: 'create',
+        newVersion: '1.0.1',
+      });
 
       const registryUUID = getRandomRegistryId();
 
@@ -440,8 +440,7 @@ describe('rdme openapi', () => {
         .get('/api/v1/version')
         .basicAuth({ user: key })
         .reply(200, [{ version: '1.0.0' }])
-        // This nock is failing because promptHandler.generatePrompts() isn't being called in this test
-        .post('/api/v1/version', { from: '1.0.0', version: '1.0.1', is_stable: false })
+        .post('/api/v1/version')
         .basicAuth({ user: key })
         .reply(200, { from: '1.0.0', version: '1.0.1' })
         .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))

--- a/__tests__/cmds/openapi.test.ts
+++ b/__tests__/cmds/openapi.test.ts
@@ -8,8 +8,8 @@ import SwaggerCommand from '../../src/cmds/swagger';
 import APIError from '../../src/lib/apiError';
 import getAPIMock from '../helpers/get-api-mock';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const promptHandler = require('../../src/lib/prompts');
+// // eslint-disable-next-line @typescript-eslint/no-var-requires
+// const promptHandler = require('../../src/lib/prompts');
 
 const openapi = new OpenAPICommand();
 const swagger = new SwaggerCommand();
@@ -428,11 +428,11 @@ describe('rdme openapi', () => {
       return mock.done();
     });
 
-    it('should request a version list if version is not found', async () => {
-      promptHandler.generatePrompts.mockResolvedValue({
-        option: 'create',
-        newVersion: '1.0.1',
-      });
+    it.only('should request a version list if version is not found', async () => {
+      // promptHandler.generatePrompts.mockResolvedValue({
+      //   option: 'create',
+      //   newVersion: '1.0.1',
+      // });
 
       const registryUUID = getRandomRegistryId();
 
@@ -440,7 +440,8 @@ describe('rdme openapi', () => {
         .get('/api/v1/version')
         .basicAuth({ user: key })
         .reply(200, [{ version: '1.0.0' }])
-        .post('/api/v1/version')
+        // This nock is failing because promptHandler.generatePrompts() isn't being called in this test
+        .post('/api/v1/version', { from: '1.0.0', version: '1.0.1', is_stable: false })
         .basicAuth({ user: key })
         .reply(200, { from: '1.0.0', version: '1.0.1' })
         .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))

--- a/__tests__/cmds/openapi.test.ts
+++ b/__tests__/cmds/openapi.test.ts
@@ -2,14 +2,12 @@
 import chalk from 'chalk';
 import config from 'config';
 import nock from 'nock';
+import prompts from 'prompts';
 
 import OpenAPICommand from '../../src/cmds/openapi';
 import SwaggerCommand from '../../src/cmds/swagger';
 import APIError from '../../src/lib/apiError';
 import getAPIMock from '../helpers/get-api-mock';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const promptHandler = require('../../src/lib/prompts');
 
 const openapi = new OpenAPICommand();
 const swagger = new SwaggerCommand();
@@ -42,8 +40,6 @@ const successfulUpdate = (specPath, specType = 'OpenAPI') =>
   ].join('\n');
 
 const testWorkingDir = process.cwd();
-
-jest.mock('../../src/lib/prompts');
 
 const getCommandOutput = () => {
   return [consoleWarnSpy.mock.calls.join('\n\n'), consoleInfoSpy.mock.calls.join('\n\n')].filter(Boolean).join('\n\n');
@@ -429,10 +425,7 @@ describe('rdme openapi', () => {
     });
 
     it('should request a version list if version is not found', async () => {
-      promptHandler.generatePrompts.mockResolvedValue({
-        option: 'create',
-        newVersion: '1.0.1',
-      });
+      prompts.inject(['create', '1.0.1']);
 
       const registryUUID = getRandomRegistryId();
 
@@ -440,7 +433,7 @@ describe('rdme openapi', () => {
         .get('/api/v1/version')
         .basicAuth({ user: key })
         .reply(200, [{ version: '1.0.0' }])
-        .post('/api/v1/version')
+        .post('/api/v1/version', { from: '1.0.0', version: '1.0.1', is_stable: false })
         .basicAuth({ user: key })
         .reply(200, { from: '1.0.0', version: '1.0.1' })
         .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))

--- a/__tests__/cmds/openapi.test.ts
+++ b/__tests__/cmds/openapi.test.ts
@@ -348,6 +348,8 @@ describe('rdme openapi', () => {
       ).resolves.toBe(successfulUpdate(spec));
       return mock.done();
     });
+
+    it.todo('should paginate to next and previous pages of specs');
   });
 
   describe('versioning', () => {

--- a/__tests__/cmds/versions/create.test.ts
+++ b/__tests__/cmds/versions/create.test.ts
@@ -21,6 +21,18 @@ describe('rdme versions:create', () => {
     );
   });
 
+  it('should error if no version provided', () => {
+    return expect(createVersion.run({ key })).rejects.toStrictEqual(
+      new Error('Please specify a semantic version. See `rdme help versions:create` for help.')
+    );
+  });
+
+  it('should error if invaild version provided', () => {
+    return expect(createVersion.run({ key, version: 'test' })).rejects.toStrictEqual(
+      new Error('Please specify a semantic version. See `rdme help versions:create` for help.')
+    );
+  });
+
   it('should create a specific version', async () => {
     prompts.inject([version, false, true, true]);
     const newVersion = '1.0.1';

--- a/__tests__/cmds/versions/create.test.ts
+++ b/__tests__/cmds/versions/create.test.ts
@@ -1,16 +1,12 @@
 import nock from 'nock';
+import prompts from 'prompts';
 
 import CreateVersionCommand from '../../../src/cmds/versions/create';
 import APIError from '../../../src/lib/apiError';
 import getAPIMock from '../../helpers/get-api-mock';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const promptHandler = require('../../../src/lib/prompts');
-
 const key = 'API_KEY';
 const version = '1.0.0';
-
-jest.mock('../../../src/lib/prompts');
 
 const createVersion = new CreateVersionCommand();
 
@@ -26,31 +22,59 @@ describe('rdme versions:create', () => {
   });
 
   it('should create a specific version', async () => {
-    promptHandler.createVersionPrompt.mockResolvedValue({
-      is_stable: true,
-      is_beta: false,
-      from: '1.0.0',
-    });
+    prompts.inject([version, false, true, true]);
+    const newVersion = '1.0.1';
 
     const mockRequest = getAPIMock()
       .get('/api/v1/version')
       .basicAuth({ user: key })
-      .reply(200, [{ version }, { version }])
-      .post('/api/v1/version')
+      .reply(200, [{ version }, { version: '1.1.0' }])
+      .post('/api/v1/version', {
+        version: newVersion,
+        codename: '',
+        is_stable: false,
+        is_beta: true,
+        from: '1.0.0',
+        is_hidden: false,
+      })
       .basicAuth({ user: key })
-      .reply(201, { version });
+      .reply(201, { version: newVersion });
 
-    await expect(createVersion.run({ key, version })).resolves.toBe('Version 1.0.0 created successfully.');
+    await expect(createVersion.run({ key, version: newVersion })).resolves.toBe(
+      `Version ${newVersion} created successfully.`
+    );
+    mockRequest.done();
+  });
+
+  it('should create a specific version with options', async () => {
+    const newVersion = '1.0.1';
+
+    const mockRequest = getAPIMock()
+      .post('/api/v1/version', {
+        version: newVersion,
+        codename: 'test',
+        from: '1.0.0',
+        is_hidden: false,
+      })
+      .basicAuth({ user: key })
+      .reply(201, { version: newVersion });
+
+    await expect(
+      createVersion.run({
+        key,
+        version: newVersion,
+        fork: version,
+        beta: 'false',
+        main: 'false',
+        codename: 'test',
+        isPublic: 'true',
+      })
+    ).resolves.toBe(`Version ${newVersion} created successfully.`);
+
     mockRequest.done();
   });
 
   it('should catch any post request errors', async () => {
-    expect.assertions(1);
-    promptHandler.createVersionPrompt.mockResolvedValue({
-      is_stable: false,
-      is_beta: false,
-    });
-
     const errorResponse = {
       error: 'VERSION_EMPTY',
       message: 'You need to include an x-readme-version header',

--- a/__tests__/lib/prompts.test.ts
+++ b/__tests__/lib/prompts.test.ts
@@ -46,19 +46,24 @@ describe('prompt test bed', () => {
 
   describe('generatePrompts()', () => {
     it('should return an update option if selected', async () => {
-      prompts.inject(['update', '1']);
+      prompts.inject(['update', '2']);
 
       const answer = await promptTerminal(promptHandler.generatePrompts(versionlist));
-      expect(answer.versionSelection).toBe('1');
-      expect(answer.newVersion).toBeUndefined();
+      expect(answer).toStrictEqual({ option: 'update', versionSelection: '2' });
     });
 
     it('should return a create option if selected', async () => {
       prompts.inject(['create', '1.1']);
 
       const answer = await promptTerminal(promptHandler.generatePrompts(versionlist));
-      expect(answer.newVersion).toBe('1.1');
-      expect(answer.versionSelection).toBeUndefined();
+      expect(answer).toStrictEqual({ newVersion: '1.1', option: 'create' });
+    });
+
+    it('should return an update option if selectOnly=true', async () => {
+      prompts.inject(['2']);
+
+      const answer = await promptTerminal(promptHandler.generatePrompts(versionlist, true));
+      expect(answer).toStrictEqual({ versionSelection: '2' });
     });
   });
 

--- a/__tests__/lib/prompts.test.ts
+++ b/__tests__/lib/prompts.test.ts
@@ -64,12 +64,9 @@ describe('prompt test bed', () => {
 
   describe('createOasPrompt()', () => {
     it('should return a create option if selected', async () => {
-      enquirer.on('prompt', async prompt => {
-        await prompt.keypress(null, { name: 'down' });
-        await prompt.submit();
-      });
+      prompts.inject(['create']);
 
-      const answer = await enquirer.prompt(
+      const answer = await promptTerminal(
         promptHandler.createOasPrompt(
           [
             {
@@ -83,19 +80,11 @@ describe('prompt test bed', () => {
         )
       );
 
-      expect(answer.option).toBe('create');
+      expect(answer).toStrictEqual({ option: 'create' });
     });
 
     it('should return specId if user chooses to update file', async () => {
-      jest.mock('enquirer');
-      enquirer.on('prompt', async prompt => {
-        await prompt.keypress(null, { name: 'down' });
-        await prompt.keypress(null, { name: 'up' });
-        await prompt.submit();
-      });
-
-      enquirer.prompt = jest.fn();
-      enquirer.prompt.mockReturnValue('spec1');
+      prompts.inject(['update', 'spec1']);
 
       const parsedDocs = {
         next: {
@@ -108,9 +97,9 @@ describe('prompt test bed', () => {
         },
       };
 
-      const answer = await enquirer.prompt(promptHandler.createOasPrompt(specList, parsedDocs, 1, getSpecs));
+      const answer = await promptTerminal(promptHandler.createOasPrompt(specList, parsedDocs, 1, getSpecs));
 
-      expect(answer).toBe('spec1');
+      expect(answer).toStrictEqual({ option: 'spec1' });
     });
   });
 

--- a/__tests__/lib/prompts.test.ts
+++ b/__tests__/lib/prompts.test.ts
@@ -1,8 +1,10 @@
 import type { Response } from 'node-fetch';
 
 import Enquirer from 'enquirer';
+import prompts from 'prompts';
 
 import * as promptHandler from '../../src/lib/prompts';
+import promptTerminal from '../../src/lib/promptWrapper';
 
 const versionlist = [
   {
@@ -43,40 +45,20 @@ describe('prompt test bed', () => {
   });
 
   describe('generatePrompts()', () => {
-    it('should not allow selection of version if chosen to create new version', async () => {
-      enquirer.on('prompt', async prompt => {
-        // eslint-disable-next-line default-case
-        switch (prompt.name) {
-          case 'option':
-            await prompt.keypress(null, { name: 'down' });
-            await prompt.submit();
-            break;
+    it('should return an update option if selected', async () => {
+      prompts.inject(['update', '1']);
 
-          case 'versionSelection':
-            // eslint-disable-next-line jest/no-conditional-expect
-            await expect(prompt.skip()).resolves.toBe(true);
-            break;
-
-          case 'newVersion':
-            // eslint-disable-next-line no-param-reassign
-            prompt.value = '1.2.1';
-            await prompt.submit();
-        }
-      });
-
-      await enquirer.prompt(promptHandler.generatePrompts(versionlist));
+      const answer = await promptTerminal(promptHandler.generatePrompts(versionlist));
+      expect(answer.versionSelection).toBe('1');
+      expect(answer.newVersion).toBeUndefined();
     });
 
     it('should return a create option if selected', async () => {
-      enquirer.on('prompt', async prompt => {
-        await prompt.keypress(null, { name: 'down' });
-        await prompt.keypress(null, { name: 'up' });
-        await prompt.submit();
-        await prompt.submit();
-      });
+      prompts.inject(['create', '1.1']);
 
-      const answer = await enquirer.prompt(promptHandler.generatePrompts(versionlist));
-      expect(answer.versionSelection).toBe('1');
+      const answer = await promptTerminal(promptHandler.generatePrompts(versionlist));
+      expect(answer.newVersion).toBe('1.1');
+      expect(answer.versionSelection).toBeUndefined();
     });
   });
 

--- a/__tests__/lib/prompts.test.ts
+++ b/__tests__/lib/prompts.test.ts
@@ -1,3 +1,4 @@
+import type { VersionCreateOptions } from '../../src/cmds/versions/create';
 import type { Response } from 'node-fetch';
 
 import Enquirer from 'enquirer';
@@ -110,7 +111,7 @@ describe('prompt test bed', () => {
 
   describe('createVersionPrompt()', () => {
     it('should allow user to choose a fork if flag is not passed', async () => {
-      const opts = { main: true, beta: true };
+      const opts = { main: 'true', beta: 'true' } as VersionCreateOptions;
 
       enquirer.on('prompt', async prompt => {
         await prompt.keypress(null, { name: 'down' });
@@ -132,10 +133,10 @@ describe('prompt test bed', () => {
         version: '1',
         codename: 'test',
         fork: '1.0.0',
-        main: false,
-        beta: true,
-        isPublic: false,
-      };
+        main: 'false',
+        beta: 'true',
+        isPublic: 'false',
+      } as VersionCreateOptions;
 
       enquirer.on('prompt', async prompt => {
         if (prompt.name === 'newVersion') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "form-data": "^4.0.0",
         "gray-matter": "^4.0.1",
         "ignore": "^5.2.0",
-        "isemail": "^3.1.3",
         "mime-types": "^2.1.35",
         "node-fetch": "^2.6.1",
         "oas-normalize": "^7.0.0",
@@ -30,10 +29,10 @@
         "ora": "^5.4.1",
         "parse-link-header": "^2.0.0",
         "prompts": "^2.4.2",
-        "read": "^1.0.7",
         "semver": "^7.0.0",
         "tmp-promise": "^3.0.2",
-        "update-notifier": "^5.1.0"
+        "update-notifier": "^5.1.0",
+        "validator": "^13.7.0"
       },
       "bin": {
         "rdme": "bin/rdme"
@@ -51,10 +50,10 @@
         "@types/npmcli__ci-detect": "^2.0.0",
         "@types/parse-link-header": "^2.0.0",
         "@types/prompts": "^2.0.14",
-        "@types/read": "^0.0.29",
         "@types/semver": "^7.3.10",
         "@types/tmp": "^0.2.3",
         "@types/update-notifier": "^6.0.1",
+        "@types/validator": "^13.7.5",
         "alex": "^10.0.0",
         "eslint": "^8.21.0",
         "jest": "^28.1.1",
@@ -1914,12 +1913,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/read": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/read/-/read-0.0.29.tgz",
-      "integrity": "sha512-TisW3O3OhpP8/ZwaiqV7kewh9gnoH7PfqHd4hkCM9ogiqWEagu43WXpHWqgPbltXhembYJDpYB3cVwUIOweHXg==",
-      "dev": true
-    },
     "node_modules/@types/semver": {
       "version": "7.3.10",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.10.tgz",
@@ -2111,6 +2104,12 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.7.5",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.5.tgz",
+      "integrity": "sha512-9rQHeAqz6Jw3gDhttkmWetoriW5FPbxylv/6h6mXtaj2NKRcOvOmvfcswVdLVpbuy10NrO486K3lCoLgoIhiIA==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.10",
@@ -6446,17 +6445,6 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "node_modules/isemail": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "dependencies": {
-        "punycode": "2.x.x"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -9217,11 +9205,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -10269,17 +10252,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
-    },
-    "node_modules/read": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-      "dependencies": {
-        "mute-stream": "~0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
@@ -12405,6 +12377,14 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vfile": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
@@ -14314,12 +14294,6 @@
         "@types/node": "*"
       }
     },
-    "@types/read": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/read/-/read-0.0.29.tgz",
-      "integrity": "sha512-TisW3O3OhpP8/ZwaiqV7kewh9gnoH7PfqHd4hkCM9ogiqWEagu43WXpHWqgPbltXhembYJDpYB3cVwUIOweHXg==",
-      "dev": true
-    },
     "@types/semver": {
       "version": "7.3.10",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.10.tgz",
@@ -14453,6 +14427,12 @@
           }
         }
       }
+    },
+    "@types/validator": {
+      "version": "13.7.5",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.5.tgz",
+      "integrity": "sha512-9rQHeAqz6Jw3gDhttkmWetoriW5FPbxylv/6h6mXtaj2NKRcOvOmvfcswVdLVpbuy10NrO486K3lCoLgoIhiIA==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "17.0.10",
@@ -17510,14 +17490,6 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "isemail": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "requires": {
-        "punycode": "2.x.x"
-      }
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -19502,11 +19474,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -20297,14 +20264,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
-    },
-    "read": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-      "requires": {
-        "mute-stream": "~0.0.4"
-      }
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -21901,6 +21860,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "vfile": {
       "version": "5.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "configstore": "^5.0.0",
         "debug": "^4.3.3",
         "editor": "^1.0.0",
-        "enquirer": "^2.3.0",
         "form-data": "^4.0.0",
         "gray-matter": "^4.0.1",
         "ignore": "^5.2.0",
@@ -2400,14 +2399,6 @@
         "string-width": "^4.1.0"
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -3907,17 +3898,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dependencies": {
-        "ansi-colors": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/error-ex": {
@@ -14651,11 +14631,6 @@
         "string-width": "^4.1.0"
       }
     },
-    "ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
-    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -15727,14 +15702,6 @@
       "requires": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
-      }
-    },
-    "enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "requires": {
-        "ansi-colors": "^4.1.1"
       }
     },
     "error-ex": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "configstore": "^5.0.0",
     "debug": "^4.3.3",
     "editor": "^1.0.0",
-    "enquirer": "^2.3.0",
     "form-data": "^4.0.0",
     "gray-matter": "^4.0.1",
     "ignore": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "debug:bin": "ts-node src/cli.ts",
+    "debug": "ts-node src/cli.ts",
     "lint": "eslint . bin/rdme bin/set-version-output --ext .js,.ts",
     "lint-docs": "alex . && npm run prettier",
     "prebuild": "rm -rf dist/",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "form-data": "^4.0.0",
     "gray-matter": "^4.0.1",
     "ignore": "^5.2.0",
-    "isemail": "^3.1.3",
     "mime-types": "^2.1.35",
     "node-fetch": "^2.6.1",
     "oas-normalize": "^7.0.0",
@@ -55,10 +54,10 @@
     "ora": "^5.4.1",
     "parse-link-header": "^2.0.0",
     "prompts": "^2.4.2",
-    "read": "^1.0.7",
     "semver": "^7.0.0",
     "tmp-promise": "^3.0.2",
-    "update-notifier": "^5.1.0"
+    "update-notifier": "^5.1.0",
+    "validator": "^13.7.0"
   },
   "devDependencies": {
     "@readme/eslint-config": "^10.0.0",
@@ -73,10 +72,10 @@
     "@types/npmcli__ci-detect": "^2.0.0",
     "@types/parse-link-header": "^2.0.0",
     "@types/prompts": "^2.0.14",
-    "@types/read": "^0.0.29",
     "@types/semver": "^7.3.10",
     "@types/tmp": "^0.2.3",
     "@types/update-notifier": "^6.0.1",
+    "@types/validator": "^13.7.5",
     "alex": "^10.0.0",
     "eslint": "^8.21.0",
     "jest": "^28.1.1",

--- a/src/cmds/openapi.ts
+++ b/src/cmds/openapi.ts
@@ -1,6 +1,5 @@
 import type { CommandOptions } from '../lib/baseCommand';
 import type { RequestInit, Response } from 'node-fetch';
-import type { Answers } from 'prompts';
 
 import chalk from 'chalk';
 import config from 'config';
@@ -228,7 +227,9 @@ export default class OpenAPICommand extends Command {
       Command.debug(`api settings list response payload: ${JSON.stringify(apiSettingsBody)}`);
       if (!apiSettingsBody.length) return createSpec();
 
-      const { option }: Answers<string> = await promptTerminal(
+      // @todo: figure out how to add a stricter type here, see:
+      // https://github.com/readmeio/rdme/pull/570#discussion_r949715913
+      const { option } = await promptTerminal(
         promptHandler.createOasPrompt(apiSettingsBody, parsedDocs, totalPages, getSpecs)
       );
       Command.debug(`selection result: ${option}`);

--- a/src/cmds/openapi.ts
+++ b/src/cmds/openapi.ts
@@ -1,9 +1,9 @@
 import type { CommandOptions } from '../lib/baseCommand';
 import type { RequestInit, Response } from 'node-fetch';
+import type { Answers } from 'prompts';
 
 import chalk from 'chalk';
 import config from 'config';
-import { prompt } from 'enquirer';
 import { Headers } from 'node-fetch';
 import ora from 'ora';
 import parse from 'parse-link-header';
@@ -13,6 +13,7 @@ import fetch, { cleanHeaders, handleRes } from '../lib/fetch';
 import { oraOptions } from '../lib/logger';
 import prepareOas from '../lib/prepareOas';
 import * as promptHandler from '../lib/prompts';
+import promptTerminal from '../lib/promptWrapper';
 import streamSpecToRegistry from '../lib/streamSpecToRegistry';
 import { getProjectVersion } from '../lib/versionSelect';
 
@@ -227,7 +228,7 @@ export default class OpenAPICommand extends Command {
       Command.debug(`api settings list response payload: ${JSON.stringify(apiSettingsBody)}`);
       if (!apiSettingsBody.length) return createSpec();
 
-      const { option }: { option: 'create' | 'update' } = await prompt(
+      const { option }: Answers<string> = await promptTerminal(
         promptHandler.createOasPrompt(apiSettingsBody, parsedDocs, totalPages, getSpecs)
       );
 

--- a/src/cmds/openapi.ts
+++ b/src/cmds/openapi.ts
@@ -231,9 +231,8 @@ export default class OpenAPICommand extends Command {
       const { option }: Answers<string> = await promptTerminal(
         promptHandler.createOasPrompt(apiSettingsBody, parsedDocs, totalPages, getSpecs)
       );
-
       Command.debug(`selection result: ${option}`);
-      if (!option) return null;
+
       return option === 'create' ? createSpec() : updateSpec(option);
     }
 

--- a/src/cmds/versions/create.ts
+++ b/src/cmds/versions/create.ts
@@ -44,26 +44,7 @@ export default class CreateVersionCommand extends Command {
         type: String,
         description: "The semantic version which you'd like to fork from.",
       },
-      {
-        name: 'codename',
-        type: String,
-        description: 'The codename, or nickname, for a particular version.',
-      },
-      {
-        name: 'main',
-        type: String,
-        description: 'Should this version be the primary (default) version for your project?',
-      },
-      {
-        name: 'beta',
-        type: String,
-        description: 'Is this version in beta?',
-      },
-      {
-        name: 'isPublic',
-        type: String,
-        description: 'Would you like to make this version public? Any primary version must be public.',
-      },
+      ...this.getVersionOpts(),
     ];
   }
 

--- a/src/cmds/versions/create.ts
+++ b/src/cmds/versions/create.ts
@@ -1,13 +1,13 @@
 import type { CommandOptions } from '../../lib/baseCommand';
 
 import config from 'config';
-import { prompt } from 'enquirer';
 import { Headers } from 'node-fetch';
 import semver from 'semver';
 
 import Command, { CommandCategories } from '../../lib/baseCommand';
 import fetch, { cleanHeaders, handleRes } from '../../lib/fetch';
 import * as promptHandler from '../../lib/prompts';
+import promptTerminal from '../../lib/promptWrapper';
 
 export type VersionCreateOptions = { fork?: string } & VersionBaseOptions;
 
@@ -69,15 +69,12 @@ export default class CreateVersionCommand extends Command {
       }).then(res => handleRes(res));
     }
 
-    const versionPrompt = promptHandler.createVersionPrompt(versionList || [{}], {
+    const versionPrompt = promptHandler.createVersionPrompt(versionList || [], {
       newVersion: version,
       ...opts,
     });
 
-    const promptResponse: { from: string; is_beta: string; is_hidden: string; is_stable: string } = await prompt(
-      // @ts-expect-error Seems like our version prompts aren't what Enquirer actually expects.
-      versionPrompt
-    );
+    const promptResponse = await promptTerminal(versionPrompt);
 
     return fetch(`${config.get('host')}/api/v1/version`, {
       method: 'post',

--- a/src/cmds/versions/create.ts
+++ b/src/cmds/versions/create.ts
@@ -16,7 +16,6 @@ export type VersionBaseOptions = {
   codename?: string;
   isPublic?: 'true' | 'false';
   main?: 'true' | 'false';
-  newVersion?: string;
 };
 
 export default class CreateVersionCommand extends Command {
@@ -54,7 +53,7 @@ export default class CreateVersionCommand extends Command {
     super.run(opts, true);
 
     let versionList;
-    const { key, version, codename, fork, main, beta, isPublic } = opts;
+    const { key, version, fork, codename, main, beta, isPublic } = opts;
 
     if (!version || !semver.valid(semver.coerce(version))) {
       return Promise.reject(

--- a/src/cmds/versions/create.ts
+++ b/src/cmds/versions/create.ts
@@ -9,12 +9,14 @@ import Command, { CommandCategories } from '../../lib/baseCommand';
 import fetch, { cleanHeaders, handleRes } from '../../lib/fetch';
 import * as promptHandler from '../../lib/prompts';
 
-export type Options = {
-  beta?: string | boolean;
+export type VersionCreateOptions = { fork?: string } & VersionBaseOptions;
+
+export type VersionBaseOptions = {
+  beta?: 'true' | 'false';
   codename?: string;
-  fork?: string;
-  isPublic?: string | boolean;
-  main?: string | boolean;
+  isPublic?: 'true' | 'false';
+  main?: 'true' | 'false';
+  newVersion?: string;
 };
 
 export default class CreateVersionCommand extends Command {
@@ -48,7 +50,7 @@ export default class CreateVersionCommand extends Command {
     ];
   }
 
-  async run(opts: CommandOptions<Options>) {
+  async run(opts: CommandOptions<VersionCreateOptions>) {
     super.run(opts, true);
 
     let versionList;

--- a/src/cmds/versions/delete.ts
+++ b/src/cmds/versions/delete.ts
@@ -36,9 +36,7 @@ export default class DeleteVersionCommand extends Command {
 
     const { key, version } = opts;
 
-    const selectedVersion = await getProjectVersion(version, key, false).catch(e => {
-      return Promise.reject(e);
-    });
+    const selectedVersion = await getProjectVersion(version, key, false);
 
     Command.debug(`selectedVersion: ${selectedVersion}`);
 

--- a/src/cmds/versions/update.ts
+++ b/src/cmds/versions/update.ts
@@ -1,4 +1,5 @@
 import type { CommandOptions } from '../../lib/baseCommand';
+import type { VersionBaseOptions } from './create';
 
 import config from 'config';
 import { prompt } from 'enquirer';
@@ -9,14 +10,7 @@ import fetch, { cleanHeaders, handleRes } from '../../lib/fetch';
 import * as promptHandler from '../../lib/prompts';
 import { getProjectVersion } from '../../lib/versionSelect';
 
-export type Options = {
-  beta?: string;
-  codename?: string;
-  deprecated?: string;
-  isPublic?: string;
-  main?: string;
-  newVersion?: string;
-};
+export type VersionUpdateOptions = { deprecated?: 'true' | 'false' } & VersionBaseOptions;
 
 export default class UpdateVersionCommand extends Command {
   constructor() {
@@ -39,7 +33,7 @@ export default class UpdateVersionCommand extends Command {
     ];
   }
 
-  async run(opts: CommandOptions<Options>) {
+  async run(opts: CommandOptions<VersionUpdateOptions>) {
     super.run(opts, true);
 
     const { key, version, codename, newVersion, main, beta, isPublic, deprecated } = opts;

--- a/src/cmds/versions/update.ts
+++ b/src/cmds/versions/update.ts
@@ -2,12 +2,12 @@ import type { CommandOptions } from '../../lib/baseCommand';
 import type { VersionBaseOptions } from './create';
 
 import config from 'config';
-import { prompt } from 'enquirer';
 import { Headers } from 'node-fetch';
 
 import Command, { CommandCategories } from '../../lib/baseCommand';
 import fetch, { cleanHeaders, handleRes } from '../../lib/fetch';
 import * as promptHandler from '../../lib/prompts';
+import promptTerminal from '../../lib/promptWrapper';
 import { getProjectVersion } from '../../lib/versionSelect';
 
 export type VersionUpdateOptions = { deprecated?: 'true' | 'false' } & VersionBaseOptions;
@@ -49,16 +49,7 @@ export default class UpdateVersionCommand extends Command {
       headers: cleanHeaders(key),
     }).then(res => handleRes(res));
 
-    const promptResponse: {
-      is_beta: string;
-      is_deprecated: string;
-      is_hidden: string;
-      is_stable: string;
-      newVersion: string;
-    } = await prompt(
-      // @ts-expect-error Seems like our version prompts aren't what Enquirer actually expects.
-      promptHandler.createVersionPrompt([{}], opts, foundVersion)
-    );
+    const promptResponse = await promptTerminal(promptHandler.createVersionPrompt([], opts, foundVersion));
 
     return fetch(`${config.get('host')}/api/v1/version/${selectedVersion}`, {
       method: 'put',

--- a/src/cmds/versions/update.ts
+++ b/src/cmds/versions/update.ts
@@ -35,26 +35,7 @@ export default class UpdateVersionCommand extends Command {
         description: 'Project API key',
       },
       this.getVersionArg(),
-      {
-        name: 'codename',
-        type: String,
-        description: 'The codename, or nickname, for a particular version.',
-      },
-      {
-        name: 'main',
-        type: String,
-        description: 'Should this version be the primary (default) version for your project?',
-      },
-      {
-        name: 'beta',
-        type: String,
-        description: 'Is this version in beta?',
-      },
-      {
-        name: 'isPublic',
-        type: String,
-        description: 'Would you like to make this version public? Any primary version must be public.',
-      },
+      ...this.getVersionOpts(),
     ];
   }
 

--- a/src/cmds/versions/update.ts
+++ b/src/cmds/versions/update.ts
@@ -48,9 +48,7 @@ export default class UpdateVersionCommand extends Command {
 
     const { key, version, newVersion, codename, main, beta, isPublic, deprecated } = opts;
 
-    const selectedVersion = await getProjectVersion(version, key, false).catch(e => {
-      return Promise.reject(e);
-    });
+    const selectedVersion = await getProjectVersion(version, key, false);
 
     Command.debug(`selectedVersion: ${selectedVersion}`);
 

--- a/src/cmds/versions/update.ts
+++ b/src/cmds/versions/update.ts
@@ -10,7 +10,7 @@ import * as promptHandler from '../../lib/prompts';
 import promptTerminal from '../../lib/promptWrapper';
 import { getProjectVersion } from '../../lib/versionSelect';
 
-export type VersionUpdateOptions = { deprecated?: 'true' | 'false' } & VersionBaseOptions;
+export type VersionUpdateOptions = { deprecated?: 'true' | 'false'; newVersion?: string } & VersionBaseOptions;
 
 export default class UpdateVersionCommand extends Command {
   constructor() {
@@ -29,14 +29,24 @@ export default class UpdateVersionCommand extends Command {
         description: 'Project API key',
       },
       this.getVersionArg(),
+      {
+        name: 'newVersion',
+        type: String,
+        description: 'What should the version be renamed to?',
+      },
       ...this.getVersionOpts(),
+      {
+        name: 'deprecated',
+        type: String,
+        description: 'Would you like to deprecate this version?',
+      },
     ];
   }
 
   async run(opts: CommandOptions<VersionUpdateOptions>) {
     super.run(opts, true);
 
-    const { key, version, codename, newVersion, main, beta, isPublic, deprecated } = opts;
+    const { key, version, newVersion, codename, main, beta, isPublic, deprecated } = opts;
 
     const selectedVersion = await getProjectVersion(version, key, false).catch(e => {
       return Promise.reject(e);

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -45,6 +45,9 @@ export default class Command {
     }
   }
 
+  /**
+   * Used in any command where `version` is an option.
+   */
   getVersionArg() {
     return {
       name: 'version',

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -20,18 +20,55 @@ export enum CommandCategories {
 }
 
 export default class Command {
+  /**
+   * The command name
+   *
+   * @example openapi
+   */
   command: string;
 
+  /**
+   * Example command usage, used on invidivual command help screens
+   *
+   * @example openapi [file] [options]
+   */
   usage: string;
 
+  /**
+   * The command description, used on help screens
+   *
+   * @example Upload, or resync, your OpenAPI/Swagger definition to ReadMe.
+   */
   description: string;
 
+  /**
+   * The category that the command belongs to, used on
+   * the general help screen to group commands together
+   * and on individual command help screens
+   * to show related commands
+   *
+   * @example CommandCategories.APIS
+   */
   cmdCategory: CommandCategories;
 
+  /**
+   * The order in which to display the command within the `cmdCategory`
+   *
+   * @example 1
+   */
   position: number;
 
+  /**
+   * Arguments to hide from the individual command help screen
+   * (typically used for hiding default arguments)
+   *
+   * @example ['spec']
+   */
   hiddenArgs: string[] = [];
 
+  /**
+   * All documented arguments for the command
+   */
   args: OptionDefinition[];
 
   run(opts: CommandOptions<{}>, requiresAuth?: boolean): void | Promise<string> {

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -54,6 +54,34 @@ export default class Command {
     };
   }
 
+  /**
+   * Used in the versions:create and versions:update commands.
+   */
+  getVersionOpts() {
+    return [
+      {
+        name: 'codename',
+        type: String,
+        description: 'The codename, or nickname, for a particular version.',
+      },
+      {
+        name: 'main',
+        type: String,
+        description: 'Should this version be the primary (default) version for your project?',
+      },
+      {
+        name: 'beta',
+        type: String,
+        description: 'Is this version in beta?',
+      },
+      {
+        name: 'isPublic',
+        type: String,
+        description: 'Would you like to make this version public? Any primary version must be public.',
+      },
+    ];
+  }
+
   static debug(msg: string) {
     debug(msg);
   }

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -58,7 +58,7 @@ export default class Command {
   }
 
   /**
-   * Used in the versions:create and versions:update commands.
+   * Used in the `versions:create` and `versions:update` commands.
    */
   getVersionOpts() {
     return [

--- a/src/lib/prepareOas.ts
+++ b/src/lib/prepareOas.ts
@@ -2,9 +2,9 @@ import ciDetect from '@npmcli/ci-detect';
 import chalk from 'chalk';
 import OASNormalize from 'oas-normalize';
 import ora from 'ora';
-import prompts from 'prompts';
 
 import { debug, info, oraOptions } from './logger';
+import promptTerminal from './promptWrapper';
 import readdirRecursive from './readdirRecursive';
 
 type FileSelection = {
@@ -93,7 +93,7 @@ export default async function prepareOas(path: string, command: 'openapi' | 'val
 
       fileFindingSpinner.succeed(`${fileFindingSpinner.text} found! 🔍`);
 
-      const selection: FileSelection = await prompts({
+      const selection: FileSelection = await promptTerminal({
         name: 'file',
         message: `Multiple potential API definitions found! Which file would you like to ${action}?`,
         type: 'select',

--- a/src/lib/promptWrapper.ts
+++ b/src/lib/promptWrapper.ts
@@ -1,0 +1,29 @@
+import prompts from 'prompts';
+
+/**
+ * The `prompts` library doesn't always interpret CTRL+C and release the terminal back to the user
+ * so we need handle this ourselves. This function is just a simple overload of the main `prompts`
+ * import that we use.
+ *
+ * @see {@link https://github.com/terkelg/prompts/issues/252}
+ */
+export default async function promptTerminal<T extends string = string>(
+  questions: prompts.PromptObject<T> | prompts.PromptObject<T>[],
+  options?: prompts.Options
+): Promise<prompts.Answers<T>> {
+  const enableTerminalCursor = () => {
+    process.stdout.write('\x1B[?25h');
+  };
+
+  const onState = (state: { aborted: boolean }) => {
+    if (state.aborted) {
+      // If we don't re-enable the terminal cursor before exiting the program, the cursor will
+      // remain hidden.
+      enableTerminalCursor();
+      process.stdout.write('\n');
+      process.exit(1);
+    }
+  };
+
+  return prompts({ ...questions, onState }, options);
+}

--- a/src/lib/promptWrapper.ts
+++ b/src/lib/promptWrapper.ts
@@ -20,7 +20,9 @@ export default async function promptTerminal<T extends string = string>(
       // If we don't re-enable the terminal cursor before exiting the program, the cursor will
       // remain hidden.
       enableTerminalCursor();
-      process.stdout.write('\n');
+      process.stdout.write('\n\n');
+      process.stdout.write('Thanks for using rdme! See you soon ✌️');
+      process.stdout.write('\n\n');
       process.exit(1);
     }
   };

--- a/src/lib/promptWrapper.ts
+++ b/src/lib/promptWrapper.ts
@@ -25,5 +25,13 @@ export default async function promptTerminal<T extends string = string>(
     }
   };
 
-  return prompts({ ...questions, onState }, options);
+  if (Array.isArray(questions)) {
+    // eslint-disable-next-line no-param-reassign
+    questions = questions.map(question => ({ ...question, onState }));
+  } else {
+    // eslint-disable-next-line no-param-reassign
+    questions.onState = onState;
+  }
+
+  return prompts(questions, options);
 }

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -164,7 +164,7 @@ export function createVersionPrompt(
   versionList: VersionList,
   opts: VersionCreateOptions & VersionUpdateOptions,
   isUpdate?: {
-    is_stable: string;
+    is_stable: boolean;
   }
 ): PromptObject[] {
   return [

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -182,7 +182,7 @@ export function createVersionPrompt(
     {
       type: opts.newVersion || !isUpdate ? null : 'text',
       name: 'newVersion',
-      message: "What's your new version?",
+      message: 'What should the version be renamed to?',
       initial: opts.newVersion || false,
       hint: '1.0.0',
       validate(val: string) {

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -64,13 +64,23 @@ export function generatePrompts(versionList: VersionList, selectOnly = false) {
 function specOptions(specList: SpecList, parsedDocs: ParsedDocs, currPage: number, totalPages: number) {
   const specs = specList.map(s => {
     return {
+      description: `API Definition ID: ${s._id}`, // eslint-disable-line no-underscore-dangle
       title: s.title,
       value: s._id, // eslint-disable-line no-underscore-dangle
     };
   });
-  if (parsedDocs?.prev?.page) specs.push({ title: `< Prev (page ${currPage - 1} of ${totalPages})`, value: 'prev' });
+  if (parsedDocs?.prev?.page)
+    specs.push({
+      description: 'Go to the previous page',
+      title: `< Prev (page ${currPage - 1} of ${totalPages})`,
+      value: 'prev',
+    });
   if (parsedDocs?.next?.page) {
-    specs.push({ title: `Next (page ${currPage + 1} of ${totalPages}) >`, value: 'next' });
+    specs.push({
+      description: 'Go to the next page',
+      title: `Next (page ${currPage + 1} of ${totalPages}) >`,
+      value: 'next',
+    });
   }
   return specs as Choice[];
 }

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,3 +1,5 @@
+import type { VersionCreateOptions } from 'cmds/versions/create';
+import type { VersionUpdateOptions } from 'cmds/versions/update';
 import type { Response } from 'node-fetch';
 import type { Answers, Choice, PromptObject } from 'prompts';
 
@@ -160,14 +162,7 @@ export function createOasPrompt(
 
 export function createVersionPrompt(
   versionList: VersionList,
-  opts: {
-    beta?: string | boolean;
-    deprecated?: string;
-    fork?: string;
-    isPublic?: string | boolean;
-    main?: string | boolean;
-    newVersion?: string;
-  },
+  opts: VersionCreateOptions & VersionUpdateOptions,
   isUpdate?: {
     is_stable: string;
   }

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -26,7 +26,6 @@ type ParsedDocs = {
 };
 
 export function generatePrompts(versionList: VersionList, selectOnly = false) {
-  console.log("this function should be called... but it isn't and I have no idea why :sob:");
   return [
     {
       type: selectOnly ? null : 'select',

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -26,6 +26,7 @@ type ParsedDocs = {
 };
 
 export function generatePrompts(versionList: VersionList, selectOnly = false) {
+  console.log("this function should be called... but it isn't and I have no idea why :sob:");
   return [
     {
       type: selectOnly ? null : 'select',

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,7 +1,7 @@
 import type { VersionCreateOptions } from 'cmds/versions/create';
 import type { VersionUpdateOptions } from 'cmds/versions/update';
 import type { Response } from 'node-fetch';
-import type { Answers, Choice, PromptObject } from 'prompts';
+import type { Choice, PromptObject } from 'prompts';
 
 import parse from 'parse-link-header';
 import semver from 'semver';
@@ -71,12 +71,13 @@ function specOptions(specList: SpecList, parsedDocs: ParsedDocs, currPage: numbe
       value: s._id, // eslint-disable-line no-underscore-dangle
     };
   });
-  if (parsedDocs?.prev?.page)
+  if (parsedDocs?.prev?.page) {
     specs.push({
       description: 'Go to the previous page',
       title: `< Prev (page ${currPage - 1} of ${totalPages})`,
       value: 'prev',
     });
+  }
   if (parsedDocs?.next?.page) {
     specs.push({
       description: 'Go to the next page',
@@ -105,7 +106,9 @@ const updateOasPrompt = (
           const newSpecs = await getSpecs(`${parsedDocs.prev.url}`);
           const newParsedDocs = parse(newSpecs.headers.get('link'));
           const newSpecList = await newSpecs.json();
-          const { specId }: Answers<string> = await promptTerminal(
+          // @todo: figure out how to add a stricter type here, see:
+          // https://github.com/readmeio/rdme/pull/570#discussion_r949715913
+          const { specId } = await promptTerminal(
             updateOasPrompt(newSpecList, newParsedDocs, currPage - 1, totalPages, getSpecs)
           );
           return specId;
@@ -117,7 +120,9 @@ const updateOasPrompt = (
           const newSpecs = await getSpecs(`${parsedDocs.next.url}`);
           const newParsedDocs = parse(newSpecs.headers.get('link'));
           const newSpecList = await newSpecs.json();
-          const { specId }: Answers<string> = await promptTerminal(
+          // @todo: figure out how to add a stricter type here, see:
+          // https://github.com/readmeio/rdme/pull/570#discussion_r949715913
+          const { specId } = await promptTerminal(
             updateOasPrompt(newSpecList, newParsedDocs, currPage + 1, totalPages, getSpecs)
           );
           return specId;
@@ -146,11 +151,11 @@ export function createOasPrompt(
         { title: 'Update existing', value: 'update' },
         { title: 'Create a new spec', value: 'create' },
       ],
-      async format(picked: string) {
+      async format(picked: 'update' | 'create') {
         if (picked === 'update') {
-          const { specId }: Answers<string> = await promptTerminal(
-            updateOasPrompt(specList, parsedDocs, 1, totalPages, getSpecs)
-          );
+          // @todo: figure out how to add a stricter type here, see:
+          // https://github.com/readmeio/rdme/pull/570#discussion_r949715913
+          const { specId } = await promptTerminal(updateOasPrompt(specList, parsedDocs, 1, totalPages, getSpecs));
           return specId;
         }
 

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -186,7 +186,7 @@ export function createVersionPrompt(
       initial: opts.newVersion || false,
       hint: '1.0.0',
       validate(val: string) {
-        return semver.valid(semver.coerce(val)) ? true : this.styles.danger('Please specify a semantic version.');
+        return semver.valid(semver.coerce(val)) ? true : 'Please specify a semantic version.';
       },
     },
     {

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -166,64 +166,52 @@ export function createVersionPrompt(
   isUpdate?: {
     is_stable: string;
   }
-) {
+): PromptObject[] {
   return [
     {
-      type: 'select',
+      type: opts.fork || isUpdate ? null : 'select',
       name: 'from',
       message: 'Which version would you like to fork from?',
-      skip() {
-        return opts.fork || isUpdate;
-      },
       choices: versionList.map(v => {
         return {
-          message: v.version,
+          title: v.version,
           value: v.version,
         };
       }),
     },
     {
-      type: 'input',
+      type: opts.newVersion || !isUpdate ? null : 'text',
       name: 'newVersion',
       message: "What's your new version?",
       initial: opts.newVersion || false,
-      skip() {
-        return opts.newVersion || !isUpdate;
-      },
       hint: '1.0.0',
       validate(val: string) {
         return semver.valid(semver.coerce(val)) ? true : this.styles.danger('Please specify a semantic version.');
       },
     },
     {
-      type: 'confirm',
+      type: opts.main || isUpdate?.is_stable ? null : 'confirm',
       name: 'is_stable',
       message: 'Would you like to make this version the main version for this project?',
-      skip() {
-        return opts.main || isUpdate?.is_stable;
-      },
     },
     {
-      type: 'confirm',
+      type: opts.beta ? null : 'confirm',
       name: 'is_beta',
       message: 'Should this version be in beta?',
-      skip: () => opts.beta,
     },
     {
-      type: 'confirm',
+      type: (prev, values) => {
+        return opts.isPublic || opts.main || values.is_stable ? null : 'confirm';
+      },
       name: 'is_hidden',
       message: 'Would you like to make this version public?',
-      skip() {
-        return opts.isPublic || opts.main || this.enquirer.answers.is_stable;
-      },
     },
     {
-      type: 'confirm',
+      type: (prev, values) => {
+        return opts.deprecated || opts.main || !isUpdate || values.is_stable ? null : 'confirm';
+      },
       name: 'is_deprecated',
       message: 'Would you like to deprecate this version?',
-      skip() {
-        return opts.deprecated || opts.main || !isUpdate || this.enquirer.answers.is_stable;
-      },
     },
   ];
 }

--- a/src/lib/versionSelect.ts
+++ b/src/lib/versionSelect.ts
@@ -43,20 +43,14 @@ export async function getProjectVersion(versionFlag: string, key: string, allowN
 
       if (option === 'update') return versionSelection;
 
-      console.log('newVersion:', newVersion);
-
-      const body = JSON.stringify({
-        from: versionList[0].version,
-        version: newVersion,
-        is_stable: false,
-      });
-
-      console.log('body:', body);
-
       const newVersionFromApi = await fetch(`${config.get('host')}/api/v1/version`, {
         method: 'post',
         headers: cleanHeaders(key, new Headers({ 'Content-Type': 'application/json' })),
-        body,
+        body: JSON.stringify({
+          from: versionList[0].version,
+          version: newVersion,
+          is_stable: false,
+        }),
       })
         .then(res => handleRes(res))
         .then(res => res.version);

--- a/src/lib/versionSelect.ts
+++ b/src/lib/versionSelect.ts
@@ -43,14 +43,20 @@ export async function getProjectVersion(versionFlag: string, key: string, allowN
 
       if (option === 'update') return versionSelection;
 
+      console.log('newVersion:', newVersion);
+
+      const body = JSON.stringify({
+        from: versionList[0].version,
+        version: newVersion,
+        is_stable: false,
+      });
+
+      console.log('body:', body);
+
       const newVersionFromApi = await fetch(`${config.get('host')}/api/v1/version`, {
         method: 'post',
         headers: cleanHeaders(key, new Headers({ 'Content-Type': 'application/json' })),
-        body: JSON.stringify({
-          from: versionList[0].version,
-          version: newVersion,
-          is_stable: false,
-        }),
+        body,
       })
         .then(res => handleRes(res))
         .then(res => res.version);

--- a/src/lib/versionSelect.ts
+++ b/src/lib/versionSelect.ts
@@ -1,12 +1,12 @@
 import ciDetect from '@npmcli/ci-detect';
 import config from 'config';
 import { Headers } from 'node-fetch';
-import prompts from 'prompts';
 
 import APIError from './apiError';
 import fetch, { cleanHeaders, handleRes } from './fetch';
 import { warn } from './logger';
 import * as promptHandler from './prompts';
+import promptTerminal from './promptWrapper';
 
 /**
  * Validates and returns a project version.
@@ -39,7 +39,7 @@ export async function getProjectVersion(versionFlag: string, key: string, allowN
     }).then(res => handleRes(res));
 
     if (allowNewVersion) {
-      const { option, versionSelection, newVersion } = await prompts(promptHandler.generatePrompts(versionList));
+      const { option, versionSelection, newVersion } = await promptTerminal(promptHandler.generatePrompts(versionList));
 
       if (option === 'update') return versionSelection;
 
@@ -58,7 +58,7 @@ export async function getProjectVersion(versionFlag: string, key: string, allowN
       return newVersionFromApi;
     }
 
-    const { versionSelection } = await prompts(promptHandler.generatePrompts(versionList, true));
+    const { versionSelection } = await promptTerminal(promptHandler.generatePrompts(versionList, true));
 
     return versionSelection;
   } catch (err) {

--- a/src/lib/versionSelect.ts
+++ b/src/lib/versionSelect.ts
@@ -49,7 +49,7 @@ export async function getProjectVersion(versionFlag: string, key: string, allowN
 
       if (option === 'update') return versionSelection;
 
-      const { version: newVersionFromApi }: { version: string } = await fetch(`${config.get('host')}/api/v1/version`, {
+      const newVersionFromApi = await fetch(`${config.get('host')}/api/v1/version`, {
         method: 'post',
         headers: cleanHeaders(key, new Headers({ 'Content-Type': 'application/json' })),
         body: JSON.stringify({
@@ -57,7 +57,9 @@ export async function getProjectVersion(versionFlag: string, key: string, allowN
           version: newVersion,
           is_stable: false,
         }),
-      }).then(res => handleRes(res));
+      })
+        .then(res => handleRes(res))
+        .then(res => res.version);
 
       return newVersionFromApi;
     }

--- a/src/lib/versionSelect.ts
+++ b/src/lib/versionSelect.ts
@@ -1,7 +1,7 @@
 import ciDetect from '@npmcli/ci-detect';
 import config from 'config';
-import { prompt } from 'enquirer';
 import { Headers } from 'node-fetch';
+import prompts from 'prompts';
 
 import APIError from './apiError';
 import fetch, { cleanHeaders, handleRes } from './fetch';
@@ -39,13 +39,7 @@ export async function getProjectVersion(versionFlag: string, key: string, allowN
     }).then(res => handleRes(res));
 
     if (allowNewVersion) {
-      const {
-        option,
-        versionSelection,
-        newVersion,
-      }: { option: 'update' | 'create'; versionSelection: string; newVersion: string } = await prompt(
-        promptHandler.generatePrompts(versionList)
-      );
+      const { option, versionSelection, newVersion } = await prompts(promptHandler.generatePrompts(versionList));
 
       if (option === 'update') return versionSelection;
 
@@ -64,9 +58,7 @@ export async function getProjectVersion(versionFlag: string, key: string, allowN
       return newVersionFromApi;
     }
 
-    const { versionSelection }: { versionSelection: string } = await prompt(
-      promptHandler.generatePrompts(versionList, true)
-    );
+    const { versionSelection } = await prompts(promptHandler.generatePrompts(versionList, true));
 
     return versionSelection;
   } catch (err) {

--- a/src/lib/versionSelect.ts
+++ b/src/lib/versionSelect.ts
@@ -49,7 +49,7 @@ export async function getProjectVersion(versionFlag: string, key: string, allowN
 
       if (option === 'update') return versionSelection;
 
-      await fetch(`${config.get('host')}/api/v1/version`, {
+      const { version: newVersionFromApi }: { version: string } = await fetch(`${config.get('host')}/api/v1/version`, {
         method: 'post',
         headers: cleanHeaders(key, new Headers({ 'Content-Type': 'application/json' })),
         body: JSON.stringify({
@@ -57,9 +57,9 @@ export async function getProjectVersion(versionFlag: string, key: string, allowN
           version: newVersion,
           is_stable: false,
         }),
-      });
+      }).then(res => handleRes(res));
 
-      return newVersion;
+      return newVersionFromApi;
     }
 
     const { versionSelection }: { versionSelection: string } = await prompt(


### PR DESCRIPTION
| 🚥 Fix RM-5116 |
| :-- |

## 🧰 Changes

Migrating our prompts system from the universally-disliked [`enquirer`](https://github.com/enquirer/enquirer) to [`prompts`](https://github.com/terkelg/prompts). In addition to it being a far better from a DX and testing standpoint, we also get a few nice helpful cues from `prompts` when a user is required to take an action (note the grayed out "use arrow-keys" guidance):

<img width="750" alt="image" src="https://user-images.githubusercontent.com/8854718/185512817-4c848c4a-dccd-4b7e-9cbe-e1bc42842735.png">

Overall, the prompt object patterns are fairly similar and there shouldn't be a whole lot of material changes for users (except in maybe the `login` command since that was previously using the ancient [`read`](https://npm.im/read) package).

### Which Commands Are Affected?

All areas of `rdme` that use a prompts-based system have been migrated over, namely:

- [x] Version selection (prompt: selecting project versions in the `categories`, `docs`, `openapi`, and `versions` command families)
- [x] `openapi` (prompt: selecting a spec)
- [x] `versions:create` (prompt: setting properties on the version you want to create)
- [x] `versions:update` (prompt: similar to above[^2])
- [x] `login` (prompt: logging in!)

### Other Small Cleanups 🧹 

Because this work got me looking into commands that don't get a lot of love, here are a bunch of other miscellaneous changes in this PR:
 - [x] I cleaned a bunch of types and added a bunch of tests in the `versions` group of commands (and honestly there's still a lot of work left to be done) and may or may not have fixed a few random bugs in the process. Not sure how much these commands are being used, I'd honestly love if we did away with them at some point 👀 
 - [x] Swapped out [`isemail`](https://npm.im/isemail) for [`vaildator`](https://npm.im/vaildator) since it's better maintained and a bit smaller of a dep.
 - [x] Shortened our debug command from `debug:bin` to just `debug`.
 - [x] Finally got our `openapi` command test coverage to 💯 
 - [x] Added a smol send off when someone exits the prompt system early:

<img width="634" alt="image" src="https://user-images.githubusercontent.com/8854718/185512370-4940bea1-8275-425a-8c10-ddad4af00982.png">

## 🧬 QA & Testing

Tests (particularly for the version commands) should be far more resilient, so if those pass then that's a really good sign[^1]. I've tried a bunch of different user journeys locally (and backfilled test coverage where I easily could) and everything appears to work well!

[^1]: I still **cannot** get over how almost all of our `enquirer`-mocked tests were simply not testing anything at all for like... 3+ years now. Good riddance 🖕🏽 
[^2]: you'd think it was similar enough to `create` that this would be easy... but they're annoyingly different