### PR TITLE
ci: run tests against node 19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - 14
           - 16
           - 18
+          - 19
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## 🧰 Changes

Node 19 was released yesterday so though our `engines` field allows Node >=14, we should still make sure we're able to be run on it.