### PR TITLE
fix: don't prompt for version if only one exists

### DIFF
--- a/__tests__/cmds/docs/index.test.ts
+++ b/__tests__/cmds/docs/index.test.ts
@@ -469,7 +469,7 @@ describe('rdme docs', () => {
       const versionsMock = getAPIMock()
         .get('/api/v1/version')
         .basicAuth({ user: key })
-        .reply(200, [{ version: altVersion }]);
+        .reply(200, [{ version }, { version: altVersion }]);
 
       const getMock = getAPIMockWithVersionHeader(altVersion)
         .get(`/api/v1/docs/${slug}`)

--- a/__tests__/cmds/open.test.ts
+++ b/__tests__/cmds/open.test.ts
@@ -52,7 +52,10 @@ describe('rdme open', () => {
         version,
       };
 
-      const mockRequest = getAPIMock().get('/api/v1/version').basicAuth({ user: key }).reply(200, [versionPayload]);
+      const mockRequest = getAPIMock()
+        .get('/api/v1/version')
+        .basicAuth({ user: key })
+        .reply(200, [versionPayload, { version: '1.0.1' }]);
 
       const dashUrl = 'https://dash.readme.com/project/subdomain/v1.0/overview';
 

--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -222,7 +222,6 @@ describe('rdme openapi', () => {
     });
 
     it('should create a new spec via `--create` flag and ignore `--id`', async () => {
-      prompts.inject([version]);
       const registryUUID = getRandomRegistryId();
 
       const mock = getAPIMock()
@@ -1297,7 +1296,7 @@ describe('rdme openapi', () => {
       const mock = getAPIMock()
         .get('/api/v1/version')
         .basicAuth({ user: key })
-        .reply(200, [{ version }])
+        .reply(200, [{ version }, { version: '1.1.0' }])
         .post('/api/v1/api-registry', body => body.match('form-data; name="spec"'))
         .reply(201, { registryUUID, spec: { openapi: '3.0.0' } });
 

--- a/src/lib/versionSelect.ts
+++ b/src/lib/versionSelect.ts
@@ -36,6 +36,10 @@ export async function getProjectVersion(versionFlag: string, key: string): Promi
       headers: cleanHeaders(key),
     }).then(res => handleRes(res));
 
+    if (versionList.length === 1) {
+      return versionList[0].version;
+    }
+
     const { versionSelection } = await promptTerminal({
       type: 'select',
       name: 'versionSelection',


### PR DESCRIPTION
## 🧰 Changes

Since simplifying our version selection flow in https://github.com/readmeio/rdme/pull/635, the version selection prompt annoyingly prompts the user to select a version even if only one exists in ReadMe:

https://user-images.githubusercontent.com/8854718/202499667-f42f5c98-a2f2-40b2-b667-659074abd877.mp4

This adds a tiny bit of logic to fix that. See below for the fix (note the lack of version selection prompt):

https://user-images.githubusercontent.com/8854718/202500267-3e31ef39-9db3-4234-aacd-0e17ff8deaf5.mp4

## 🧬 QA & Testing

Do tests pass?
