### PR TITLE
fix: unreachable code and those not getting flagged by eslint

### DIFF
--- a/__tests__/cmds/open.test.ts
+++ b/__tests__/cmds/open.test.ts
@@ -35,7 +35,7 @@ describe('rdme open', () => {
   });
 
   describe('open --dash', () => {
-    it('should open the dash', () => {
+    it('should open the dash', async () => {
       expect.assertions(2);
       configStore.set('project', 'subdomain');
       configStore.set('apiKey', '12345');
@@ -64,7 +64,7 @@ describe('rdme open', () => {
         return Promise.resolve();
       }
 
-      return expect(cmd.run({ mockOpen, dash: true, key: '12345' })).resolves.toBe(
+      await expect(cmd.run({ mockOpen, dash: true, key: '12345' })).resolves.toBe(
         `Opening ${chalk.green(dashUrl)} in your browser...`
       );
       mockRequest.done();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1452,9 +1452,9 @@
       }
     },
     "node_modules/@readme/eslint-config": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-10.1.1.tgz",
-      "integrity": "sha512-T59uKIuUPJVeVUmHKSr8AZr8cWUqvAhnn1m11byYipkFvoxLLRL2eDR+JsMKxHMSIpcmOoJRJBsaO9p4M87zqQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-10.2.0.tgz",
+      "integrity": "sha512-QNttw5J3ejDd2obA7u2K8AbydbPPpDBoRA0iJk7kpuMYQ6N+phkkJbXTI6aYkp9bIL9AnZ6wKg+IrOUlb+EhWg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.30.5",
@@ -10459,9 +10459,9 @@
       }
     },
     "@readme/eslint-config": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-10.1.1.tgz",
-      "integrity": "sha512-T59uKIuUPJVeVUmHKSr8AZr8cWUqvAhnn1m11byYipkFvoxLLRL2eDR+JsMKxHMSIpcmOoJRJBsaO9p4M87zqQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-10.2.0.tgz",
+      "integrity": "sha512-QNttw5J3ejDd2obA7u2K8AbydbPPpDBoRA0iJk7kpuMYQ6N+phkkJbXTI6aYkp9bIL9AnZ6wKg+IrOUlb+EhWg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.30.5",


### PR DESCRIPTION
## 🧰 Changes

The `no-unreachable` ESLint rule gets disabled by the TS ESLint for some reason so I've re-enabled it and released a new version of our shared config.

<img width="760" alt="Screen Shot 2022-11-17 at 1 06 43 PM" src="https://user-images.githubusercontent.com/33762/202560153-87c21bd0-5215-4ea3-ba82-02736e5bcb1b.png">