### PR TITLE
feat(openapi): Add `updateSingleSpec` option to automatically update an only available spec file without any prompts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,5 +80,10 @@ jobs:
       # Docs: https://rdme-test.readme.io
       - name: Run `openapi` command
         uses: ./rdme-repo/
+        # Only run this step if the GitHub secrets are present
+        # (this won't be the case for external contributors' forks)
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif
+        # https://docs.github.com/en/actions/learn-github-actions/expressions#about-expressions
+        if: ${{ secrets.RDME_TEST_PROJECT_API_KEY }}
         with:
           rdme: openapi oas-examples-repo/3.1/json/petstore.json --key=${{ secrets.RDME_TEST_PROJECT_API_KEY }} --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,5 @@ jobs:
       # Docs: https://rdme-test.readme.io
       - name: Run `openapi` command
         uses: ./rdme-repo/
-        # Only run this step if the GitHub secrets are present
-        # (this won't be the case for external contributors' forks)
-        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif
-        # https://docs.github.com/en/actions/learn-github-actions/expressions#about-expressions
-        if: ${{ secrets.RDME_TEST_PROJECT_API_KEY }}
         with:
           rdme: openapi oas-examples-repo/3.1/json/petstore.json --key=${{ secrets.RDME_TEST_PROJECT_API_KEY }} --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}

--- a/README.md
+++ b/README.md
@@ -117,11 +117,13 @@ rdme openapi [path-to-file.json] --id={existing-id}
 
 #### Uploading or Editing an API Definition in a Project Version
 
-You can additional include a version flag, specifying the target version for your file's destination. This approach will provide you with CLI prompts, so we do not recommend this technique in CI environments.
+You can additionally include a version flag, specifying the target version for your file's destination. This approach will provide you with CLI prompts, so we do not recommend this technique in CI environments.
 
 ```sh
 rdme openapi [path-to-file.json] --version={project-version}
 ```
