### PR TITLE
feat(breaking/docs): deprecate `docs:edit`

### DIFF
--- a/__tests__/cmds/docs/edit.test.ts
+++ b/__tests__/cmds/docs/edit.test.ts
@@ -14,6 +14,20 @@ const version = '1.0.0';
 const category = 'CATEGORY_ID';
 
 describe('rdme docs:edit', () => {
+  let consoleWarnSpy;
+
+  function getWarningCommandOutput() {
+    return [consoleWarnSpy.mock.calls.join('\n\n')].filter(Boolean).join('\n\n');
+  }
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
   beforeAll(() => nock.disableNetConnect());
 
   afterAll(() => nock.cleanAll());
@@ -29,6 +43,13 @@ describe('rdme docs:edit', () => {
     process.env.TEST_CI = 'true';
     await expect(docsEdit.run({})).rejects.toStrictEqual(new Error('No project API key provided. Please use `--key`.'));
     delete process.env.TEST_CI;
+  });
+
+  it('should log deprecation notice', async () => {
+    process.env.TEST_CI = 'true';
+    await expect(docsEdit.run({})).rejects.toStrictEqual(new Error('No project API key provided. Please use `--key`.'));
+    delete process.env.TEST_CI;
+    expect(getWarningCommandOutput()).toMatch('is now deprecated');
   });
 
   it('should error if no slug provided', () => {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,4 +1,3 @@
-import nock from 'nock';
 import prompts from 'prompts';
 
 import { version } from '../package.json';
@@ -31,17 +30,6 @@ describe('cli', () => {
       await expect(cli(['no-such-command', '--version'])).rejects.toThrow(
         // This can be ignored as it's just going to be a command not found error
         'Command not found.'
-      );
-    });
-
-    it('should not be returned if `--version` is being used on a subcommand', async () => {
-      nock.disableNetConnect();
-
-      await expect(cli(['docs:edit', 'getting-started', '--version', '1.0.0', '--key=abcdef'])).rejects.not.toThrow(
-        // We're testing that the docs:edit command does NOT return an error about `--version` not
-        // being here because if it throws that error, then that means that `--version` wasn't
-        // passed in as expected.
-        'No project version provided. Please use `--version`.'
       );
     });
   });
@@ -95,13 +83,8 @@ describe('cli', () => {
   });
 
   describe('subcommands', () => {
-    // docs:edit will make a backend connection
-    beforeAll(() => nock.disableNetConnect());
-
     it('should load subcommands from the folder', async () => {
-      await expect(cli(['docs:edit', 'getting-started', '--version=1.0.0', '--key=abcdef'])).rejects.not.toThrow(
-        'Command not found.'
-      );
+      await expect(cli(['openapi:validate', 'package.json'])).rejects.not.toThrow('Command not found.');
     });
   });
 

--- a/__tests__/lib/__snapshots__/commands.test.ts.snap
+++ b/__tests__/lib/__snapshots__/commands.test.ts.snap
@@ -120,8 +120,8 @@ exports[`utils #listByCategory should list commands by category 1`] = `
         "position": 1,
       },
       {
-        "description": "Edit a single file from your ReadMe project without saving locally.",
-        "hidden": false,
+        "description": "Edit a single file from your ReadMe project without saving locally. [deprecated]",
+        "hidden": true,
         "name": "docs:edit",
         "position": 2,
       },

--- a/src/cmds/docs/edit.ts
+++ b/src/cmds/docs/edit.ts
@@ -10,6 +10,7 @@ import editor from 'editor';
 
 import APIError from '../../lib/apiError';
 import Command, { CommandCategories } from '../../lib/baseCommand';
+import isHidden from '../../lib/decorators/isHidden';
 import fetch, { cleanHeaders, handleRes } from '../../lib/fetch';
 import { getProjectVersion } from '../../lib/versionSelect';
 
@@ -22,13 +23,14 @@ export type Options = {
   slug?: string;
 };
 
+@isHidden
 export default class EditDocsCommand extends Command {
   constructor() {
     super();
 
     this.command = 'docs:edit';
     this.usage = 'docs:edit <slug> [options]';
-    this.description = 'Edit a single file from your ReadMe project without saving locally.';
+    this.description = 'Edit a single file from your ReadMe project without saving locally. [deprecated]';
     this.cmdCategory = CommandCategories.DOCS;
     this.position = 2;
 
@@ -45,6 +47,7 @@ export default class EditDocsCommand extends Command {
   }
 
   async run(opts: CommandOptions<Options>): Promise<undefined> {
+    Command.warn('`rdme docs:edit` is now deprecated and will be removed in a future release.');
     await super.run(opts);
 
     const { slug, key, version } = opts;


### PR DESCRIPTION
| 🚥 Fix RM-5649 |
| :-- |

## 🧰 Changes

Per [this discussion](https://github.com/readmeio/rdme/pull/644#discussion_r1006261908), `docs:edit` is now deprecated.

## 🧬 QA & Testing

Does the warning look good? And do tests pass?
