### PR TITLE
feat(breaking): drop version creation question from prompt flows

### DIFF
--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -213,7 +213,7 @@ describe('rdme openapi', () => {
     });
 
     it('should create a new spec via `--create` flag and ignore `--id`', async () => {
-      prompts.inject(['update', version]);
+      prompts.inject([version]);
       const registryUUID = getRandomRegistryId();
 
       const mock = getAPIMock()
@@ -807,17 +807,14 @@ describe('rdme openapi', () => {
 
     it('should request a version list if version is not found', async () => {
       const selectedVersion = '1.0.1';
-      prompts.inject(['create', selectedVersion]);
+      prompts.inject([selectedVersion]);
 
       const registryUUID = getRandomRegistryId();
 
       const mock = getAPIMock()
         .get('/api/v1/version')
         .basicAuth({ user: key })
-        .reply(200, [{ version: '1.0.0' }])
-        .post('/api/v1/version', { from: '1.0.0', version: '1.0.1', is_stable: false })
-        .basicAuth({ user: key })
-        .reply(200, { from: '1.0.0', version: '1.0.1' })
+        .reply(200, [{ version: '1.0.0' }, { version: '1.0.1' }])
         .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
         .reply(201, { registryUUID, spec: { openapi: '3.0.0' } });
 
@@ -1285,7 +1282,7 @@ describe('rdme openapi', () => {
     it('should create GHA workflow (--create flag enabled with ignored id opt)', async () => {
       expect.assertions(3);
       const yamlFileName = 'openapi-file-create-flag-id-opt';
-      prompts.inject(['update', version, true, 'openapi-branch-create-flag-id-opt', yamlFileName]);
+      prompts.inject([version, true, 'openapi-branch-create-flag-id-opt', yamlFileName]);
       const registryUUID = getRandomRegistryId();
 
       const mock = getAPIMock()

--- a/__tests__/lib/prompts.test.ts
+++ b/__tests__/lib/prompts.test.ts
@@ -1,4 +1,3 @@
-import type { Version } from '../../src/cmds/versions';
 import type { VersionUpdateOptions } from '../../src/cmds/versions/update';
 import type { Response } from 'node-fetch';
 
@@ -7,7 +6,7 @@ import prompts from 'prompts';
 import * as promptHandler from '../../src/lib/prompts';
 import promptTerminal from '../../src/lib/promptWrapper';
 
-const versionlist: Version[] = [
+const versionlist = [
   {
     version: '1',
     is_stable: true,

--- a/__tests__/lib/prompts.test.ts
+++ b/__tests__/lib/prompts.test.ts
@@ -1,4 +1,5 @@
-import type { VersionCreateOptions } from '../../src/cmds/versions/create';
+import type { Version } from '../../src/cmds/versions';
+import type { VersionUpdateOptions } from '../../src/cmds/versions/update';
 import type { Response } from 'node-fetch';
 
 import prompts from 'prompts';
@@ -6,12 +7,14 @@ import prompts from 'prompts';
 import * as promptHandler from '../../src/lib/prompts';
 import promptTerminal from '../../src/lib/promptWrapper';
 
-const versionlist = [
+const versionlist: Version[] = [
   {
     version: '1',
+    is_stable: true,
   },
   {
     version: '2',
+    is_stable: false,
   },
 ];
 
@@ -38,29 +41,6 @@ const getSpecs = () => {
 };
 
 describe('prompt test bed', () => {
-  describe('generatePrompts()', () => {
-    it('should return an update option if selected', async () => {
-      prompts.inject(['update', '2']);
-
-      const answer = await promptTerminal(promptHandler.generatePrompts(versionlist));
-      expect(answer).toStrictEqual({ option: 'update', versionSelection: '2' });
-    });
-
-    it('should return a create option if selected', async () => {
-      prompts.inject(['create', '1.1']);
-
-      const answer = await promptTerminal(promptHandler.generatePrompts(versionlist));
-      expect(answer).toStrictEqual({ newVersion: '1.1', option: 'create' });
-    });
-
-    it('should return an update option if selectOnly=true', async () => {
-      prompts.inject(['2']);
-
-      const answer = await promptTerminal(promptHandler.generatePrompts(versionlist, true));
-      expect(answer).toStrictEqual({ versionSelection: '2' });
-    });
-  });
-
   describe('createOasPrompt()', () => {
     it('should return a create option if selected', async () => {
       prompts.inject(['create']);
@@ -104,7 +84,7 @@ describe('prompt test bed', () => {
 
   describe('createVersionPrompt()', () => {
     it('should allow user to choose a fork if flag is not passed (creating version)', async () => {
-      const opts = { newVersion: '1.2.1' } as VersionCreateOptions;
+      const opts: VersionUpdateOptions = { newVersion: '1.2.1' };
 
       prompts.inject(['1', true, true]);
 

--- a/src/cmds/categories/create.ts
+++ b/src/cmds/categories/create.ts
@@ -66,7 +66,7 @@ export default class CategoriesCreateCommand extends Command {
       return Promise.reject(new Error('`categoryType` must be `guide` or `reference`.'));
     }
 
-    const selectedVersion = await getProjectVersion(version, key, false);
+    const selectedVersion = await getProjectVersion(version, key);
 
     Command.debug(`selectedVersion: ${selectedVersion}`);
 

--- a/src/cmds/categories/index.ts
+++ b/src/cmds/categories/index.ts
@@ -22,7 +22,7 @@ export default class CategoriesCommand extends Command {
 
     const { key, version } = opts;
 
-    const selectedVersion = await getProjectVersion(version, key, false);
+    const selectedVersion = await getProjectVersion(version, key);
 
     Command.debug(`selectedVersion: ${selectedVersion}`);
 

--- a/src/cmds/categories/index.ts
+++ b/src/cmds/categories/index.ts
@@ -22,7 +22,7 @@ export default class CategoriesCommand extends Command {
 
     const { key, version } = opts;
 
-    const selectedVersion = await getProjectVersion(version, key, true);
+    const selectedVersion = await getProjectVersion(version, key, false);
 
     Command.debug(`selectedVersion: ${selectedVersion}`);
 

--- a/src/cmds/docs/edit.ts
+++ b/src/cmds/docs/edit.ts
@@ -53,7 +53,7 @@ export default class EditDocsCommand extends Command {
       return Promise.reject(new Error(`No slug provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
     }
 
-    const selectedVersion = await getProjectVersion(version, key, true);
+    const selectedVersion = await getProjectVersion(version, key, false);
 
     Command.debug(`selectedVersion: ${selectedVersion}`);
 

--- a/src/cmds/docs/edit.ts
+++ b/src/cmds/docs/edit.ts
@@ -53,7 +53,7 @@ export default class EditDocsCommand extends Command {
       return Promise.reject(new Error(`No slug provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
     }
 
-    const selectedVersion = await getProjectVersion(version, key, false);
+    const selectedVersion = await getProjectVersion(version, key);
 
     Command.debug(`selectedVersion: ${selectedVersion}`);
 

--- a/src/cmds/docs/index.ts
+++ b/src/cmds/docs/index.ts
@@ -70,7 +70,7 @@ export default class DocsCommand extends Command {
     // TODO: should we allow version selection at all here?
     // Let's revisit this once we re-evaluate our category logic in the API.
     // Ideally we should ignore this parameter entirely if the category is included.
-    const selectedVersion = await getProjectVersion(version, key, false);
+    const selectedVersion = await getProjectVersion(version, key);
 
     Command.debug(`selectedVersion: ${selectedVersion}`);
 

--- a/src/cmds/docs/single.ts
+++ b/src/cmds/docs/single.ts
@@ -57,7 +57,7 @@ export default class SingleDocCommand extends Command {
     // TODO: should we allow version selection at all here?
     // Let's revisit this once we re-evaluate our category logic in the API.
     // Ideally we should ignore this parameter entirely if the category is included.
-    const selectedVersion = await getProjectVersion(version, key, false);
+    const selectedVersion = await getProjectVersion(version, key);
 
     Command.debug(`selectedVersion: ${selectedVersion}`);
 

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -146,7 +146,7 @@ export default class OpenAPICommand extends Command {
     }
 
     if (create || !id) {
-      selectedVersion = await getProjectVersion(selectedVersion, key, true);
+      selectedVersion = await getProjectVersion(selectedVersion, key, false);
     }
 
     Command.debug(`selectedVersion: ${selectedVersion}`);

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -146,7 +146,7 @@ export default class OpenAPICommand extends Command {
     }
 
     if (create || !id) {
-      selectedVersion = await getProjectVersion(selectedVersion, key, false);
+      selectedVersion = await getProjectVersion(selectedVersion, key);
     }
 
     Command.debug(`selectedVersion: ${selectedVersion}`);

--- a/src/cmds/versions/delete.ts
+++ b/src/cmds/versions/delete.ts
@@ -32,7 +32,7 @@ export default class DeleteVersionCommand extends Command {
 
     const { key, version } = opts;
 
-    const selectedVersion = await getProjectVersion(version, key, false);
+    const selectedVersion = await getProjectVersion(version, key);
 
     Command.debug(`selectedVersion: ${selectedVersion}`);
 

--- a/src/cmds/versions/update.ts
+++ b/src/cmds/versions/update.ts
@@ -50,7 +50,7 @@ export default class UpdateVersionCommand extends Command {
 
     const { key, version, newVersion, codename, main, beta, isPublic, deprecated } = opts;
 
-    const selectedVersion = await getProjectVersion(version, key, false);
+    const selectedVersion = await getProjectVersion(version, key);
 
     Command.debug(`selectedVersion: ${selectedVersion}`);
 

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,3 +1,4 @@
+import type { Version } from '../cmds/versions';
 import type { VersionCreateOptions } from 'cmds/versions/create';
 import type { VersionUpdateOptions } from 'cmds/versions/update';
 import type { Response } from 'node-fetch';
@@ -13,10 +14,6 @@ type SpecList = {
   title: string;
 }[];
 
-type VersionList = {
-  version: string;
-}[];
-
 type ParsedDocs = {
   next?: {
     page: number;
@@ -27,41 +24,6 @@ type ParsedDocs = {
     url: string;
   };
 };
-
-export function generatePrompts(versionList: VersionList, selectOnly = false): PromptObject[] {
-  return [
-    {
-      type: selectOnly ? null : 'select',
-      name: 'option',
-      message: 'Would you like to use an existing project version or create a new one?',
-      choices: [
-        { title: 'Use existing', value: 'update' },
-        { title: 'Create a new version', value: 'create' },
-      ],
-    },
-    {
-      type: (prev, values) => {
-        return (selectOnly ? false : values.option !== 'update') ? null : 'select';
-      },
-      name: 'versionSelection',
-      message: 'Select your desired version',
-      choices: versionList.map(v => {
-        return {
-          title: v.version,
-          value: v.version,
-        };
-      }),
-    },
-    {
-      type: (prev, values) => {
-        return (selectOnly ? true : values.option === 'update') ? null : 'text';
-      },
-      name: 'newVersion',
-      message: "What's your new version?",
-      hint: '1.0.0',
-    },
-  ];
-}
 
 function specOptions(specList: SpecList, parsedDocs: ParsedDocs, currPage: number, totalPages: number): Choice[] {
   const specs = specList.map(s => {
@@ -166,7 +128,7 @@ export function createOasPrompt(
 }
 
 export function createVersionPrompt(
-  versionList: VersionList,
+  versionList: Version[],
   opts: VersionCreateOptions & VersionUpdateOptions,
   isUpdate?: {
     is_stable: boolean;

--- a/src/lib/versionSelect.ts
+++ b/src/lib/versionSelect.ts
@@ -6,7 +6,6 @@ import APIError from './apiError';
 import fetch, { cleanHeaders, handleRes } from './fetch';
 import isCI from './isCI';
 import { warn } from './logger';
-import * as promptHandler from './prompts';
 import promptTerminal from './promptWrapper';
 
 /**
@@ -37,7 +36,17 @@ export async function getProjectVersion(versionFlag: string, key: string): Promi
       headers: cleanHeaders(key),
     }).then(res => handleRes(res));
 
-    const { versionSelection } = await promptTerminal(promptHandler.generatePrompts(versionList, true));
+    const { versionSelection } = await promptTerminal({
+      type: 'select',
+      name: 'versionSelection',
+      message: 'Select your desired version',
+      choices: versionList.map(v => {
+        return {
+          title: v.version,
+          value: v.version,
+        };
+      }),
+    });
 
     return versionSelection;
   } catch (err) {

--- a/src/lib/versionSelect.ts
+++ b/src/lib/versionSelect.ts
@@ -1,7 +1,6 @@
 import type { Version } from '../cmds/versions';
 
 import config from 'config';
-import { Headers } from 'node-fetch';
 
 import APIError from './apiError';
 import fetch, { cleanHeaders, handleRes } from './fetch';
@@ -15,11 +14,9 @@ import promptTerminal from './promptWrapper';
  *
  * @param versionFlag version input parameter
  * @param key project API key
- * @param allowNewVersion if true, goes through prompt flow
- * for creating a new project version
  * @returns a cleaned up project version
  */
-export async function getProjectVersion(versionFlag: string, key: string, allowNewVersion: boolean): Promise<string> {
+export async function getProjectVersion(versionFlag: string, key: string): Promise<string> {
   try {
     if (versionFlag) {
       return await fetch(`${config.get('host')}/api/v1/version/${versionFlag}`, {
@@ -39,28 +36,6 @@ export async function getProjectVersion(versionFlag: string, key: string, allowN
       method: 'get',
       headers: cleanHeaders(key),
     }).then(res => handleRes(res));
-
-    if (allowNewVersion) {
-      const { option, versionSelection, newVersion } = await promptTerminal(promptHandler.generatePrompts(versionList));
-
-      if (option === 'update') return versionSelection;
-
-      const body: Version = {
-        from: versionList[0].version,
-        version: newVersion,
-        is_stable: false,
-      };
-
-      const newVersionFromApi = await fetch(`${config.get('host')}/api/v1/version`, {
-        method: 'post',
-        headers: cleanHeaders(key, new Headers({ 'Content-Type': 'application/json' })),
-        body: JSON.stringify(body),
-      })
-        .then(res => handleRes(res))
-        .then((res: Version) => res.version);
-
-      return newVersionFromApi;
-    }
 
     const { versionSelection } = await promptTerminal(promptHandler.generatePrompts(versionList, true));
 


### PR DESCRIPTION
## 🧰 Changes

When going through some of the prompts for the `openapi` command, I realize we have the following question in the prompt flow:
```
? Would you like to use an existing project version or create a new one? › - Use arrow-keys. Return to submit.
❯   Use existing
    Create a new version
```
It feels like an unlikely scenario where a user will want to create a new version when running this command. And upon further investigation, we do this for a few other commands for which it makes even less sense to ask this question:

- `categories`: if you're trying to list the categories for a project version, why would you want to create a new version just to list the categories in that newly created version?
- `docs:edit`: if you're trying to edit an existing document, why would you want to create a new version before editing a document within that newly created version?

All in all, the whole "version-creation-within-another-command" feature never appeared to be all that useful and was just creating additional prompt fluff[^3] and unnecessary technical debt[^2], so I ultimately decided it's time we rip it out <img width="15" src="https://user-images.githubusercontent.com/8854718/195695030-cec0de8d-d7a1-4574-9635-21f440cc0ee7.png"/>

I was able to clean up a lot of code and types in the process. Here's a summary of everything:
- [x] Drastically simplified the version selection prompt logic that's used in like 8 commands and consolidated it in [`src/lib/versionSelect.ts`](https://github.com/readmeio/rdme/pull/635/files#diff-c42c5c43dde763bc34bee8b579a0ef8b355c3bd197a8bde953b84e01265c51d3) so it's no longer a separate function in [`src/lib/prompts.ts`](https://github.com/readmeio/rdme/pull/635/files#diff-198f9c6e4714f4c1819b759cdd66ece2a658ef58c9797c084b86cba0e0224e3f)[^1]
- [x] Consolidated and cleaned up a few `Version` object types
- [x] Updated some tests affected by these two points 👆🏽 

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.

[^1]: Have I mentioned how I hate this file?
[^2]: I mean look at some of this archaic ternary logic: https://github.com/readmeio/rdme/blob/542307bd9249f6fdad66470564c88a024a6c6166/src/lib/prompts.ts#L44 https://github.com/readmeio/rdme/blob/542307bd9249f6fdad66470564c88a024a6c6166/src/lib/prompts.ts#L57
[^3]: Now that we're using [`prompts`](https://www.npmjs.com/package/prompts) and can rapidly develop prompts more easily, the number of questions we ask when a user runs `rdme openapi` has blown up quite a bit.