### PR TITLE
feat(openapi): Update oas file based on title

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ You can add `--update` to the command so if there's only one API definition for 
 rdme openapi [path-to-file.json] --version={project-version} --update
 ```
 
+You can add `--matchOnTitleAndVersion` to the command so if there's an existing API definition for the given project version that has the same title as the spec being being synced, then it will select it without and prompts.
+
+```sh
+rdme openapi [path-to-file.json] --version={project-version} --matchOnTitleAndVersion
+```
+
 #### Omitting the File Path
 
 If you run `rdme` within a directory that contains your OpenAPI or Swagger definition, you can omit the file path. `rdme` will then look for JSON or YAML files (including in sub-directories) that contain a top-level [`openapi`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#fixed-fields) or [`swagger`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#fixed-fields) property.

--- a/src/lib/getSpecifications.ts
+++ b/src/lib/getSpecifications.ts
@@ -1,0 +1,56 @@
+import config from 'config';
+import { Headers } from 'node-fetch';
+
+import fetch, { cleanHeaders, handleRes } from './fetch';
+
+/**
+ * Returns all specification for a given project and version
+ *
+ * @param {String} key project API key
+ * @param {String} selectedVersion project version
+ * @returns An array of specification objects
+ */
+export default async function getSpecification(key: string, selectedVersion: string) {
+  function getNumberOfPages() {
+    let totalCount = 0;
+    return fetch(`${config.get('host')}/api/v1/api-specification?perPage=20&page=1`, {
+      method: 'get',
+      headers: cleanHeaders(
+        key,
+        new Headers({
+          'x-readme-version': selectedVersion,
+          Accept: 'application/json',
+        })
+      ),
+    })
+      .then(res => {
+        totalCount = Math.ceil(parseInt(res.headers.get('x-total-count'), 10) / 20);
+        return handleRes(res);
+      })
+      .then(res => {
+        return { firstPage: res, totalCount };
+      });
+  }
+
+  const { firstPage, totalCount } = await getNumberOfPages();
+
+  const allSpecifications = firstPage.concat(
+    ...(await Promise.all(
+      // retrieves all specifications beyond first page
+      [...new Array(totalCount + 1).keys()].slice(2).map(async page => {
+        return fetch(`${config.get('host')}/api/v1/api-specification?perPage=20&page=${page}`, {
+          method: 'get',
+          headers: cleanHeaders(
+            key,
+            new Headers({
+              'x-readme-version': selectedVersion,
+              Accept: 'application/json',
+            })
+          ),
+        }).then(res => handleRes(res));
+      })
+    ))
+  );
+
+  return allSpecifications;
+}

--- a/src/lib/getSpecifications.ts
+++ b/src/lib/getSpecifications.ts
@@ -33,7 +33,6 @@ export default async function getSpecification(key: string, selectedVersion: str
   }
 
   const { firstPage, totalCount } = await getNumberOfPages();
-
   const allSpecifications = firstPage.concat(
     ...(await Promise.all(
       // retrieves all specifications beyond first page

--- a/src/lib/prepareOas.ts
+++ b/src/lib/prepareOas.ts
@@ -138,6 +138,9 @@ export default async function prepareOas(path: string, command: 'openapi' | 'ope
   const specVersion = api.info.version;
   debug(`version in spec: ${specVersion}`);
 
+  const specTitle = api.info.title;
+  debug(`title in this spec: ${specTitle}`);
+
   let bundledSpec = '';
 
   if (command === 'openapi' || command === 'openapi:reduce') {
@@ -148,5 +151,5 @@ export default async function prepareOas(path: string, command: 'openapi' | 'ope
     debug('spec bundled');
   }
 
-  return { bundledSpec, specPath, specType, specVersion };
+  return { bundledSpec, specPath, specType, specVersion, specTitle };
 }


### PR DESCRIPTION
| 🚥 Fix RM-XXX |
| :-- |

## 🧰 Changes

Added the `--matchOnTitleAndVersion` parameter to the `openapi` command. This allows for an API Specification to be updated based on its title and version rather than a specific id in the readme database. This prevents a developer from having to know the id of the api spec they are updating improving the developer experience. Additional update include:

1. Updated the prepareOas.ts file to return a the API Specification title
2. Added the getSpecifications.ts file in the lib to get all API specifications for a given project and paginate through the results.
3. Add test coverage for all changes

## 🧬 QA & Testing

1. Create a valid api spec locally
2. Upload the api spec using `rdme openapi`
3. Make a change to the api spec but ensure it has the same title
4. Update the api spec using `rdme openapi --matchOnTitleAndVersion` without using the `--id` parameter.
