### PR TITLE
fix(`docs:prune`): prune child docs

### DIFF
--- a/src/lib/getDocs.ts
+++ b/src/lib/getDocs.ts
@@ -14,7 +14,17 @@ interface Document {
 }
 
 function flatten(data: Document[][]): Document[] {
-  return [].concat(...data);
+  const allDocs: Document[] = [];
+  const docs: Document[] = [].concat(...data);
+  docs.forEach(doc => {
+    allDocs.push(doc);
+    if (doc.children) {
+      doc.children.forEach(child => {
+        allDocs.push(child);
+      });
+    }
+  });
+  return allDocs;
 }
 
 async function getCategoryDocs(key: string, selectedVersion: string, category: string): Promise<Document[]> {


### PR DESCRIPTION
| 🚥 Fixes #710 |
| :---------------- |

## 🧰 Changes

Turns out our response payloads from [`GET /categories/{slug}/docs`](https://docs.readme.com/main/reference/getcategorydocs) looks like this for [pages that contain subpages](https://docs.readme.com/main/docs/navigating-your-hub):

```json
[
  ...
  {
    "title": "Navigating Your Hub",
    "slug": "navigating-your-hub",
    "order": 4,
    "hidden": false,
    "children": [
      {
        "title": "Search + Search API",
        "slug": "search",
        "order": 0,
        "hidden": false
      },
      {
        "title": "Quick Nav in the API Reference",
        "slug": "quick-nav-api-reference",
        "order": 1,
        "hidden": false
      }
    ]
  }
]
```

This PR fixes our `docs:prune` command to account for child pages.

## 🧬 QA & Testing

Do tests pass?
