### PR TITLE
feat(docs): add `guides` alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ rdme openapi:reduce [path-to-file.json]
 
 The command will ask you a couple questions about how you wish to reduce the file and then do so. And as with the `openapi` command, you can also [omit the file path](#omitting-the-file-path).
 
-### Docs
+### Docs (a.k.a. Guides)
 
 The Markdown files will require YAML front matter with certain ReadMe documentation attributes. Check out [our docs](https://docs.readme.com/docs/rdme#markdown-file-setup) for more info on setting up your front matter.
 
@@ -201,6 +201,12 @@ Passing in a path to a directory will also sync any Markdown files that are loca
 
 ```sh
 rdme docs [path] --version={project-version}
+```
+
+This command also has an alias called `guides`:
+
+```
+rdme guides [path] --version={project-version}
 ```
 
 This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about dry run mode [in our docs](https://docs.readme.com/docs/rdme#dry-run-mode).
@@ -213,7 +219,13 @@ If you wish to delete documents from ReadMe that are no longer present in your l
 rdme docs:prune path-to-directory-of-markdown
 ```
 
-### Changelogs
+This command also has an alias called `guides:prune`:
+
+```sh
+rdme guides:prune path-to-directory-of-markdown
+```
+
+### Changelog
 
 The Markdown files will require YAML front matter with certain ReadMe documentation attributes. Check out [our docs](https://docs.readme.com/docs/rdme#markdown-file-setup) for more info on setting up your front matter.
 

--- a/__tests__/cmds/docs/index.test.ts
+++ b/__tests__/cmds/docs/index.test.ts
@@ -8,12 +8,14 @@ import nock from 'nock';
 import prompts from 'prompts';
 
 import DocsCommand from '../../../src/cmds/docs';
+import GuidesCommand from '../../../src/cmds/guides';
 import APIError from '../../../src/lib/apiError';
 import getAPIMock, { getAPIMockWithVersionHeader } from '../../helpers/get-api-mock';
 import { after, before } from '../../helpers/get-gha-setup';
 import hashFileContents from '../../helpers/hash-file-contents';
 
 const docs = new DocsCommand();
+const guides = new GuidesCommand();
 
 const fixturesBaseDir = '__fixtures__/docs';
 const fullFixturesDir = `${__dirname}./../../${fixturesBaseDir}`;
@@ -624,5 +626,21 @@ describe('rdme docs', () => {
       postMock.done();
       versionMock.done();
     });
+  });
+});
+
+describe('rdme guides', () => {
+  beforeAll(() => nock.disableNetConnect());
+
+  afterAll(() => nock.cleanAll());
+
+  it('should error if no path provided', async () => {
+    const versionMock = getAPIMock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
+
+    await expect(guides.run({ key, version: '1.0.0' })).rejects.toStrictEqual(
+      new Error('No path provided. Usage `rdme guides <path> [options]`.')
+    );
+
+    versionMock.done();
   });
 });

--- a/__tests__/cmds/docs/prune.test.ts
+++ b/__tests__/cmds/docs/prune.test.ts
@@ -2,9 +2,11 @@ import nock from 'nock';
 import prompts from 'prompts';
 
 import DocsPruneCommand from '../../../src/cmds/docs/prune';
+import GuidesPruneCommand from '../../../src/cmds/guides/prune';
 import getAPIMock, { getAPIMockWithVersionHeader } from '../../helpers/get-api-mock';
 
 const docsPrune = new DocsPruneCommand();
+const guidesPrune = new GuidesPruneCommand();
 
 const fixturesBaseDir = '__fixtures__/docs';
 
@@ -116,5 +118,17 @@ describe('rdme docs:prune', () => {
 
     apiMocks.done();
     versionMock.done();
+  });
+});
+
+describe('rdme guides:prune', () => {
+  beforeAll(() => nock.disableNetConnect());
+
+  afterAll(() => nock.cleanAll());
+
+  it('should error if no folder provided', () => {
+    return expect(guidesPrune.run({ key, version: '1.0.0' })).rejects.toStrictEqual(
+      new Error('No folder provided. Usage `rdme guides:prune <folder> [options]`.')
+    );
   });
 });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -89,7 +89,7 @@ describe('cli', () => {
   });
 
   it('should not error with undefined cmd', async () => {
-    await expect(cli([])).resolves.toContain('Upload OpenAPI/Swagger definitions');
+    await expect(cli([])).resolves.toContain('OpenAPI / Swagger');
   });
 
   it('should add stored apiKey to opts', async () => {

--- a/__tests__/lib/__snapshots__/commands.test.ts.snap
+++ b/__tests__/lib/__snapshots__/commands.test.ts.snap
@@ -132,7 +132,7 @@ exports[`utils #listByCategory should list commands by category 1`] = `
         "position": 4,
       },
     ],
-    "description": "Documentation",
+    "description": "Docs (a.k.a. Guides)",
   },
   "utilities": {
     "commands": [

--- a/__tests__/lib/__snapshots__/commands.test.ts.snap
+++ b/__tests__/lib/__snapshots__/commands.test.ts.snap
@@ -119,6 +119,18 @@ exports[`utils #listByCategory should list commands by category 1`] = `
         "name": "docs:edit",
         "position": 3,
       },
+      {
+        "description": "Alias for \`rdme docs\`.",
+        "hidden": false,
+        "name": "guides",
+        "position": 3,
+      },
+      {
+        "description": "Alias for \`rdme docs:prune\`.",
+        "hidden": false,
+        "name": "guides:prune",
+        "position": 4,
+      },
     ],
     "description": "Documentation",
   },

--- a/__tests__/lib/__snapshots__/commands.test.ts.snap
+++ b/__tests__/lib/__snapshots__/commands.test.ts.snap
@@ -58,7 +58,7 @@ exports[`utils #listByCategory should list commands by category 1`] = `
         "position": 5,
       },
     ],