+
+You can add `--updateSingleSpec` to the command so if there's only one spec file available to update, it will select it without any prompts.
 
 If you wish to use the version specified [in the `info.version` field of your API definition](https://spec.openapis.org/oas/v3.1.0#fixed-fields-0), you can pass the `--useSpecVersion` option. For example, say [the `info` object](https://spec.openapis.org/oas/v3.1.0#info-object) of your API definition looks like this:
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ rdme openapi [path-to-file.json] --version={project-version} --create
 
 #### Editing (Re-Syncing) an Existing API Definition
 
-This will edit (re-sync) an existing API definition (identified by `--id`) within your ReadMe project.
+This will edit (re-sync) an existing API definition (identified by `--id`) within your ReadMe project. **This is the recommended approach for usage in CI environments.**
 
 ```sh
 rdme openapi [path-to-file.json] --id={existing-id}
@@ -122,8 +122,6 @@ You can additionally include a version flag, specifying the target version for y
 ```sh
 rdme openapi [path-to-file.json] --version={project-version}
 ```
-
-You can add `--updateSingleSpec` to the command so if there's only one spec file available to update, it will select it without any prompts.
 
 If you wish to use the version specified [in the `info.version` field of your API definition](https://spec.openapis.org/oas/v3.1.0#fixed-fields-0), you can pass the `--useSpecVersion` option. For example, say [the `info` object](https://spec.openapis.org/oas/v3.1.0#info-object) of your API definition looks like this:
 
@@ -139,6 +137,12 @@ You can pass in the `--useSpecVersion` option, which would be equivalent to pass
 
 ```sh
 rdme openapi [path-to-file.json] --useSpecVersion
+```
+
+You can add `--update` to the command so if there's only one API definition for the given project version to update, it will select it without any prompts:
+
+```sh
+rdme openapi [path-to-file.json] --version={project-version} --update
 ```
 
 #### Omitting the File Path

--- a/__tests__/__snapshots__/index.test.ts.snap
+++ b/__tests__/__snapshots__/index.test.ts.snap
@@ -19,7 +19,8 @@ Options
   --useSpecVersion            Uses the version listed in the \`info.version\` field in the API        
                               definition for the project version parameter.                         
   --workingDirectory string   Working directory (for usage with relative external references)       
-  --updateSingleSpec          Automatically update an existing spec file if it's the only one found 
+  --update                    Automatically update an existing API definition in ReadMe if it's the 
+                              only one associated with the current version.                         
   -h, --help                  Display this usage guide                                              
 
 Related commands
@@ -48,7 +49,8 @@ Options
   --useSpecVersion            Uses the version listed in the \`info.version\` field in the API        
                               definition for the project version parameter.                         
   --workingDirectory string   Working directory (for usage with relative external references)       
-  --updateSingleSpec          Automatically update an existing spec file if it's the only one found 
+  --update                    Automatically update an existing API definition in ReadMe if it's the 
+                              only one associated with the current version.                         
   -h, --help                  Display this usage guide                                              
 
 Related commands
@@ -77,7 +79,8 @@ Options
   --useSpecVersion            Uses the version listed in the \`info.version\` field in the API        
                               definition for the project version parameter.                         
   --workingDirectory string   Working directory (for usage with relative external references)       
-  --updateSingleSpec          Automatically update an existing spec file if it's the only one found 
+  --update                    Automatically update an existing API definition in ReadMe if it's the 
+                              only one associated with the current version.                         
   -h, --help                  Display this usage guide                                              
 
 Related commands

--- a/__tests__/__snapshots__/index.test.ts.snap
+++ b/__tests__/__snapshots__/index.test.ts.snap
@@ -19,6 +19,7 @@ Options
   --useSpecVersion            Uses the version listed in the \`info.version\` field in the API        
                               definition for the project version parameter.                         
   --workingDirectory string   Working directory (for usage with relative external references)       
+  --updateSingleSpec          Automatically update an existing spec file if it's the only one found 
   -h, --help                  Display this usage guide                                              
 
 Related commands
@@ -47,6 +48,7 @@ Options
   --useSpecVersion            Uses the version listed in the \`info.version\` field in the API        
                               definition for the project version parameter.                         
   --workingDirectory string   Working directory (for usage with relative external references)       
+  --updateSingleSpec          Automatically update an existing spec file if it's the only one found 
   -h, --help                  Display this usage guide                                              
 
 Related commands
@@ -75,6 +77,7 @@ Options
   --useSpecVersion            Uses the version listed in the \`info.version\` field in the API        
                               definition for the project version parameter.                         
   --workingDirectory string   Working directory (for usage with relative external references)       
+  --updateSingleSpec          Automatically update an existing spec file if it's the only one found 
   -h, --help                  Display this usage guide                                              
 
 Related commands

--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -409,7 +409,7 @@ describe('rdme openapi', () => {
       return mock.done();
     });
 
-    it('should update a spec file without prompts if providing `updateSingleSpec` and it\'s the only spec available' , async () => {
+    it("should update a spec file without prompts if providing `updateSingleSpec` and it's the only spec available", async () => {
       const registryUUID = getRandomRegistryId();
 
       const mock = getAPIMock()
@@ -420,9 +420,7 @@ describe('rdme openapi', () => {
         .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
         .get('/api/v1/api-specification')
         .basicAuth({ user: key })
-        .reply(200, [
-          { _id: 'spec1', title: 'spec1_title' },
-        ])
+        .reply(200, [{ _id: 'spec1', title: 'spec1_title' }])
         .put('/api/v1/api-specification/spec1', { registryUUID })
         .delayConnection(1000)
         .basicAuth({ user: key })
@@ -435,7 +433,7 @@ describe('rdme openapi', () => {
           key,
           version,
           spec,
-          updateSingleSpec: true
+          updateSingleSpec: true,
         })
       ).resolves.toBe(successfulUpdate(spec));
       return mock.done();

--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -678,6 +678,12 @@ describe('rdme openapi', () => {
       ).rejects.toStrictEqual(new Error('No project API key provided. Please use `--key`.'));
     });
 
+    it('should error if `--create` and `--update` flags are passed simultaneously', () => {
+      return expect(openapi.run({ key, create: true, update: true })).rejects.toStrictEqual(
+        new Error('The `--create` and `--update` options cannot be used simultaneously. Please use one or the other!')
+      );
+    });
+
     it('should error if invalid API key is sent and version list does not load', async () => {
       const errorObject = {
         error: 'APIKEY_NOTFOUND',

--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -409,6 +409,38 @@ describe('rdme openapi', () => {
       return mock.done();
     });
 
+    it('should update a spec file without prompts if providing `updateSingleSpec` and it\'s the only spec available' , async () => {
+      const registryUUID = getRandomRegistryId();
+
+      const mock = getAPIMock()
+        .get(`/api/v1/version/${version}`)
+        .basicAuth({ user: key })
+        .reply(200, [{ version }])
+        .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
+        .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
+        .get('/api/v1/api-specification')
+        .basicAuth({ user: key })
+        .reply(200, [
+          { _id: 'spec1', title: 'spec1_title' },
+        ])
+        .put('/api/v1/api-specification/spec1', { registryUUID })
+        .delayConnection(1000)
+        .basicAuth({ user: key })
+        .reply(201, { _id: 1 }, { location: exampleRefLocation });
+
+      const spec = './__tests__/__fixtures__/ref-oas/petstore.json';
+
+      await expect(
+        openapi.run({
+          key,
+          version,
+          spec,
+          updateSingleSpec: true
+        })
+      ).resolves.toBe(successfulUpdate(spec));
+      return mock.done();
+    });
+
     it.todo('should paginate to next and previous pages of specs');
   });
 

--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -409,8 +409,8 @@ describe('rdme openapi', () => {
       return mock.done();
     });
 
-    describe('--updateSingleSpec', () => {
-      it("should update a spec file without prompts if providing `updateSingleSpec` and it's the only spec available", async () => {
+    describe('--update', () => {
+      it("should update a spec file without prompts if providing `update` and it's the only spec available", async () => {
         const registryUUID = getRandomRegistryId();
 
         const mock = getAPIMock()
@@ -434,13 +434,13 @@ describe('rdme openapi', () => {
             key,
             version,
             spec,
-            updateSingleSpec: true,
+            update: true,
           })
         ).resolves.toBe(successfulUpdate(spec));
         return mock.done();
       });
 
-      it('should error if providing `updateSingleSpec` and there are multiple specs available', async () => {
+      it('should error if providing `update` and there are multiple specs available', async () => {
         const registryUUID = getRandomRegistryId();
 
         const mock = getAPIMock()
@@ -463,17 +463,17 @@ describe('rdme openapi', () => {
             key,
             version,
             spec,
-            updateSingleSpec: true,
+            update: true,
           })
         ).rejects.toStrictEqual(
           new Error(
-            "The option `--updateSingleSpec` can't be used when there's more than one spec file available (found 2)."
+            "The `--update` option cannot be used when there's more than one API definition available (found 2)."
           )
         );
         return mock.done();
       });
 
-      it('should warn if providing both `updateSingleSpec` and `id`', async () => {
+      it('should warn if providing both `update` and `id`', async () => {
         const registryUUID = getRandomRegistryId();
 
         const mock = getAPIMock()
@@ -489,7 +489,7 @@ describe('rdme openapi', () => {
           openapi.run({
             key,
             spec,
-            updateSingleSpec: true,
+            update: true,
             id: 'spec1',
           })
         ).resolves.toBe(successfulUpdate(spec));
@@ -498,9 +498,7 @@ describe('rdme openapi', () => {
         expect(console.info).toHaveBeenCalledTimes(0);
 
         const output = getCommandOutput();
-        expect(output).toMatch(
-          /When using the `--id` option the `--updateSingleSpec` option is ignored, as the desired spec id is already specified./
-        );
+        expect(output).toMatch(/the `--update` parameter will be ignored./);
         return mock.done();
       });
     });

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -102,6 +102,12 @@ export default class OpenAPICommand extends Command {
       Command.warn("We'll be using the `--create` option , so the `--id` parameter will be ignored.");
     }
 
+    if (updateSingleSpec && id) {
+      Command.warn(
+        'When using the `--id` option the `--updateSingleSpec` option is ignored, as the desired spec id is already specified.'
+      );
+    }
+
     // Reason we're hardcoding in command here is because `swagger` command
     // relies on this and we don't want to use `swagger` in this function
     const { bundledSpec, specPath, specType, specVersion } = await prepareOas(spec, 'openapi');

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -23,7 +23,7 @@ export type Options = {
   create?: boolean;
   useSpecVersion?: boolean;
   workingDirectory?: string;
-  updateSingleSpec?: boolean;
+  update?: boolean;
 };
 
 export default class OpenAPICommand extends Command {
@@ -72,9 +72,10 @@ export default class OpenAPICommand extends Command {
         description: 'Working directory (for usage with relative external references)',
       },
       {
-        name: 'updateSingleSpec',
+        name: 'update',
         type: Boolean,
-        description: "Automatically update an existing spec file if it's the only one found",
+        description:
+          "Automatically update an existing API definition in ReadMe if it's the only one associated with the current version.",
       },
     ];
   }
@@ -82,7 +83,7 @@ export default class OpenAPICommand extends Command {
   async run(opts: CommandOptions<Options>) {
     super.run(opts);
 
-    const { key, id, spec, create, useSpecVersion, version, workingDirectory, updateSingleSpec } = opts;
+    const { key, id, spec, create, useSpecVersion, version, workingDirectory, update } = opts;
 
     let selectedVersion = version;
     let isUpdate: boolean;
@@ -102,9 +103,9 @@ export default class OpenAPICommand extends Command {
       Command.warn("We'll be using the `--create` option , so the `--id` parameter will be ignored.");
     }
 
-    if (updateSingleSpec && id) {
+    if (update && id) {
       Command.warn(
-        'When using the `--id` option the `--updateSingleSpec` option is ignored, as the desired spec id is already specified.'
+        "We'll be updating the API definition associated with the `--id` parameter, so the `--update` parameter will be ignored."
       );
     }
 
@@ -251,10 +252,10 @@ export default class OpenAPICommand extends Command {
       Command.debug(`api settings list response payload: ${JSON.stringify(apiSettingsBody)}`);
       if (!apiSettingsBody.length) return createSpec();
 
-      if (updateSingleSpec) {
+      if (update) {
         if (apiSettingsBody.length > 1) {
           throw new Error(
-            `The option \`--updateSingleSpec\` can't be used when there's more than one spec file available (found ${apiSettingsBody.length}).`
+            `The \`--update\` option cannot be used when there's more than one API definition available (found ${apiSettingsBody.length}).`
           );
         }
         const { _id: specId } = apiSettingsBody[0];

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -89,6 +89,12 @@ export default class OpenAPICommand extends Command {
     let isUpdate: boolean;
     const spinner = ora({ ...oraOptions() });
 
+    if (create && update) {
+      throw new Error(
+        'The `--create` and `--update` options cannot be used simultaneously. Please use one or the other!'
+      );
+    }
+
     if (workingDirectory) {
       process.chdir(workingDirectory);
     }

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -74,7 +74,7 @@ export default class OpenAPICommand extends Command {
       {
         name: 'updateSingleSpec',
         type: Boolean,
-        description: 'Automatically update an existing spec file if it\'s the only one found',
+        description: "Automatically update an existing spec file if it's the only one found",
       },
     ];
   }
