### PR TITLE
feat: `npm init` alias

### DIFF
--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -2,7 +2,7 @@
   "name": "@readme/create",
   "version": "0.0.1",
   "description": "Sync your OpenAPI definition to ReadMe",
-  "bin": "npx rdme@latest openapi --github",
+  "bin": "npx rdme@next openapi --github",
   "repository": {
     "type": "git",
     "url": "https://github.com/readmeio/rdme.git",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -2,7 +2,7 @@
   "name": "@readme/create",
   "version": "0.0.1",
   "description": "Sync your OpenAPI definition to ReadMe",
-  "bin": "../../bin/rdme openapi --github",
+  "bin": "npx rdme@latest openapi --github",
   "repository": {
     "type": "git",
     "url": "https://github.com/readmeio/rdme.git",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@readme/create",
+  "version": "0.0.1",
+  "description": "Sync your OpenAPI definition to ReadMe",
+  "bin": "../../bin/rdme openapi --github",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/readmeio/rdme.git",
+    "directory": "packages/create"
+  },
+  "keywords": [
+    "api",
+    "apis",
+    "readme",
+    "openapi",
+    "swagger"
+  ],
+  "author": "ReadMe <support@readme.io> (https://readme.com)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/readmeio/rdme/issues"
+  },
+  "homepage": "https://github.com/readmeio/rdme#readme"
+}


### PR DESCRIPTION
## 🧰 Changes

Per [the `npm init` docs](https://docs.npmjs.com/cli/v8/commands/npm-init), we can utilize the `@readme` namespace to do fancy things like:

```sh
npm init @readme
```

which would run the following:

```sh
npx @readme/create
```

This PR creates that `@readme/create` repo and aliases it to `rdme openapi --github`, but we might wanna do something fancier at some point. Also should this be versioned the same as `rdme`? Lots of open questions, but figured I'd open this PR to get the conversation started.