-    "description": "Upload OpenAPI/Swagger definitions",
+    "description": "OpenAPI / Swagger",
   },
   "categories": {
     "commands": [

--- a/src/cmds/guides/index.ts
+++ b/src/cmds/guides/index.ts
@@ -1,0 +1,19 @@
+import type { CommandOptions } from '../../lib/baseCommand';
+import type { Options } from '../docs';
+
+import DocsCommand from '../docs';
+
+export default class GuidesCommand extends DocsCommand {
+  constructor() {
+    super();
+
+    this.command = 'guides';
+    this.usage = 'guides <path> [options]';
+    this.description = 'Alias for `rdme docs`.';
+    this.position = 3;
+  }
+
+  async run(opts: CommandOptions<Options>) {
+    return super.run(opts);
+  }
+}

--- a/src/cmds/guides/prune.ts
+++ b/src/cmds/guides/prune.ts
@@ -1,0 +1,19 @@
+import type { CommandOptions } from '../../lib/baseCommand';
+import type { Options } from '../docs/prune';
+
+import DocsPruneCommand from '../docs/prune';
+
+export default class GuidesPruneCommand extends DocsPruneCommand {
+  constructor() {
+    super();
+
+    this.command = 'guides:prune';
+    this.usage = 'guides:prune <folder> [options]';
+    this.description = 'Alias for `rdme docs:prune`.';
+    this.position = 4;
+  }
+
+  async run(opts: CommandOptions<Options>) {
+    return super.run(opts);
+  }
+}

--- a/src/cmds/index.ts
+++ b/src/cmds/index.ts
@@ -5,6 +5,8 @@ import CustomPagesCommand from './custompages';
 import DocsCommand from './docs';
 import DocsEditCommand from './docs/edit';
 import DocsPruneCommand from './docs/prune';
+import GuidesCommand from './guides';
+import GuidesPruneCommand from './guides/prune';
 import LoginCommand from './login';
 import LogoutCommand from './logout';
 import OASCommand from './oas';
@@ -30,6 +32,8 @@ const commands = {
   docs: DocsCommand,
   'docs:prune': DocsPruneCommand,
   'docs:edit': DocsEditCommand,
+  guides: GuidesCommand,
+  'guides:prune': GuidesPruneCommand,
 
   versions: VersionsCommand,
   'versions:create': CreateVersionCommand,

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -20,7 +20,7 @@ export function getCategories(): Record<
       commands: [],
     },
     docs: {
-      description: 'Documentation',
+      description: 'Docs (a.k.a. Guides)',
       commands: [],
     },
     changelogs: {

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -16,7 +16,7 @@ export function getCategories(): Record<
 > {
   return {
     apis: {
-      description: 'Upload OpenAPI/Swagger definitions',
+      description: 'OpenAPI / Swagger',
       commands: [],
     },
     docs: {

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -31,12 +31,12 @@ export function getCategories(): Record<
       description: 'Custom Pages',
       commands: [],
     },
-    categories: {
-      description: 'Categories',
-      commands: [],
-    },
     versions: {
       description: 'Versions',
+      commands: [],
+    },
+    categories: {
+      description: 'Categories',
       commands: [],
     },
     admin: {


### PR DESCRIPTION
| 🚥 Fix RM-5581 |
| :-- |

## 🧰 Changes

Adds an alias for the `docs` family of commands called `guides`, as well as some corresponding documentation touch-ups. Note that the `docs:edit` command doesn't have a corresponding alias since that command is now deprecated (see https://github.com/readmeio/rdme/pull/646).

## 🧬 QA & Testing

Does the alias'ing approach + the corresponding docs look good?
