### PR TITLE
chore(prompt): various enhancements and refactors

### DIFF
--- a/__tests__/cmds/login.test.ts
+++ b/__tests__/cmds/login.test.ts
@@ -103,5 +103,21 @@ describe('rdme login', () => {
     mock.done();
   });
 
-  it.todo('should error if trying to access a project that is not yours');
+  it('should error if trying to access a project that is not yours', async () => {
+    const projectThatIsNotYours = 'unauthorized-project';
+    prompts.inject([email, password, projectThatIsNotYours]);
+    const errorResponse = {
+      error: 'PROJECT_NOTFOUND',
+      message: `The project (${projectThatIsNotYours}) can't be found.`,
+      suggestion: `The project is referred to as your \`subdomain\` in the dashboard when you're looking for it. If you're sure it exists, maybe you don't have access to it? You can check if it exists here: https://${projectThatIsNotYours}.readme.io.`,
+      help: 'If you need help, email support@readme.io',
+    };
+
+    const mock = getAPIMock()
+      .post('/api/v1/login', { email, password, project: projectThatIsNotYours })
+      .reply(404, errorResponse);
+
+    await expect(cmd.run({})).rejects.toStrictEqual(new APIError(errorResponse));
+    mock.done();
+  });
 });

--- a/src/cmds/categories/create.ts
+++ b/src/cmds/categories/create.ts
@@ -58,7 +58,7 @@ export default class CategoriesCreateCommand extends Command {
   }
 
   async run(opts: CommandOptions<Options>) {
-    super.run(opts, true);
+    super.run(opts);
 
     const { categoryType, title, key, version, preventDuplicates } = opts;
 

--- a/src/cmds/categories/index.ts
+++ b/src/cmds/categories/index.ts
@@ -25,7 +25,7 @@ export default class CategoriesCommand extends Command {
   }
 
   async run(opts: CommandOptions<{}>) {
-    super.run(opts, true);
+    super.run(opts);
 
     const { key, version } = opts;
 

--- a/src/cmds/changelogs/index.ts
+++ b/src/cmds/changelogs/index.ts
@@ -43,7 +43,7 @@ export default class ChangelogsCommand extends Command {
   }
 
   async run(opts: CommandOptions<Options>) {
-    super.run(opts, true);
+    super.run(opts);
 
     const { dryRun, folder, key } = opts;
 

--- a/src/cmds/changelogs/single.ts
+++ b/src/cmds/changelogs/single.ts
@@ -42,7 +42,7 @@ export default class SingleChangelogCommand extends Command {
   }
 
   async run(opts: CommandOptions<Options>) {
-    super.run(opts, true);
+    super.run(opts);
 
     const { dryRun, filePath, key } = opts;
 

--- a/src/cmds/custompages/index.ts
+++ b/src/cmds/custompages/index.ts
@@ -43,7 +43,7 @@ export default class CustomPagesCommand extends Command {
   }
 
   async run(opts: CommandOptions<Options>) {
-    super.run(opts, true);
+    super.run(opts);
 
     const { dryRun, folder, key } = opts;
 

--- a/src/cmds/custompages/single.ts
+++ b/src/cmds/custompages/single.ts
@@ -41,7 +41,7 @@ export default class SingleCustomPageCommand extends Command {
   }
 
   async run(opts: CommandOptions<Options>) {
-    super.run(opts, true);
+    super.run(opts);
 
     const { dryRun, filePath, key } = opts;
 

--- a/src/cmds/docs/edit.ts
+++ b/src/cmds/docs/edit.ts
@@ -49,7 +49,7 @@ export default class EditDocsCommand extends Command {
   }
 
   async run(opts: CommandOptions<Options>): Promise<undefined> {
-    super.run(opts, true);
+    super.run(opts);
 
     const { slug, key, version } = opts;
 

--- a/src/cmds/docs/index.ts
+++ b/src/cmds/docs/index.ts
@@ -45,7 +45,7 @@ export default class DocsCommand extends Command {
   }
 
   async run(opts: CommandOptions<Options>) {
-    super.run(opts, true);
+    super.run(opts);
 
     const { dryRun, folder, key, version } = opts;
 

--- a/src/cmds/docs/single.ts
+++ b/src/cmds/docs/single.ts
@@ -44,7 +44,7 @@ export default class SingleDocCommand extends Command {
   }
 
   async run(opts: CommandOptions<Options>) {
-    super.run(opts, true);
+    super.run(opts);
 
     const { dryRun, filePath, key, version } = opts;
 

--- a/src/cmds/login.ts
+++ b/src/cmds/login.ts
@@ -2,6 +2,7 @@ import type { CommandOptions } from '../lib/baseCommand';
 
 import chalk from 'chalk';
 import config from 'config';
+import prompts from 'prompts';
 import isEmail from 'validator/lib/isEmail';
 
 import Command, { CommandCategories } from '../lib/baseCommand';
@@ -44,9 +45,9 @@ export default class LoginCommand extends Command {
   async run(opts: CommandOptions<Options>) {
     super.run(opts);
 
-    let { project } = opts;
+    prompts.override(opts);
 
-    const promptResults = await promptTerminal([
+    const { email, password, project, token } = await promptTerminal([
       {
         type: 'text',
         name: 'email',
@@ -62,7 +63,7 @@ export default class LoginCommand extends Command {
         message: 'What is your password?',
       },
       {
-        type: opts.project ? null : 'text',
+        type: 'text',
         name: 'project',
         message: 'What project are you logging into?',
         initial: configStore.get('project'),
@@ -73,10 +74,6 @@ export default class LoginCommand extends Command {
         message: 'What is your 2FA token?',
       },
     ]);
-
-    const { email, password, token } = promptResults;
-
-    if (promptResults.project) project = promptResults.project;
 
     if (!project) {
       return Promise.reject(new Error('No project subdomain provided. Please use `--project`.'));

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -68,7 +68,7 @@ export default class OpenAPICommand extends Command {
   }
 
   async run(opts: CommandOptions<Options>) {
-    super.run(opts, true);
+    super.run(opts);
 
     const { key, id, spec, useSpecVersion, version, workingDirectory } = opts;
 

--- a/src/cmds/versions/create.ts
+++ b/src/cmds/versions/create.ts
@@ -50,7 +50,7 @@ export default class CreateVersionCommand extends Command {
   }
 
   async run(opts: CommandOptions<VersionCreateOptions>) {
-    super.run(opts, true);
+    super.run(opts);
 
     let versionList;
     const { key, version, fork, codename, main, beta, isPublic } = opts;

--- a/src/cmds/versions/delete.ts
+++ b/src/cmds/versions/delete.ts
@@ -32,7 +32,7 @@ export default class DeleteVersionCommand extends Command {
   }
 
   async run(opts: CommandOptions<{}>) {
-    super.run(opts, true);
+    super.run(opts);
 
     const { key, version } = opts;
 

--- a/src/cmds/versions/index.ts
+++ b/src/cmds/versions/index.ts
@@ -106,7 +106,7 @@ export default class VersionsCommand extends Command {
   }
 
   async run(opts: CommandOptions<Options>) {
-    super.run(opts, true);
+    super.run(opts);
 
     const { key, version, raw } = opts;
 

--- a/src/cmds/versions/update.ts
+++ b/src/cmds/versions/update.ts
@@ -44,7 +44,7 @@ export default class UpdateVersionCommand extends Command {
   }
 
   async run(opts: CommandOptions<VersionUpdateOptions>) {
-    super.run(opts, true);
+    super.run(opts);
 
     const { key, version, newVersion, codename, main, beta, isPublic, deprecated } = opts;
 

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -71,11 +71,11 @@ export default class Command {
    */
   args: OptionDefinition[];
 
-  run(opts: CommandOptions<{}>, requiresAuth?: boolean): void | Promise<string> {
+  run(opts: CommandOptions<{}>): void | Promise<string> {
     Command.debug(`command: ${this.command}`);
     Command.debug(`opts: ${JSON.stringify(opts)}`);
 
-    if (requiresAuth) {
+    if (this.args.some(arg => arg.name === 'key')) {
       if (!opts.key) {
         throw new Error('No project API key provided. Please use `--key`.');
       }

--- a/src/lib/promptWrapper.ts
+++ b/src/lib/promptWrapper.ts
@@ -11,12 +11,7 @@ export default async function promptTerminal<T extends string = string>(
   questions: prompts.PromptObject<T> | prompts.PromptObject<T>[],
   options?: prompts.Options
 ): Promise<prompts.Answers<T>> {
-  const enableTerminalCursor = () => {
-    process.stdout.write('\x1B[?25h');
-  };
-
   const onCancel = () => {
-    enableTerminalCursor();
     process.stdout.write('\n');
     process.stdout.write('Thanks for using rdme! See you soon ✌️');
     process.stdout.write('\n\n');

--- a/src/lib/promptWrapper.ts
+++ b/src/lib/promptWrapper.ts
@@ -11,6 +11,10 @@ export default async function promptTerminal<T extends string = string>(
   questions: prompts.PromptObject<T> | prompts.PromptObject<T>[],
   options?: prompts.Options
 ): Promise<prompts.Answers<T>> {
+  /**
+   * The CTRL+C handler discussed above.
+   * @see {@link https://github.com/terkelg/prompts#optionsoncancel}
+   */
   const onCancel = () => {
     process.stdout.write('\n');
     process.stdout.write('Thanks for using rdme! See you soon ✌️');

--- a/src/lib/promptWrapper.ts
+++ b/src/lib/promptWrapper.ts
@@ -15,25 +15,13 @@ export default async function promptTerminal<T extends string = string>(
     process.stdout.write('\x1B[?25h');
   };
 
-  const onState = (state: { aborted: boolean }) => {
-    if (state.aborted) {
-      // If we don't re-enable the terminal cursor before exiting the program, the cursor will
-      // remain hidden.
-      enableTerminalCursor();
-      process.stdout.write('\n\n');
-      process.stdout.write('Thanks for using rdme! See you soon ✌️');
-      process.stdout.write('\n\n');
-      process.exit(1);
-    }
+  const onCancel = () => {
+    enableTerminalCursor();
+    process.stdout.write('\n');
+    process.stdout.write('Thanks for using rdme! See you soon ✌️');
+    process.stdout.write('\n\n');
+    process.exit(1);
   };
 
-  if (Array.isArray(questions)) {
-    // eslint-disable-next-line no-param-reassign
-    questions = questions.map(question => ({ ...question, onState }));
-  } else {
-    // eslint-disable-next-line no-param-reassign
-    questions.onState = onState;
-  }
-
-  return prompts(questions, options);
+  return prompts(questions, { onCancel, ...options });
 }


### PR DESCRIPTION
| 🚥 Fix RM-3621 (and a bunch of other stuff) |
| :-- |

## 🧰 Changes

- [x] Refactored the `login` command to use [overrides](https://github.com/terkelg/prompts#override) and added a few tests
- [x] Refactored our [`onState`](https://github.com/terkelg/prompts#onstate) usage to use [`onCancel`](https://github.com/terkelg/prompts#optionsoncancel) (see 16f61172839e1ced3b0c9bd8a555416dca967bad for more reasoning)
- [x] Removed the apparently unnecessary `enableTerminalCursor` function. Not sure if it was working before but I've tried a bunch of things and can't get my cursor to disappear. I'm cool with keeping it in there just to be safe too, let me know what you think 🤷🏽 
- [x] Refactored our authenticated commands so we dynamically detect the `key` argument via the `args` array, rather than having a flag that we have to manually enable
- [x] Added top-level CI detection so our prompts error out in CI environments

## 🧬 QA & Testing

Tests appear to pass, but it might be good to check out this branch, run the build, and try messing around.

- [ ] Does the terminal cursor remain intact no matter what commands you try?
- [ ] Are you still able to safely exit out of prompts using <kbd>CTRL</kbd>+<kbd>C</kbd> or <kbd>ESC</kbd>?
- [ ] Does CI detection work for you properly?[^1]

[^1]: You can test this by prefixing any command with a [CI env variable](https://github.com/npm/ci-detect/blob/main/lib/index.js). I've been running `GITLAB_CI=true bin/rdme login`