### PR TITLE
fix: swap out `@npmcli/ci-detect` for `ci-info`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - 14
           - 16
           - 18
-          # - 19
+          - 19
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - 14
           - 16
           - 18
-          - 19
+          # - 19
 
     steps:
       - uses: actions/checkout@v3

--- a/__tests__/lib/fetch.test.ts
+++ b/__tests__/lib/fetch.test.ts
@@ -4,10 +4,13 @@ import { Headers } from 'node-fetch';
 
 import pkg from '../../package.json';
 import fetch, { cleanHeaders, handleRes } from '../../src/lib/fetch';
+import * as isCI from '../../src/lib/isCI';
 import getAPIMock from '../helpers/get-api-mock';
 
 describe('#fetch()', () => {
   describe('GitHub Actions environment', () => {
+    let spy: jest.SpyInstance;
+
     // List of all GitHub Actions env variables:
     // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
     beforeEach(() => {
@@ -18,6 +21,8 @@ describe('#fetch()', () => {
       process.env.GITHUB_RUN_ID = '1658821493';
       process.env.GITHUB_RUN_NUMBER = '3';
       process.env.GITHUB_SHA = 'ffac537e6cbbf934b08745a378932722df287a53';
+      spy = jest.spyOn(isCI, 'isGHA');
+      spy.mockReturnValue(true);
     });
 
     afterEach(() => {
@@ -28,6 +33,7 @@ describe('#fetch()', () => {
       delete process.env.GITHUB_RUN_ID;
       delete process.env.GITHUB_RUN_NUMBER;
       delete process.env.GITHUB_SHA;
+      spy.mockReset();
     });
 
     it('should have correct headers for requests in GitHub Action env', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.6.0",
         "chalk": "^4.1.2",
-        "ci-info": "^3.5.0",
+        "ci-info": "^3.6.1",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.0.2",
         "config": "^3.1.0",
@@ -2718,9 +2718,12 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.1.tgz",
+      "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
@@ -11398,9 +11401,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.1.tgz",
+      "integrity": "sha512-up5ggbaDqOqJ4UqLKZ2naVkyqSJQgJi5lwD6b6mM748ysrghDBX0bx/qJTUHzw7zu6Mq4gycviSF5hJnwceD8w=="
     },
     "cjs-module-lexer": {
       "version": "1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.6.0",
-        "@npmcli/ci-detect": "^3.0.0",
         "chalk": "^4.1.2",
+        "ci-info": "^3.5.0",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.0.2",
         "config": "^3.1.0",
@@ -53,7 +53,6 @@
         "@types/jsonpath": "^0.2.0",
         "@types/mime-types": "^2.1.1",
         "@types/node-fetch": "^2.6.2",
-        "@types/npmcli__ci-detect": "^2.0.0",
         "@types/parse-link-header": "^2.0.0",
         "@types/prompts": "^2.0.14",
         "@types/semver": "^7.3.12",
@@ -1383,14 +1382,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@npmcli/ci-detect": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-3.0.1.tgz",
-      "integrity": "sha512-zQ/qTg2eWnGDToPZH5n7FggNlGC2OYWl6TZv/kDZrTttpm3y2bBcybXSIjlr1ne/ecVp4/vmRNxZP7qTMZo90g==",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/@pkgr/utils": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.3.0.tgz",
@@ -1835,12 +1826,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
-    },
-    "node_modules/@types/npmcli__ci-detect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/npmcli__ci-detect/-/npmcli__ci-detect-2.0.0.tgz",
-      "integrity": "sha512-Nzom9KQvlBNk3gLWKThXZ+DhX/uZ6sDOltOgPFNONo30wi9fePwuwd6V+4+ES9vY+/SVMP4S7Z3QQHXhidAYyg==",
       "dev": true
     },
     "node_modules/@types/parse-link-header": {
@@ -2735,8 +2720,7 @@
     "node_modules/ci-info": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
-      "dev": true
+      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw=="
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
@@ -10351,11 +10335,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@npmcli/ci-detect": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-3.0.1.tgz",
-      "integrity": "sha512-zQ/qTg2eWnGDToPZH5n7FggNlGC2OYWl6TZv/kDZrTttpm3y2bBcybXSIjlr1ne/ecVp4/vmRNxZP7qTMZo90g=="
-    },
     "@pkgr/utils": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.3.0.tgz",
@@ -10759,12 +10738,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
-    },
-    "@types/npmcli__ci-detect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/npmcli__ci-detect/-/npmcli__ci-detect-2.0.0.tgz",
-      "integrity": "sha512-Nzom9KQvlBNk3gLWKThXZ+DhX/uZ6sDOltOgPFNONo30wi9fePwuwd6V+4+ES9vY+/SVMP4S7Z3QQHXhidAYyg==",
       "dev": true
     },
     "@types/parse-link-header": {
@@ -11360,8 +11333,7 @@
     "ci-info": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
-      "dev": true
+      "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw=="
     },
     "cjs-module-lexer": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@actions/core": "^1.6.0",
     "chalk": "^4.1.2",
-    "ci-info": "^3.5.0",
+    "ci-info": "^3.6.1",
     "command-line-args": "^5.2.0",
     "command-line-usage": "^6.0.2",
     "config": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@actions/core": "^1.6.0",
-    "@npmcli/ci-detect": "^3.0.0",
     "chalk": "^4.1.2",
+    "ci-info": "^3.5.0",
     "command-line-args": "^5.2.0",
     "command-line-usage": "^6.0.2",
     "config": "^3.1.0",
@@ -75,7 +75,6 @@
     "@types/jsonpath": "^0.2.0",
     "@types/mime-types": "^2.1.1",
     "@types/node-fetch": "^2.6.2",
-    "@types/npmcli__ci-detect": "^2.0.0",
     "@types/parse-link-header": "^2.0.0",
     "@types/prompts": "^2.0.14",
     "@types/semver": "^7.3.12",

--- a/src/lib/isCI.ts
+++ b/src/lib/isCI.ts
@@ -1,4 +1,4 @@
-import ciDetect from '@npmcli/ci-detect';
+import ci from 'ci-info';
 
 /**
  * Small env check to determine if we're in a GitHub Actions environment.
@@ -6,7 +6,7 @@ import ciDetect from '@npmcli/ci-detect';
  * @see {@link https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables}
  */
 export function isGHA() {
-  return ciDetect() === 'github-actions';
+  return ci.GITHUB_ACTIONS;
 }
 
 /**
@@ -40,5 +40,5 @@ export function isNpmScript() {
  */
 export default function isCI() {
   /* istanbul ignore next */
-  return (ciDetect() && !isTest()) || !!process.env.TEST_RDME_CI;
+  return (ci.isCI && !isTest()) || !!process.env.TEST_RDME_CI;
 }


### PR DESCRIPTION
<!---

| 🚥 Fix RM-XXX |
| :-- |

--->

## 🧰 Changes

I opened https://github.com/npm/ci-detect/issues/47 to address this, but per #664 it looks like our CI detection has some imperfections. [`ci-info`](https://github.com/watson/ci-info) seems to be more popular and well-maintained. We looked at this package ages ago but I was initially hesitant because it is a bit annoying to write tests with it but I got that figured out.

**Update**: it looks like the npm CLI team [is planning on deprecating their package in favor of `ci-info`](https://github.com/watson/ci-info/pull/95#issue-1444551786), so we should probably do this anyways.

## 🧬 QA & Testing

No material changes here except perhaps better CI detection. Do tests pass?
