### PR TITLE
feat(breaking/login): remove `2fa` flag in favor of better prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,6 @@ For local CLI usage with a single project, you can authenticate `rdme` to your R
 rdme login
 ```
 
-If you have [two-factor authentication (2FA)](https://docs.readme.com/docs/two-factor-authentication) enabled on your account, you'll need to pass in the `--2fa` option:
-
-```sh
-rdme login --2fa
-```
-
 `rdme whoami` is also available to you to determine who you are logged in as, and to what project, as well as `rdme logout` for logging out of that account.
 
 ## Usage

--- a/__tests__/cmds/__snapshots__/login.test.ts.snap
+++ b/__tests__/cmds/__snapshots__/login.test.ts.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`rdme login should post to /login on the API 1`] = `"Successfully logged in as user@example.com to the subdomain project."`;
-
-exports[`rdme login should post to /login on the API if passing in project via opt 1`] = `"Successfully logged in as user@example.com to the subdomain project."`;
-
-exports[`rdme login should send 2fa token if provided 1`] = `"Successfully logged in as user@example.com to the subdomain project."`;

--- a/__tests__/cmds/login.test.ts
+++ b/__tests__/cmds/login.test.ts
@@ -8,9 +8,11 @@ import getAPIMock from '../helpers/get-api-mock';
 
 const cmd = new Command();
 
+const apiKey = 'abcdefg';
 const email = 'user@example.com';
-const password = '123456';
+const password = 'password';
 const project = 'subdomain';
+const token = '123456';
 
 describe('rdme login', () => {
   beforeAll(() => nock.disableNetConnect());
@@ -33,34 +35,32 @@ describe('rdme login', () => {
 
   it('should post to /login on the API', async () => {
     prompts.inject([email, password, project]);
-    const apiKey = 'abcdefg';
 
     const mock = getAPIMock().post('/api/v1/login').reply(200, { apiKey });
 
-    await expect(cmd.run({})).resolves.toMatchSnapshot();
+    await expect(cmd.run({})).resolves.toBe('Successfully logged in as user@example.com to the subdomain project.');
 
     mock.done();
 
     expect(configStore.get('apiKey')).toBe(apiKey);
     expect(configStore.get('email')).toBe(email);
     expect(configStore.get('project')).toBe(project);
-    configStore.clear();
   });
 
   it('should post to /login on the API if passing in project via opt', async () => {
     prompts.inject([email, password]);
-    const apiKey = 'abcdefg';
 
     const mock = getAPIMock().post('/api/v1/login').reply(200, { apiKey });
 
-    await expect(cmd.run({ project })).resolves.toMatchSnapshot();
+    await expect(cmd.run({ project })).resolves.toBe(
+      'Successfully logged in as user@example.com to the subdomain project.'
+    );
 
     mock.done();
 
     expect(configStore.get('apiKey')).toBe(apiKey);
     expect(configStore.get('email')).toBe(email);
     expect(configStore.get('project')).toBe(project);
-    configStore.clear();
   });
 
   it('should error if invalid credentials are given', async () => {
@@ -94,12 +94,13 @@ describe('rdme login', () => {
   });
 
   it('should send 2fa token if provided', async () => {
-    const token = '123456';
     prompts.inject([email, password, project, token]);
 
     const mock = getAPIMock().post('/api/v1/login', { email, password, project, token }).reply(200, { apiKey: '123' });
 
-    await expect(cmd.run({ '2fa': true })).resolves.toMatchSnapshot();
+    await expect(cmd.run({ '2fa': true })).resolves.toBe(
+      'Successfully logged in as user@example.com to the subdomain project.'
+    );
     mock.done();
   });
 


### PR DESCRIPTION
| 🚥 Fix RM-5498 |
| :-- |

## 🧰 Changes

The `--2fa` flag that's required to log in with `rdme` is clunky. Now that we've overhauled our prompts system, it was stupidly easy to add a flow that goes something like this:

1. User logs in with username and password

1. API returns a 401 with the `LOGIN_TWOFACTOR` code, meaning the user forgot to include a 2FA code

1. `rdme` checks for the `LOGIN_TWOFACTOR` code. In that case, it prompts the user for the token and sends another login request with the token![^1]

By removing the `2fa` flag in the `rdme` client, the login flow is infinitely more smooth. The other great thing is that this requires no changes to our API, so we can maintain backwards compatibility with older versions of `rdme`.

This PR also includes some minor testbed housekeeping as well.

## 🧬 QA & Testing

Do these changes make sense to you? And do tests pass?

[^1]: If the API returns any other error, it just throws it as it normally would.