### PR TITLE
fix: upgrade oas-normalize to fix a postman conversion issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "mime-types": "^2.1.35",
         "node-fetch": "^2.6.1",
         "oas": "^20.0.0",
-        "oas-normalize": "^8.1.1",
+        "oas-normalize": "^8.1.3",
         "open": "^8.2.1",
         "ora": "^5.4.1",
         "parse-link-header": "^2.0.0",
@@ -7189,9 +7189,9 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-8.1.1.tgz",
-      "integrity": "sha512-H+jCpVrVBpr2M23ZkvnMNXHSOvCdNZO0NotW38WJC7aufxnrbiPbzlN5S0gvhSp3GUym2O4hczkwcuPFV6gc/Q==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-8.1.3.tgz",
+      "integrity": "sha512-JFxgz7+GIcKufS+RfY1RF1lBt+TTcti5CVFUbs4JUTgq9aGLTOcbH6hmN5zHfQY2iey1HzLQH3AYu/mI+KAVwQ==",
       "dependencies": {
         "@readme/openapi-parser": "^2.3.0",
         "js-yaml": "^4.1.0",
@@ -14769,9 +14769,9 @@
       }
     },
     "oas-normalize": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-8.1.1.tgz",
-      "integrity": "sha512-H+jCpVrVBpr2M23ZkvnMNXHSOvCdNZO0NotW38WJC7aufxnrbiPbzlN5S0gvhSp3GUym2O4hczkwcuPFV6gc/Q==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-8.1.3.tgz",
+      "integrity": "sha512-JFxgz7+GIcKufS+RfY1RF1lBt+TTcti5CVFUbs4JUTgq9aGLTOcbH6hmN5zHfQY2iey1HzLQH3AYu/mI+KAVwQ==",
       "requires": {
         "@readme/openapi-parser": "^2.3.0",
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mime-types": "^2.1.35",
     "node-fetch": "^2.6.1",
     "oas": "^20.0.0",
-    "oas-normalize": "^8.1.1",
+    "oas-normalize": "^8.1.3",
     "open": "^8.2.1",
     "ora": "^5.4.1",
     "parse-link-header": "^2.0.0",


### PR DESCRIPTION
## 🧰 Changes

Upgrades `oas-normalize` to fix a problem with Postman to OpenAPI conversions where we weren't replacing variables, leading to server URLs containing variables getting corrupted and losing a lot of data.

https://github.com/readmeio/oas-normalize/pull/229
