### PR TITLE
feat(openapi): raw command output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The following examples use JSON files, but `rdme` supports API Definitions that 
 > **Note**
 > The `rdme openapi` command supports both OpenAPI and Swagger API definitions. The `rdme swagger` command is an alias for `rdme openapi` and is deprecated.
 
+If you wish to see the raw JSON output of any of the `openapi` command examples below, supply the `--raw` flag.
+
 #### Uploading a New API Definition to ReadMe
 
 This will upload `path-to-openapi.json` to your project and return an ID and URL for you to later update your file, and view it in the client.

--- a/__tests__/__snapshots__/index.test.ts.snap
+++ b/__tests__/__snapshots__/index.test.ts.snap
@@ -17,6 +17,8 @@ Options
                               option is not passed, the main project version will be used.          
   --useSpecVersion            Uses the version listed in the \`info.version\` field in the API        
                               definition for the project version parameter.                         
+  --raw                       Return the command results as a JSON object instead of a pretty       
+                              output.                                                               
   --github                    Create a new GitHub Actions workflow for this command.                
   --workingDirectory string   Working directory (for usage with relative external references)       
   --create                    Bypasses the create/update prompt and creates a new API definition.   
@@ -48,6 +50,8 @@ Options
                               option is not passed, the main project version will be used.          
   --useSpecVersion            Uses the version listed in the \`info.version\` field in the API        
                               definition for the project version parameter.                         
+  --raw                       Return the command results as a JSON object instead of a pretty       
+                              output.                                                               
   --github                    Create a new GitHub Actions workflow for this command.                
   --workingDirectory string   Working directory (for usage with relative external references)       
   --create                    Bypasses the create/update prompt and creates a new API definition.   
@@ -79,6 +83,8 @@ Options
                               option is not passed, the main project version will be used.          
   --useSpecVersion            Uses the version listed in the \`info.version\` field in the API        
                               definition for the project version parameter.                         
+  --raw                       Return the command results as a JSON object instead of a pretty       
+                              output.                                                               
   --github                    Create a new GitHub Actions workflow for this command.                
   --workingDirectory string   Working directory (for usage with relative external references)       
   --create                    Bypasses the create/update prompt and creates a new API definition.   

--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -286,6 +286,44 @@ describe('rdme openapi', () => {
       return mock.done();
     });
 
+    it('should upload the expected content and return raw output', async () => {
+      let requestBody;
+      const registryUUID = getRandomRegistryId();
+      const mock = getAPIMock()
+        .get(`/api/v1/version/${version}`)
+        .basicAuth({ user: key })
+        .reply(200, { version: '1.0.0' })
+        .post('/api/v1/api-registry', body => {
+          requestBody = body.substring(body.indexOf('{'), body.lastIndexOf('}') + 1);
+          requestBody = JSON.parse(requestBody);
+
+          return body.match('form-data; name="spec"');
+        })
+        .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
+        .get('/api/v1/api-specification')
+        .basicAuth({ user: key })
+        .reply(200, []);
+
+      const postMock = getAPIMockWithVersionHeader(version)
+        .post('/api/v1/api-specification', { registryUUID })
+        .basicAuth({ user: key })
+        .reply(201, { _id: 1 }, { location: exampleRefLocation });
+
+      const spec = './__tests__/__fixtures__/ref-oas/petstore.json';
+
+      await expect(openapi.run({ spec, key, version, raw: true })).resolves.toMatchInlineSnapshot(`
+        "{
+          \\"docs\\": \\"https://dash.readme.com/project/example-project/1.0.1/refs/ex\\",
+          \\"id\\": 1,
+          \\"specPath\\": \\"./__tests__/__fixtures__/ref-oas/petstore.json\\",
+          \\"specType\\": \\"OpenAPI\\"
+        }"
+      `);
+
+      postMock.done();
+      return mock.done();
+    });
+
     it('should use specified working directory and upload the expected content', async () => {
       let requestBody;
       const registryUUID = getRandomRegistryId();

--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -313,10 +313,12 @@ describe('rdme openapi', () => {
 
       await expect(openapi.run({ spec, key, version, raw: true })).resolves.toMatchInlineSnapshot(`
         "{
+          \\"commandType\\": \\"create\\",
           \\"docs\\": \\"https://dash.readme.com/project/example-project/1.0.1/refs/ex\\",
           \\"id\\": 1,
           \\"specPath\\": \\"./__tests__/__fixtures__/ref-oas/petstore.json\\",
-          \\"specType\\": \\"OpenAPI\\"
+          \\"specType\\": \\"OpenAPI\\",
+          \\"version\\": \\"1.0.0\\"
         }"
       `);
 

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -22,7 +22,7 @@ export type Options = {
   spec?: string;
   version?: string;
   create?: boolean;
-  // raw?: boolean;
+  raw?: boolean;
   useSpecVersion?: boolean;
   workingDirectory?: string;
   update?: boolean;

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -151,11 +151,13 @@ export default class OpenAPICommand extends Command {
       Command.debug(`successful response payload: ${JSON.stringify(body)}`);
 
       const output = {
+        commandType: isUpdate ? 'update' : 'create',
         docs: data.headers.get('location'),
         // eslint-disable-next-line no-underscore-dangle
         id: body._id,
         specPath,
         specType,
+        version: selectedVersion,
       };
 
       const prettyOutput = [

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -62,7 +62,7 @@ export default class OpenAPICommand extends Command {
       {
         name: 'raw',
         type: Boolean,
-        description: 'TKTK',
+        description: 'Return the command results as a JSON object instead of a pretty output.',
       },
       this.getGitHubArg(),
       {


### PR DESCRIPTION
| 🚥 Fix RM-5419 |
| :-- |

## 🧰 Changes

Chatted with a customer who wants to programmatically grab the `id` from the `openapi` command output. Figured this would be a nice win to sneak into v8.

## 🧬 QA & Testing

Any other attributes that you think would be helpful to include in the JSON object? And do tests pass?
