### PR TITLE
test: cleaning up our jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,13 +12,6 @@ module.exports = {
   },
   modulePaths: ['<rootDir>'],
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
-  /**
-   * Not sure why, but the non-legacy preset gives us TS compilation errors
-   * since it's not properly reading our testing TS config.
-   * @see {@link https://kulshekhar.github.io/ts-jest/docs/getting-started/presets}
-   * @see {@link https://kulshekhar.github.io/ts-jest/docs/getting-started/options/tsconfig/}
-   */
-  preset: 'ts-jest/presets/js-with-ts-legacy',
   roots: ['<rootDir>'],
   setupFiles: ['./__tests__/setup'],
   setupFilesAfterEnv: ['jest-extended/all'],


### PR DESCRIPTION
## 🧰 Changes

While upgrading `oas` to Jest 29 I also encountered the same issue we had here where `ts-jest` wasn't picking up our `tsconfig.json` file. Turns out that because we're setting up `transform` on `.ts` files ourselves we don't need this extra `presets` config as it's already being loaded from the `transform` config. Loading both of these was causing the first preset to get loaded without unit test `tsconfig`.

Kind of an annoying gotcha but all tests should still be passing with this change.