### PR TITLE
feat(docs): Add id to success message response for `docs` and `docs:single`

### DIFF
--- a/__tests__/cmds/changelogs/index.test.ts
+++ b/__tests__/cmds/changelogs/index.test.ts
@@ -195,6 +195,7 @@ describe('rdme changelogs', () => {
   describe('new changelogs', () => {
     it('should create new changelog', async () => {
       const slug = 'new-doc';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
 
@@ -211,10 +212,10 @@ describe('rdme changelogs', () => {
       const postMock = getAPIMock()
         .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       await expect(changelogs.run({ folder: `./__tests__/${fixturesBaseDir}/new-docs`, key })).resolves.toBe(
-        `🌱 successfully created 'new-doc' with contents from __tests__/${fixturesBaseDir}/new-docs/new-doc.md`
+        `🌱 successfully created 'new-doc' with contents from __tests__/${fixturesBaseDir}/new-docs/new-doc.md with an id of 1234`
       );
 
       getMock.done();
@@ -314,6 +315,7 @@ describe('rdme changelogs', () => {
   describe('slug metadata', () => {
     it('should use provided slug', async () => {
       const slug = 'new-doc-slug';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/slug-docs/${slug}.md`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/slug-docs/${slug}.md`)));
 
@@ -330,10 +332,10 @@ describe('rdme changelogs', () => {
       const postMock = getAPIMock()
         .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug: doc.data.slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug: doc.data.slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       await expect(changelogs.run({ folder: `./__tests__/${fixturesBaseDir}/slug-docs`, key })).resolves.toBe(
-        `🌱 successfully created 'marc-actually-wrote-a-test' with contents from __tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`
+        `🌱 successfully created 'marc-actually-wrote-a-test' with contents from __tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md with an id of 1234`
       );
 
       getMock.done();

--- a/__tests__/cmds/changelogs/single.test.ts
+++ b/__tests__/cmds/changelogs/single.test.ts
@@ -48,6 +48,7 @@ describe('rdme changelogs:single', () => {
   describe('new changelogs', () => {
     it('should create new changelog', async () => {
       const slug = 'new-doc';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
 
@@ -64,12 +65,12 @@ describe('rdme changelogs:single', () => {
       const postMock = getAPIMock()
         .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, body: doc.content, ...doc.data });
+        .reply(201, { slug, id, body: doc.content, ...doc.data });
 
       await expect(
         changelogsSingle.run({ filePath: `./__tests__/${fixturesBaseDir}/new-docs/new-doc.md`, key })
       ).resolves.toBe(
-        `🌱 successfully created 'new-doc' with contents from ./__tests__/${fixturesBaseDir}/new-docs/new-doc.md`
+        `🌱 successfully created 'new-doc' with contents from ./__tests__/${fixturesBaseDir}/new-docs/new-doc.md with an id of 1234`
       );
 
       getMock.done();
@@ -177,6 +178,7 @@ describe('rdme changelogs:single', () => {
   describe('slug metadata', () => {
     it('should use provided slug', async () => {
       const slug = 'new-doc-slug';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/slug-docs/${slug}.md`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/slug-docs/${slug}.md`)));
 
@@ -193,12 +195,12 @@ describe('rdme changelogs:single', () => {
       const postMock = getAPIMock()
         .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug: doc.data.slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug: doc.data.slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       await expect(
         changelogsSingle.run({ filePath: `./__tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`, key })
       ).resolves.toBe(
-        `🌱 successfully created 'marc-actually-wrote-a-test' with contents from ./__tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`
+        `🌱 successfully created 'marc-actually-wrote-a-test' with contents from ./__tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md with an id of 1234`
       );
 
       getMock.done();

--- a/__tests__/cmds/custompages/index.test.ts
+++ b/__tests__/cmds/custompages/index.test.ts
@@ -198,6 +198,7 @@ describe('rdme custompages', () => {
   describe('new custompages', () => {
     it('should create new custom page', async () => {
       const slug = 'new-doc';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
 
@@ -214,10 +215,10 @@ describe('rdme custompages', () => {
       const postMock = getAPIMock()
         .post('/api/v1/custompages', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       await expect(custompages.run({ folder: `./__tests__/${fixturesBaseDir}/new-docs`, key })).resolves.toBe(
-        `🌱 successfully created 'new-doc' with contents from __tests__/${fixturesBaseDir}/new-docs/new-doc.md`
+        `🌱 successfully created 'new-doc' with contents from __tests__/${fixturesBaseDir}/new-docs/new-doc.md with an id of 1234`
       );
 
       getMock.done();
@@ -226,6 +227,7 @@ describe('rdme custompages', () => {
 
     it('should create new HTML custom page', async () => {
       const slug = 'new-doc';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/new-docs-html/${slug}.html`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/new-docs-html/${slug}.html`)));
 
@@ -242,10 +244,10 @@ describe('rdme custompages', () => {
       const postMock = getAPIMock()
         .post('/api/v1/custompages', { slug, html: doc.content, htmlmode: true, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, html: doc.content, htmlmode: true, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug, id, html: doc.content, htmlmode: true, ...doc.data, lastUpdatedHash: hash });
 
       await expect(custompages.run({ folder: `./__tests__/${fixturesBaseDir}/new-docs-html`, key })).resolves.toBe(
-        `🌱 successfully created 'new-doc' with contents from __tests__/${fixturesBaseDir}/new-docs-html/new-doc.html`
+        `🌱 successfully created 'new-doc' with contents from __tests__/${fixturesBaseDir}/new-docs-html/new-doc.html with an id of 1234`
       );
 
       getMock.done();
@@ -351,6 +353,7 @@ describe('rdme custompages', () => {
   describe('slug metadata', () => {
     it('should use provided slug', async () => {
       const slug = 'new-doc-slug';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/slug-docs/${slug}.md`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/slug-docs/${slug}.md`)));
 
@@ -367,10 +370,10 @@ describe('rdme custompages', () => {
       const postMock = getAPIMock()
         .post('/api/v1/custompages', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug: doc.data.slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug: doc.data.slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       await expect(custompages.run({ folder: `./__tests__/${fixturesBaseDir}/slug-docs`, key })).resolves.toBe(
-        `🌱 successfully created 'marc-actually-wrote-a-test' with contents from __tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`
+        `🌱 successfully created 'marc-actually-wrote-a-test' with contents from __tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md with an id of 1234`
       );
 
       getMock.done();

--- a/__tests__/cmds/custompages/single.test.ts
+++ b/__tests__/cmds/custompages/single.test.ts
@@ -48,6 +48,7 @@ describe('rdme custompages:single', () => {
   describe('new custompages', () => {
     it('should create new custom page', async () => {
       const slug = 'new-doc';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
 
@@ -64,12 +65,12 @@ describe('rdme custompages:single', () => {
       const postMock = getAPIMock()
         .post('/api/v1/custompages', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, body: doc.content, ...doc.data });
+        .reply(201, { slug, id, body: doc.content, ...doc.data });
 
       await expect(
         customPagesSingle.run({ filePath: `./__tests__/${fixturesBaseDir}/new-docs/new-doc.md`, key })
       ).resolves.toBe(
-        `🌱 successfully created 'new-doc' with contents from ./__tests__/${fixturesBaseDir}/new-docs/new-doc.md`
+        `🌱 successfully created 'new-doc' with contents from ./__tests__/${fixturesBaseDir}/new-docs/new-doc.md with an id of 1234`
       );
 
       getMock.done();
@@ -78,6 +79,7 @@ describe('rdme custompages:single', () => {
 
     it('should create new HTML custom page', async () => {
       const slug = 'new-doc';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/new-docs-html/${slug}.html`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/new-docs-html/${slug}.html`)));
 
@@ -94,12 +96,12 @@ describe('rdme custompages:single', () => {
       const postMock = getAPIMock()
         .post('/api/v1/custompages', { slug, html: doc.content, htmlmode: true, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, html: doc.content, htmlmode: true, ...doc.data });
+        .reply(201, { slug, id, html: doc.content, htmlmode: true, ...doc.data });
 
       await expect(
         customPagesSingle.run({ filePath: `./__tests__/${fixturesBaseDir}/new-docs-html/new-doc.html`, key })
       ).resolves.toBe(
-        `🌱 successfully created 'new-doc' with contents from ./__tests__/${fixturesBaseDir}/new-docs-html/new-doc.html`
+        `🌱 successfully created 'new-doc' with contents from ./__tests__/${fixturesBaseDir}/new-docs-html/new-doc.html with an id of 1234`
       );
 
       getMock.done();
@@ -207,6 +209,7 @@ describe('rdme custompages:single', () => {
   describe('slug metadata', () => {
     it('should use provided slug', async () => {
       const slug = 'new-doc-slug';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/slug-docs/${slug}.md`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/slug-docs/${slug}.md`)));
 
@@ -223,12 +226,12 @@ describe('rdme custompages:single', () => {
       const postMock = getAPIMock()
         .post('/api/v1/custompages', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug: doc.data.slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug: doc.data.slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       await expect(
         customPagesSingle.run({ filePath: `./__tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`, key })
       ).resolves.toBe(
-        `🌱 successfully created 'marc-actually-wrote-a-test' with contents from ./__tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`
+        `🌱 successfully created 'marc-actually-wrote-a-test' with contents from ./__tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md with an id of 1234`
       );
 
       getMock.done();

--- a/__tests__/cmds/docs/index.test.ts
+++ b/__tests__/cmds/docs/index.test.ts
@@ -232,6 +232,7 @@ describe('rdme docs', () => {
   describe('new docs', () => {
     it('should create new doc', async () => {
       const slug = 'new-doc';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
 
@@ -248,7 +249,7 @@ describe('rdme docs', () => {
       const postMock = getAPIMockWithVersionHeader(version)
         .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       const versionMock = getAPIMock()
         .get(`/api/v1/version/${version}`)
@@ -256,7 +257,7 @@ describe('rdme docs', () => {
         .reply(200, { version });
 
       await expect(docs.run({ folder: `./__tests__/${fixturesBaseDir}/new-docs`, key, version })).resolves.toBe(
-        `🌱 successfully created 'new-doc' with contents from __tests__/${fixturesBaseDir}/new-docs/new-doc.md`
+        `🌱 successfully created 'new-doc' with contents from __tests__/${fixturesBaseDir}/new-docs/new-doc.md with an id of 1234`
       );
 
       getMock.done();
@@ -377,6 +378,7 @@ describe('rdme docs', () => {
   describe('slug metadata', () => {
     it('should use provided slug', async () => {
       const slug = 'new-doc-slug';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/slug-docs/${slug}.md`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/slug-docs/${slug}.md`)));
 
@@ -393,7 +395,7 @@ describe('rdme docs', () => {
       const postMock = getAPIMock()
         .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug: doc.data.slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug: doc.data.slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       const versionMock = getAPIMock()
         .get(`/api/v1/version/${version}`)
@@ -401,7 +403,7 @@ describe('rdme docs', () => {
         .reply(200, { version });
 
       await expect(docs.run({ folder: `./__tests__/${fixturesBaseDir}/slug-docs`, key, version })).resolves.toBe(
-        `🌱 successfully created 'marc-actually-wrote-a-test' with contents from __tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`
+        `🌱 successfully created 'marc-actually-wrote-a-test' with contents from __tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md with an id of 1234`
       );
 
       getMock.done();

--- a/__tests__/cmds/docs/single.test.ts
+++ b/__tests__/cmds/docs/single.test.ts
@@ -53,6 +53,7 @@ describe('rdme docs:single', () => {
   describe('new docs', () => {
     it('should create new doc', async () => {
       const slug = 'new-doc';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
 
@@ -69,7 +70,7 @@ describe('rdme docs:single', () => {
       const postMock = getAPIMockWithVersionHeader(version)
         .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       const versionMock = getAPIMock()
         .get(`/api/v1/version/${version}`)
@@ -79,7 +80,7 @@ describe('rdme docs:single', () => {
       await expect(
         docsSingle.run({ filePath: `./__tests__/${fixturesBaseDir}/new-docs/new-doc.md`, key, version })
       ).resolves.toBe(
-        `🌱 successfully created 'new-doc' with contents from ./__tests__/${fixturesBaseDir}/new-docs/new-doc.md`
+        `🌱 successfully created 'new-doc' with contents from ./__tests__/${fixturesBaseDir}/new-docs/new-doc.md with an id of 1234`
       );
 
       getMock.done();
@@ -206,6 +207,7 @@ describe('rdme docs:single', () => {
   describe('slug metadata', () => {
     it('should use provided slug', async () => {
       const slug = 'new-doc-slug';
+      const id = '1234';
       const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/slug-docs/${slug}.md`)));
       const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/slug-docs/${slug}.md`)));
 
@@ -222,7 +224,7 @@ describe('rdme docs:single', () => {
       const postMock = getAPIMock()
         .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug: doc.data.slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug: doc.data.slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       const versionMock = getAPIMock()
         .get(`/api/v1/version/${version}`)
@@ -232,7 +234,7 @@ describe('rdme docs:single', () => {
       await expect(
         docsSingle.run({ filePath: `./__tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`, key, version })
       ).resolves.toBe(
-        `🌱 successfully created 'marc-actually-wrote-a-test' with contents from ./__tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`
+        `🌱 successfully created 'marc-actually-wrote-a-test' with contents from ./__tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md with an id of 1234`
       );
 
       getMock.done();

--- a/src/lib/pushDoc.ts
+++ b/src/lib/pushDoc.ts
@@ -77,7 +77,7 @@ export default async function pushDoc(
       }),
     })
       .then(res => handleRes(res))
-      .then(res => `🌱 successfully created '${res.slug}' with contents from ${filepath}`);
+      .then(res => `🌱 successfully created '${res.slug}' with contents from ${filepath} with an id of ${res.id}`);
   }
 
   function updateDoc(existingDoc: typeof data) {


### PR DESCRIPTION
| 🚥 Fix RM-XXX |
| :-- |

## 🧰 Changes

Added the id of a document to the success response when a document is uploaded. We often have developer publishing a single doc that will be used as the parent for another doc, and getting the id directly in the response improves the experience for the developer.

## 🧬 QA & Testing

Run the `docs:single` or `docs` command on a file you wish to upload.
Notice the id is added to the success message(s) printed in the console.