### PR TITLE
fix(docs): use correct `_id` param

### DIFF
--- a/__tests__/cmds/changelogs/index.test.ts
+++ b/__tests__/cmds/changelogs/index.test.ts
@@ -212,7 +212,7 @@ describe('rdme changelogs', () => {
       const postMock = getAPIMock()
         .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug, _id: id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       await expect(changelogs.run({ folder: `./__tests__/${fixturesBaseDir}/new-docs`, key })).resolves.toBe(
         `🌱 successfully created 'new-doc' (ID: 1234) with contents from __tests__/${fixturesBaseDir}/new-docs/new-doc.md`
@@ -332,7 +332,7 @@ describe('rdme changelogs', () => {
       const postMock = getAPIMock()
         .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug: doc.data.slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug: doc.data.slug, _id: id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       await expect(changelogs.run({ folder: `./__tests__/${fixturesBaseDir}/slug-docs`, key })).resolves.toBe(
         `🌱 successfully created 'marc-actually-wrote-a-test' (ID: 1234) with contents from __tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`

--- a/__tests__/cmds/changelogs/single.test.ts
+++ b/__tests__/cmds/changelogs/single.test.ts
@@ -65,7 +65,7 @@ describe('rdme changelogs:single', () => {
       const postMock = getAPIMock()
         .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, id, body: doc.content, ...doc.data });
+        .reply(201, { slug, _id: id, body: doc.content, ...doc.data });
 
       await expect(
         changelogsSingle.run({ filePath: `./__tests__/${fixturesBaseDir}/new-docs/new-doc.md`, key })
@@ -195,7 +195,7 @@ describe('rdme changelogs:single', () => {
       const postMock = getAPIMock()
         .post('/api/v1/changelogs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug: doc.data.slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug: doc.data.slug, _id: id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       await expect(
         changelogsSingle.run({ filePath: `./__tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`, key })

--- a/__tests__/cmds/custompages/index.test.ts
+++ b/__tests__/cmds/custompages/index.test.ts
@@ -215,7 +215,7 @@ describe('rdme custompages', () => {
       const postMock = getAPIMock()
         .post('/api/v1/custompages', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug, _id: id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       await expect(custompages.run({ folder: `./__tests__/${fixturesBaseDir}/new-docs`, key })).resolves.toBe(
         `🌱 successfully created 'new-doc' (ID: 1234) with contents from __tests__/${fixturesBaseDir}/new-docs/new-doc.md`
@@ -244,7 +244,7 @@ describe('rdme custompages', () => {
       const postMock = getAPIMock()
         .post('/api/v1/custompages', { slug, html: doc.content, htmlmode: true, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, id, html: doc.content, htmlmode: true, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug, _id: id, html: doc.content, htmlmode: true, ...doc.data, lastUpdatedHash: hash });
 
       await expect(custompages.run({ folder: `./__tests__/${fixturesBaseDir}/new-docs-html`, key })).resolves.toBe(
         `🌱 successfully created 'new-doc' (ID: 1234) with contents from __tests__/${fixturesBaseDir}/new-docs-html/new-doc.html`
@@ -370,7 +370,7 @@ describe('rdme custompages', () => {
       const postMock = getAPIMock()
         .post('/api/v1/custompages', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug: doc.data.slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug: doc.data.slug, _id: id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       await expect(custompages.run({ folder: `./__tests__/${fixturesBaseDir}/slug-docs`, key })).resolves.toBe(
         `🌱 successfully created 'marc-actually-wrote-a-test' (ID: 1234) with contents from __tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`

--- a/__tests__/cmds/custompages/single.test.ts
+++ b/__tests__/cmds/custompages/single.test.ts
@@ -65,7 +65,7 @@ describe('rdme custompages:single', () => {
       const postMock = getAPIMock()
         .post('/api/v1/custompages', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, id, body: doc.content, ...doc.data });
+        .reply(201, { slug, _id: id, body: doc.content, ...doc.data });
 
       await expect(
         customPagesSingle.run({ filePath: `./__tests__/${fixturesBaseDir}/new-docs/new-doc.md`, key })
@@ -96,7 +96,7 @@ describe('rdme custompages:single', () => {
       const postMock = getAPIMock()
         .post('/api/v1/custompages', { slug, html: doc.content, htmlmode: true, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, id, html: doc.content, htmlmode: true, ...doc.data });
+        .reply(201, { slug, _id: id, html: doc.content, htmlmode: true, ...doc.data });
 
       await expect(
         customPagesSingle.run({ filePath: `./__tests__/${fixturesBaseDir}/new-docs-html/new-doc.html`, key })
@@ -226,7 +226,7 @@ describe('rdme custompages:single', () => {
       const postMock = getAPIMock()
         .post('/api/v1/custompages', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug: doc.data.slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug: doc.data.slug, _id: id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       await expect(
         customPagesSingle.run({ filePath: `./__tests__/${fixturesBaseDir}/slug-docs/new-doc-slug.md`, key })

--- a/__tests__/cmds/docs/index.test.ts
+++ b/__tests__/cmds/docs/index.test.ts
@@ -255,7 +255,7 @@ describe('rdme docs', () => {
       const postMock = getAPIMockWithVersionHeader(version)
         .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug, _id: id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       const versionMock = getAPIMock()
         .get(`/api/v1/version/${version}`)
@@ -519,7 +519,7 @@ describe('rdme docs', () => {
       const postMock = getAPIMock()
         .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug: doc.data.slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug: doc.data.slug, _id: id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       const versionMock = getAPIMock()
         .get(`/api/v1/version/${version}`)
@@ -586,7 +586,7 @@ describe('rdme docs', () => {
       const postMock = getAPIMockWithVersionHeader(altVersion)
         .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { id, slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { _id: id, slug, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       const fileName = 'docs-test-file';
       prompts.inject([altVersion, true, 'docs-test-branch', fileName]);

--- a/__tests__/cmds/docs/single.test.ts
+++ b/__tests__/cmds/docs/single.test.ts
@@ -70,7 +70,7 @@ describe('rdme docs:single', () => {
       const postMock = getAPIMockWithVersionHeader(version)
         .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug, _id: id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       const versionMock = getAPIMock()
         .get(`/api/v1/version/${version}`)
@@ -224,7 +224,7 @@ describe('rdme docs:single', () => {
       const postMock = getAPIMock()
         .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
         .basicAuth({ user: key })
-        .reply(201, { slug: doc.data.slug, id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+        .reply(201, { slug: doc.data.slug, _id: id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
 
       const versionMock = getAPIMock()
         .get(`/api/v1/version/${version}`)

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -74,6 +74,7 @@ async function handleRes(res: Response) {
     return body;
   }
   if (res.status === SUCCESS_NO_CONTENT) {
+    debug(`received status code ${res.status} from ${res.url} with no content`);
     return {};
   }
   // If we receive a non-JSON response, it's likely an error.

--- a/src/lib/pushDoc.ts
+++ b/src/lib/pushDoc.ts
@@ -51,22 +51,25 @@ export default async function pushDoc(
       )}`;
     }
 
-    return fetch(`${config.get('host')}/api/v1/${type}`, {
-      method: 'post',
-      headers: cleanHeaders(
-        key,
-        new Headers({
-          'x-readme-version': selectedVersion,
-          'Content-Type': 'application/json',
-        })
-      ),
-      body: JSON.stringify({
-        slug,
-        ...payload,
-      }),
-    })
-      .then(res => handleRes(res))
-      .then(res => `🌱 successfully created '${res.slug}' (ID: ${res.id}) with contents from ${filepath}`);
+    return (
+      fetch(`${config.get('host')}/api/v1/${type}`, {
+        method: 'post',
+        headers: cleanHeaders(
+          key,
+          new Headers({
+            'x-readme-version': selectedVersion,
+            'Content-Type': 'application/json',
+          })
+        ),
+        body: JSON.stringify({
+          slug,
+          ...payload,
+        }),
+      })
+        .then(res => handleRes(res))
+        // eslint-disable-next-line no-underscore-dangle
+        .then(res => `🌱 successfully created '${res.slug}' (ID: ${res._id}) with contents from ${filepath}`)
+    );
   }
 
   function updateDoc(existingDoc: typeof payload) {


### PR DESCRIPTION
## 🧰 Changes

We render the doc ID in the success response for the `docs`/`changelogs`/`custompages` commands. Issue is that we were using `res.id` when we should be using `res._id`, since only the latter actually shows up for Changelog and Custom Pages.

## 🧬 QA & Testing

Do tests pass?
