### PR TITLE
fix(createGHA): remove non-github remote check

### DIFF
--- a/__tests__/lib/createGHA.test.ts
+++ b/__tests__/lib/createGHA.test.ts
@@ -166,6 +166,12 @@ describe('#createGHA', () => {
         return expect(createGHA('success!', cmd, command.args, opts)).resolves.toBe('success!');
       });
 
+      it('should not run if a repo with no remote', () => {
+        git.remote = getGitRemoteMock('', '', '');
+
+        return expect(createGHA('success!', cmd, command.args, opts)).resolves.toBe('success!');
+      });
+
       it('should not run if user previously declined to set up GHA for current directory + pkg version', async () => {
         const repoRoot = process.cwd();
 
@@ -209,7 +215,6 @@ describe('#createGHA', () => {
 
         return expect(getGitData()).resolves.toStrictEqual({
           containsGitHubRemote: true,
-          containsNonGitHubRemote: false,
           defaultBranch: 'main',
           isRepo: true,
           repoRoot,
@@ -223,7 +228,6 @@ describe('#createGHA', () => {
 
         return expect(getGitData()).resolves.toStrictEqual({
           containsGitHubRemote: true,
-          containsNonGitHubRemote: false,
           defaultBranch: 'main',
           isRepo: true,
           repoRoot: '',
@@ -243,7 +247,6 @@ describe('#createGHA', () => {
 
         return expect(getGitData()).resolves.toStrictEqual({
           containsGitHubRemote: undefined,
-          containsNonGitHubRemote: undefined,
           defaultBranch: undefined,
           isRepo: false,
           repoRoot: '',


### PR DESCRIPTION
<!----

| 🚥 Fix RM-XXX |
| :-- |


---->

## 🧰 Changes

Tightening our requirements for executing the GitHub Actions prompt: now, a user *must* have a GitHub remote for their repo in order for the ask to be made. We've had a few issues related to this prompt running when it shouldn't, so this should hopefully reduce the likelihood of a false positive.

## 🧬 QA & Testing

Do tests pass?
