### PR TITLE
feat(openapi): add `--create` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ This will upload `path-to-openapi.json` to your project and return an ID and URL
 rdme openapi [path-to-file.json]
 ```
 
+If you want to bypass the prompt to upload or create an API definition, you can pass the `--create` flag:
+
+```sh
+rdme openapi [path-to-file.json] --version={project-version} --create
+```
+
 #### Editing (Re-Syncing) an Existing API Definition
 
 This will edit (re-sync) an existing API definition (identified by `--id`) within your ReadMe project.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This will upload `path-to-openapi.json` to your project and return an ID and URL
 rdme openapi [path-to-file.json]
 ```
 
-If you want to bypass the prompt to upload or create an API definition, you can pass the `--create` flag:
+If you want to bypass the prompt to create or update an API definition, you can pass the `--create` flag:
 
 ```sh
 rdme openapi [path-to-file.json] --version={project-version} --create

--- a/__tests__/__snapshots__/index.test.ts.snap
+++ b/__tests__/__snapshots__/index.test.ts.snap
@@ -15,6 +15,7 @@ Options
                               uploading an existing API definition.                                 
   --version string            Project version. If running command in a CI environment and this      
                               option is not passed, the main project version will be used.          
+  --create                    Bypasses the create/update prompt and creates a new API definition.   
   --useSpecVersion            Uses the version listed in the \`info.version\` field in the API        
                               definition for the project version parameter.                         
   --workingDirectory string   Working directory (for usage with relative external references)       
@@ -43,6 +44,7 @@ Options
                               uploading an existing API definition.                                 
   --version string            Project version. If running command in a CI environment and this      
                               option is not passed, the main project version will be used.          
+  --create                    Bypasses the create/update prompt and creates a new API definition.   
   --useSpecVersion            Uses the version listed in the \`info.version\` field in the API        
                               definition for the project version parameter.                         
   --workingDirectory string   Working directory (for usage with relative external references)       
@@ -71,6 +73,7 @@ Options
                               uploading an existing API definition.                                 
   --version string            Project version. If running command in a CI environment and this      
                               option is not passed, the main project version will be used.          
+  --create                    Bypasses the create/update prompt and creates a new API definition.   
   --useSpecVersion            Uses the version listed in the \`info.version\` field in the API        
                               definition for the project version parameter.                         
   --workingDirectory string   Working directory (for usage with relative external references)       

--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -197,6 +197,38 @@ describe('rdme openapi', () => {
       return mock.done();
     });
 
+    it('should create a new spec via `--create` flag and ignore `--id`', async () => {
+      const registryUUID = getRandomRegistryId();
+
+      const mock = getAPIMock()
+        .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
+        .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
+        .post('/api/v1/api-specification', { registryUUID })
+        .delayConnection(1000)
+        .basicAuth({ user: key })
+        .reply(201, { _id: 1 }, { location: exampleRefLocation });
+
+      const spec = './__tests__/__fixtures__/ref-oas/petstore.json';
+
+      await expect(
+        openapi.run({
+          key,
+          spec,
+          id: 'some-id',
+          create: true,
+        })
+      ).resolves.toBe(successfulUpload(spec));
+
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(console.info).toHaveBeenCalledTimes(0);
+
+      const output = getCommandOutput();
+
+      expect(output).toMatch(/the `--id` parameter will be ignored/i);
+
+      return mock.done();
+    });
+
     it('should bundle and upload the expected content', async () => {
       let requestBody;
       const registryUUID = getRandomRegistryId();

--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -169,6 +169,34 @@ describe('rdme openapi', () => {
       return mock.done();
     });
 
+    it('should create a new spec via `--create` flag', async () => {
+      const registryUUID = getRandomRegistryId();
+
+      const mock = getAPIMock()
+        .get(`/api/v1/version/${version}`)
+        .basicAuth({ user: key })
+        .reply(200, [{ version }])
+        .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
+        .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
+        .post('/api/v1/api-specification', { registryUUID })
+        .delayConnection(1000)
+        .basicAuth({ user: key })
+        .reply(201, { _id: 1 }, { location: exampleRefLocation });
+
+      const spec = './__tests__/__fixtures__/ref-oas/petstore.json';
+
+      await expect(
+        openapi.run({
+          key,
+          version,
+          spec,
+          create: true,
+        })
+      ).resolves.toBe(successfulUpload(spec));
+
+      return mock.done();
+    });
+
     it('should bundle and upload the expected content', async () => {
       let requestBody;
       const registryUUID = getRandomRegistryId();

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -92,6 +92,10 @@ export default class OpenAPICommand extends Command {
       );
     }
 
+    if (create && id) {
+      Command.warn("We'll be using the `--create` option , so the `--id` parameter will be ignored.");
+    }
+
     // Reason we're hardcoding in command here is because `swagger` command
     // relies on this and we don't want to use `swagger` in this function
     const { bundledSpec, specPath, specType, specVersion } = await prepareOas(spec, 'openapi');
@@ -220,8 +224,9 @@ export default class OpenAPICommand extends Command {
       });
     }
 
+    if (create) return createSpec();
+
     if (!id) {
-      if (create) return createSpec();
       Command.debug('no id parameter, retrieving list of API specs');
       const apiSettings = await getSpecs('/api/v1/api-specification');
 

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -57,7 +57,7 @@ export default class OpenAPICommand extends Command {
       {
         name: 'create',
         type: Boolean,
-        description: 'Bypasses the update/create prompt and creates a new API definition.',
+        description: 'Bypasses the create/update prompt and creates a new API definition.',
       },
       {
         name: 'useSpecVersion',

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -20,6 +20,7 @@ export type Options = {
   id?: string;
   spec?: string;
   version?: string;
+  create?: boolean;
   useSpecVersion?: boolean;
   workingDirectory?: string;
 };
@@ -54,6 +55,11 @@ export default class OpenAPICommand extends Command {
         defaultOption: true,
       },
       {
+        name: 'create',
+        type: Boolean,
+        description: 'Bypasses the update/create prompt and creates a new API definition.',
+      },
+      {
         name: 'useSpecVersion',
         type: Boolean,
         description:
@@ -70,7 +76,7 @@ export default class OpenAPICommand extends Command {
   async run(opts: CommandOptions<Options>) {
     super.run(opts, true);
 
-    const { key, id, spec, useSpecVersion, version, workingDirectory } = opts;
+    const { key, id, spec, create, useSpecVersion, version, workingDirectory } = opts;
 
     let selectedVersion = version;
     let isUpdate: boolean;
@@ -215,6 +221,7 @@ export default class OpenAPICommand extends Command {
     }
 
     if (!id) {
+      if (create) return createSpec();
       Command.debug('no id parameter, retrieving list of API specs');
       const apiSettings = await getSpecs('/api/v1/api-specification');
 


### PR DESCRIPTION
| 🚥 Fix RM-5148 |
| :-- |

## 🧰 Changes

Adds a `--create` flag to the `openapi` command so users can bypass the prompt that asks them whether or not they want to create or update a spec.

## 🧬 QA & Testing

See tests.
