### PR TITLE
fix(openapi): stricter tests, `create` flag edge case

### DIFF
--- a/__tests__/helpers/get-api-mock.ts
+++ b/__tests__/helpers/get-api-mock.ts
@@ -12,7 +12,7 @@ export default function getAPIMock(reqHeaders = {}) {
   });
 }
 
-export function getAPIMockWithVersionHeader(v) {
+export function getAPIMockWithVersionHeader(v: string) {
   return getAPIMock({
     'x-readme-version': v,
   });

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -126,7 +126,7 @@ export default class OpenAPICommand extends Command {
       selectedVersion = specVersion;
     }
 
-    if (!id) {
+    if (create || !id) {
       selectedVersion = await getProjectVersion(selectedVersion, key, true);
     }
 


### PR DESCRIPTION
## 🧰 Changes

Continuing the work from #584 by ensuring our test bed has really good `x-readme-version` header checks. Turns out, there was a tiny bug discovered! Thanks tests.

## 🧬 QA & Testing

Do tests pass?
