### PR TITLE
fix: package.json keywords declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bin": {
     "rdme": "bin/rdme"
   },
-  "tags": [
+  "keywords": [
     "api",
     "apis",
     "openapi",


### PR DESCRIPTION
## 🧰 Changes

Apparently `tags` isn't a thing in [the package.json spec](https://docs.npmjs.com/cli/v8/configuring-npm/package-json), which seems to be the reason why our keywords aren't showing up on npm: https://www.npmjs.com/package/rdme