### PR TITLE
feat(docs:prune): `--confirm` flag to bypass prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ If you wish to delete documents from ReadMe that are no longer present in your l
 rdme docs:prune path-to-directory-of-markdown
 ```
 
-Run with `--noPrompt` to deleted files without asking for confirmation (useful for CI environments)
+Run with `--confirm` to bypass the confirmation prompt (useful for CI environments).
 
 This command also has an alias called `guides:prune`:
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ If you wish to delete documents from ReadMe that are no longer present in your l
 rdme docs:prune path-to-directory-of-markdown
 ```
 
+Run with `--noPrompt` to deleted files without asking for confirmation (useful for CI environments)
+
 This command also has an alias called `guides:prune`:
 
 ```sh

--- a/__tests__/cmds/docs/prune.test.ts
+++ b/__tests__/cmds/docs/prune.test.ts
@@ -67,27 +67,27 @@ describe('rdme docs:prune', () => {
     versionMock.done();
   });
 
-  it('should not ask for user confirmation if noPrompt is set to true', async () => {
+  it('should not ask for user confirmation if `confirm` is set to true', async () => {
     const versionMock = getAPIMock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
 
     const apiMocks = getAPIMockWithVersionHeader(version)
-        .get('/api/v1/categories?perPage=20&page=1')
-        .basicAuth({ user: key })
-        .reply(200, [{ slug: 'category1', type: 'guide' }], { 'x-total-count': '1' })
-        .get('/api/v1/categories/category1/docs')
-        .basicAuth({ user: key })
-        .reply(200, [{ slug: 'this-doc-should-be-missing-in-folder' }, { slug: 'some-doc' }])
-        .delete('/api/v1/docs/this-doc-should-be-missing-in-folder')
-        .basicAuth({ user: key })
-        .reply(204, '');
+      .get('/api/v1/categories?perPage=20&page=1')
+      .basicAuth({ user: key })
+      .reply(200, [{ slug: 'category1', type: 'guide' }], { 'x-total-count': '1' })
+      .get('/api/v1/categories/category1/docs')
+      .basicAuth({ user: key })
+      .reply(200, [{ slug: 'this-doc-should-be-missing-in-folder' }, { slug: 'some-doc' }])
+      .delete('/api/v1/docs/this-doc-should-be-missing-in-folder')
+      .basicAuth({ user: key })
+      .reply(204, '');
 
     await expect(
-        docsPrune.run({
-          folder,
-          key,
-          noPrompt: true,
-          version,
-        })
+      docsPrune.run({
+        folder,
+        key,
+        confirm: true,
+        version,
+      })
     ).resolves.toBe('🗑️ successfully deleted `this-doc-should-be-missing-in-folder`.');
 
     apiMocks.done();

--- a/__tests__/cmds/docs/prune.test.ts
+++ b/__tests__/cmds/docs/prune.test.ts
@@ -67,6 +67,33 @@ describe('rdme docs:prune', () => {
     versionMock.done();
   });
 
+  it('should not ask for user confirmation if noPrompt is set to true', async () => {
+    const versionMock = getAPIMock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
+
+    const apiMocks = getAPIMockWithVersionHeader(version)
+        .get('/api/v1/categories?perPage=20&page=1')
+        .basicAuth({ user: key })
+        .reply(200, [{ slug: 'category1', type: 'guide' }], { 'x-total-count': '1' })
+        .get('/api/v1/categories/category1/docs')
+        .basicAuth({ user: key })
+        .reply(200, [{ slug: 'this-doc-should-be-missing-in-folder' }, { slug: 'some-doc' }])
+        .delete('/api/v1/docs/this-doc-should-be-missing-in-folder')
+        .basicAuth({ user: key })
+        .reply(204, '');
+
+    await expect(
+        docsPrune.run({
+          folder,
+          key,
+          noPrompt: true,
+          version,
+        })
+    ).resolves.toBe('🗑️ successfully deleted `this-doc-should-be-missing-in-folder`.');
+
+    apiMocks.done();
+    versionMock.done();
+  });
+
   it('should delete doc if file is missing', async () => {
     prompts.inject([true]);
 

--- a/src/cmds/docs/prune.ts
+++ b/src/cmds/docs/prune.ts
@@ -47,13 +47,18 @@ export default class DocsPruneCommand extends Command {
         type: Boolean,
         description: 'Runs the command without creating/updating any docs in ReadMe. Useful for debugging.',
       },
+      {
+        name: 'noPrompt',
+        type: Boolean,
+        description: 'Runs the command without asking confirmation from the user. Useful for CI environments.',
+      },
     ];
   }
 
   async run(opts: CommandOptions<Options>) {
     await super.run(opts);
 
-    const { dryRun, folder, key, version } = opts;
+    const { dryRun, folder, key, noPrompt, version } = opts;
 
     if (!folder) {
       return Promise.reject(new Error(`No folder provided. Usage \`${config.get('cli')} ${this.usage}\`.`));
@@ -73,14 +78,16 @@ export default class DocsPruneCommand extends Command {
 
     Command.debug(`number of files: ${files.length}`);
 
-    const { continueWithDeletion } = await promptTerminal({
-      type: 'confirm',
-      name: 'continueWithDeletion',
-      message: `This command will delete all guides page from your ReadMe project (version ${selectedVersion}) that are not also in ${folder}, would you like to continue?`,
-    });
+    if (!noPrompt) {
+      const { continueWithDeletion } = await promptTerminal({
+        type: 'confirm',
+        name: 'continueWithDeletion',
+        message: `This command will delete all guides page from your ReadMe project (version ${selectedVersion}) that are not also in ${folder}, would you like to continue?`,
+      });
 
-    if (!continueWithDeletion) {
-      return Promise.reject(new Error('Aborting, no changes were made.'));
+      if (!continueWithDeletion) {
+        return Promise.reject(new Error('Aborting, no changes were made.'));
+      }
     }
 
     const docs = await getDocs(key, selectedVersion);


### PR DESCRIPTION
## 🧰 Changes

Add `--noPrompt` flag to the `docs:prune` command

## 🧬 QA & Testing

1. Manually add a document to your project in the UI.
2. Run the `docs:prune` command as is, see that it asks for confirmation before deleting the document.
3. Run again but with `--noPrompt` and see that the document is deleted from the project.
