### PR TITLE
feat(`openapi:reduce`): pass opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ rdme openapi:reduce [path-to-file.json]
 The command will ask you a couple questions about how you wish to reduce the file and then do so. If you wish to automate this command, you can pass in CLI arguments to bypass the prompts. Here's an example use case:
 
 - The input API definition is called `petstore.json`
-- The file is reduced by the `/pet/{id}` path and the `GET` and `PUT` methods
+- The file is reduced to only the `/pet/{id}` path and the `GET` and `PUT` methods
 - The output file is called `petstore-reduced.json`
 
 Here's what the resulting command looks like:

--- a/README.md
+++ b/README.md
@@ -246,7 +246,19 @@ We also offer a tool that allows you to reduce a large API definition down to a 
 rdme openapi:reduce [path-to-file.json]
 ```
 
-The command will ask you a couple questions about how you wish to reduce the file and then do so. And as with the `openapi` command, you can also [omit the file path](#omitting-the-file-path).
+The command will ask you a couple questions about how you wish to reduce the file and then do so. If you wish to automate this command, you can pass in CLI arguments to bypass the prompts. Here's an example use case:
+
+- The input API definition is called `petstore.json`
+- The file is reduced by the `/pet/{id}` path and the `GET` and `PUT` methods
+- The output file is called `petstore-reduced.json`
+
+Here's what the resulting command looks like:
+
+```
+rdme openapi:reduce petstore.json --path /pet/{id} --method get --method put --out petstore-reduced.json
+```
+
+As with the `openapi` command, you can also [omit the file path](#omitting-the-file-path).
 
 ### Docs (a.k.a. Guides) 📖
 

--- a/__tests__/cmds/openapi/reduce.test.ts
+++ b/__tests__/cmds/openapi/reduce.test.ts
@@ -195,7 +195,7 @@ describe('rdme openapi:reduce', () => {
       );
     });
 
-    it('should fail if you attempt to reduce a spec to nothin via paths', async () => {
+    it('should fail if you attempt to reduce a spec to nothing via paths', async () => {
       const spec = require.resolve('@readme/oas-examples/3.0/json/petstore.json');
 
       prompts.inject(['paths', ['unknown-path'], 'output.json']);

--- a/__tests__/cmds/openapi/reduce.test.ts
+++ b/__tests__/cmds/openapi/reduce.test.ts
@@ -232,5 +232,18 @@ describe('rdme openapi:reduce', () => {
         })
       ).rejects.toStrictEqual(new Error('You can pass in either tags or paths/methods, but not both.'));
     });
+
+    it('should fail if you attempt to pass non-existent path and no method', async () => {
+      const spec = require.resolve('@readme/oas-examples/3.0/json/petstore.json');
+
+      await expect(
+        reducer.run({
+          spec,
+          path: ['unknown-path'],
+        })
+      ).rejects.toStrictEqual(
+        new Error('All paths in the API definition were removed. Did you supply the right path name to reduce by?')
+      );
+    });
   });
 });

--- a/__tests__/cmds/openapi/reduce.test.ts
+++ b/__tests__/cmds/openapi/reduce.test.ts
@@ -214,7 +214,7 @@ describe('rdme openapi:reduce', () => {
         reducer.run({
           spec,
           tag: ['tag1', 'tag2'],
-          path: ['/path'],
+          method: ['get'],
         })
       ).rejects.toStrictEqual(new Error('You can pass in either tags or paths/methods, but not both.'));
     });

--- a/__tests__/cmds/openapi/reduce.test.ts
+++ b/__tests__/cmds/openapi/reduce.test.ts
@@ -85,6 +85,30 @@ describe('rdme openapi:reduce', () => {
 
         expect(Object.keys(reducedSpec.paths)).toStrictEqual(['/user']);
       });
+
+      it('should reduce with no prompts via opts', async () => {
+        const spec = 'petstore.json';
+
+        let reducedSpec;
+        fs.writeFileSync = jest.fn((fileName, data) => {
+          reducedSpec = JSON.parse(data as string);
+        });
+
+        await expect(
+          reducer.run({
+            workingDirectory: './__tests__/__fixtures__/relative-ref-oas',
+            tag: ['user'],
+            out: 'output.json',
+          })
+        ).resolves.toBe(successfulReduction());
+
+        expect(console.info).toHaveBeenCalledTimes(1);
+
+        const output = getCommandOutput();
+        expect(output).toBe(chalk.yellow(`ℹ️  We found ${spec} and are attempting to reduce it.`));
+
+        expect(Object.keys(reducedSpec.paths)).toStrictEqual(['/user']);
+      });
     });
 
     describe('by path', () => {
@@ -115,6 +139,34 @@ describe('rdme openapi:reduce', () => {
         expect(Object.keys(reducedSpec.paths['/pet'])).toStrictEqual(['post']);
         expect(Object.keys(reducedSpec.paths['/pet/findByStatus'])).toStrictEqual(['get']);
       });
+
+      it('should reduce with no prompts via opts', async () => {
+        const spec = 'petstore.json';
+
+        let reducedSpec;
+        fs.writeFileSync = jest.fn((fileName, data) => {
+          reducedSpec = JSON.parse(data as string);
+        });
+
+        await expect(
+          reducer.run({
+            workingDirectory: './__tests__/__fixtures__/relative-ref-oas',
+            path: ['/pet', '/pet/{petId}'],
+            method: ['get', 'post'],
+            out: 'output.json',
+          })
+        ).resolves.toBe(successfulReduction());
+
+        expect(console.info).toHaveBeenCalledTimes(1);
+
+        const output = getCommandOutput();
+        expect(output).toBe(chalk.yellow(`ℹ️  We found ${spec} and are attempting to reduce it.`));
+
+        expect(fs.writeFileSync).toHaveBeenCalledWith('output.json', expect.any(String));
+        expect(Object.keys(reducedSpec.paths)).toStrictEqual(['/pet', '/pet/{petId}']);
+        expect(Object.keys(reducedSpec.paths['/pet'])).toStrictEqual(['post']);
+        expect(Object.keys(reducedSpec.paths['/pet/{petId}'])).toStrictEqual(['get']);
+      });
     });
   });
 
@@ -141,6 +193,30 @@ describe('rdme openapi:reduce', () => {
       ).rejects.toStrictEqual(
         new Error('All paths in the API definition were removed. Did you supply the right path name to reduce by?')
       );
+    });
+
+    it('should fail if you attempt to pass both tags and paths as opts', async () => {
+      const spec = require.resolve('@readme/oas-examples/3.0/json/petstore.json');
+
+      await expect(
+        reducer.run({
+          spec,
+          tag: ['tag1', 'tag2'],
+          path: ['/path'],
+        })
+      ).rejects.toStrictEqual(new Error('You can pass in either tags or paths/methods, but not both.'));
+    });
+
+    it('should fail if you attempt to pass both tags and methods as opts', async () => {
+      const spec = require.resolve('@readme/oas-examples/3.0/json/petstore.json');
+
+      await expect(
+        reducer.run({
+          spec,
+          tag: ['tag1', 'tag2'],
+          path: ['/path'],
+        })
+      ).rejects.toStrictEqual(new Error('You can pass in either tags or paths/methods, but not both.'));
     });
   });
 });

--- a/__tests__/cmds/openapi/reduce.test.ts
+++ b/__tests__/cmds/openapi/reduce.test.ts
@@ -181,10 +181,24 @@ describe('rdme openapi:reduce', () => {
       ).rejects.toStrictEqual(new Error('Sorry, this reducer feature in rdme only supports OpenAPI 3.0+ definitions.'));
     });
 
-    it('should fail if you attempt to reduce a spec to nothing', async () => {
+    it('should fail if you attempt to reduce a spec to nothing via tags', async () => {
       const spec = require.resolve('@readme/oas-examples/3.0/json/petstore.json');
 
       prompts.inject(['tags', ['unknown-tag'], 'output.json']);
+
+      await expect(
+        reducer.run({
+          spec,
+        })
+      ).rejects.toStrictEqual(
+        new Error('All paths in the API definition were removed. Did you supply the right path name to reduce by?')
+      );
+    });
+
+    it('should fail if you attempt to reduce a spec to nothin via paths', async () => {
+      const spec = require.resolve('@readme/oas-examples/3.0/json/petstore.json');
+
+      prompts.inject(['paths', ['unknown-path'], 'output.json']);
 
       await expect(
         reducer.run({

--- a/src/cmds/openapi/reduce.ts
+++ b/src/cmds/openapi/reduce.ts
@@ -155,6 +155,13 @@ export default class OpenAPIReduceCommand extends Command {
             .flat()
             .filter((method: string) => method.toLowerCase() !== 'parameters');
 
+          // We have to catch this case so prompt doesn't crash
+          if (!methods.length && !opts.method?.length) {
+            throw new Error(
+              'All paths in the API definition were removed. Did you supply the right path name to reduce by?'
+            );
+          }
+
           methods = [...new Set(methods)];
           methods.sort();
 

--- a/src/cmds/openapi/reduce.ts
+++ b/src/cmds/openapi/reduce.ts
@@ -151,7 +151,7 @@ export default class OpenAPIReduceCommand extends Command {
         choices: (prev, values) => {
           const paths: string[] = values.paths;
           let methods = paths
-            .map((p: string) => Object.keys(parsedBundledSpec.paths[p]))
+            .map((p: string) => Object.keys(parsedBundledSpec.paths[p] || {}))
             .flat()
             .filter((method: string) => method.toLowerCase() !== 'parameters');
 

--- a/src/cmds/openapi/reduce.ts
+++ b/src/cmds/openapi/reduce.ts
@@ -140,7 +140,7 @@ export default class OpenAPIReduceCommand extends Command {
     Command.debug(
       `options being supplied to the reducer: ${JSON.stringify({
         tags: promptResults.tags,
-        paths: promptResults.tags,
+        paths: promptResults.paths,
         methods: promptResults.methods,
       })}`
     );

--- a/src/cmds/openapi/reduce.ts
+++ b/src/cmds/openapi/reduce.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk';
 import jsonpath from 'jsonpath';
 import oasReducer from 'oas/dist/lib/reducer';
 import ora from 'ora';
+import prompts from 'prompts';
 
 import Command, { CommandCategories } from '../../lib/baseCommand';
 import { checkFilePath } from '../../lib/checkFile';
@@ -16,6 +17,10 @@ import promptTerminal from '../../lib/promptWrapper';
 
 export type Options = {
   spec?: string;
+  tag?: string[];
+  path?: string[];
+  method?: string[];
+  out?: string;
   workingDirectory?: string;
 };
 
@@ -35,6 +40,29 @@ export default class OpenAPIReduceCommand extends Command {
         name: 'spec',
         type: String,
         defaultOption: true,
+      },
+      {
+        name: 'tag',
+        type: String,
+        multiple: true,
+        description: 'Tags to reduce by',
+      },
+      {
+        name: 'path',
+        type: String,
+        multiple: true,
+        description: 'Paths to reduce by',
+      },
+      {
+        name: 'method',
+        type: String,
+        multiple: true,
+        description: 'Methods to reduce by (can only be used alongside the `path` option)',
+      },
+      {
+        name: 'out',
+        type: String,
+        description: 'Output file path to write reduced file to',
       },
       {
         name: 'workingDirectory',
@@ -59,6 +87,18 @@ export default class OpenAPIReduceCommand extends Command {
     if (specType !== 'OpenAPI') {
       throw new Error('Sorry, this reducer feature in rdme only supports OpenAPI 3.0+ definitions.');
     }
+
+    if ((opts.path?.length || opts.method?.length) && opts.tag?.length) {
+      throw new Error('You can pass in either tags or paths/methods, but not both.');
+    }
+
+    prompts.override({
+      reduceBy: opts.tag?.length ? 'tags' : opts.path?.length ? 'paths' : undefined,
+      tags: opts.tag,
+      paths: opts.path,
+      methods: opts.method,
+      outputPath: opts.out,
+    });
 
     const promptResults = await promptTerminal([
       {


### PR DESCRIPTION
| 🚥 Fix #683 |
| :-- |

## 🧰 Changes

Adds the ability to pass in opts to the `openapi:reduce` command.

## 🧬 QA & Testing

Check out this branch and run the following commands:

```sh
# install deps
npm ci

# success state
npm run debug -- openapi:reduce __tests__/__fixtures__/petstore-simple-weird-version.json --tag pet --out test.json

# fail state
npm run debug -- openapi:reduce __tests__/__fixtures__/petstore-simple-weird-version.json --path /unknown-path --out test.json
```

Does it work?