@@ -246,7 +246,7 @@ export default class OpenAPICommand extends Command {
       if (!apiSettingsBody.length) return createSpec();
 
       if (apiSettingsBody.length === 1 && updateSingleSpec) {
-        const {_id: specId} = apiSettingsBody[0];
+        const { _id: specId } = apiSettingsBody[0];
         return updateSpec(specId);
       }
 

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -245,7 +245,12 @@ export default class OpenAPICommand extends Command {
       Command.debug(`api settings list response payload: ${JSON.stringify(apiSettingsBody)}`);
       if (!apiSettingsBody.length) return createSpec();
 
-      if (apiSettingsBody.length === 1 && updateSingleSpec) {
+      if (updateSingleSpec) {
+        if (apiSettingsBody.length > 1) {
+          throw new Error(
+            `The option \`--updateSingleSpec\` can't be used when there's more than one spec file available (found ${apiSettingsBody.length}).`
+          );
+        }
         const { _id: specId } = apiSettingsBody[0];
         return updateSpec(specId);
       }

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -23,6 +23,7 @@ export type Options = {
   create?: boolean;
   useSpecVersion?: boolean;
   workingDirectory?: string;
+  updateSingleSpec?: boolean;
 };
 
 export default class OpenAPICommand extends Command {
@@ -70,13 +71,18 @@ export default class OpenAPICommand extends Command {
         type: String,
         description: 'Working directory (for usage with relative external references)',
       },
+      {
+        name: 'updateSingleSpec',
+        type: Boolean,
+        description: 'Automatically update an existing spec file if it\'s the only one found',
+      },
     ];
   }
 
   async run(opts: CommandOptions<Options>) {
     super.run(opts);
 
-    const { key, id, spec, create, useSpecVersion, version, workingDirectory } = opts;
+    const { key, id, spec, create, useSpecVersion, version, workingDirectory, updateSingleSpec } = opts;
 
     let selectedVersion = version;
     let isUpdate: boolean;
@@ -238,6 +244,11 @@ export default class OpenAPICommand extends Command {
       const apiSettingsBody = await apiSettings.json();
       Command.debug(`api settings list response payload: ${JSON.stringify(apiSettingsBody)}`);
       if (!apiSettingsBody.length) return createSpec();
+
+      if (apiSettingsBody.length === 1 && updateSingleSpec) {
+        const {_id: specId} = apiSettingsBody[0];
+        return updateSpec(specId);
+      }
 
       // @todo: figure out how to add a stricter type here, see:
       // https://github.com/readmeio/rdme/pull/570#discussion_r949715913


### PR DESCRIPTION
Today when using the `rdme openapi <path> --version=<version>` command to update a spec file (selecting `Update` in the first prompt), we're prompted for selecting an API spec file, even if there's only a single one present.

## 🧰 Changes

This PR adds the `--updateSingleSpec` option that will instruct the CLI to not prompt the user if there's only a single spec file available, and choose it automatically.

## 🧬 QA & Testing

1. Start with a clean project with no API spec files at all
2. Run `rdme openapi <path> --version=<version>`, which will upload the file without any create/update prompt because there's nothing to update.
3. Run `rdme openapi <path> --version=<version>` once again, and select `update` in the first prompt and expect to see another prompt with a single option.
4. Abort the previous command.
5. Run `rdme openapi <path> --version=<version> --updateSingleSpec` and expect the file to upload successfully without any prompts.
