### PR TITLE
feat(openapi): add ability to override title

### DIFF
--- a/__tests__/__snapshots__/index.test.ts.snap
+++ b/__tests__/__snapshots__/index.test.ts.snap
@@ -24,6 +24,7 @@ Options
   --create                    Bypasses the create/update prompt and creates a new API definition.   
   --update                    Automatically update an existing API definition in ReadMe if it's the 
                               only one associated with the current version.                         
+  --title string              An override value for the \`info.title\` field in the API definition    
   --dryRun                    Runs the command without creating/updating any API Definitions in     
                               ReadMe. Useful for debugging.                                         
   -h, --help                  Display this usage guide                                              
@@ -62,6 +63,7 @@ Options
   --create                    Bypasses the create/update prompt and creates a new API definition.   
   --update                    Automatically update an existing API definition in ReadMe if it's the 
                               only one associated with the current version.                         
+  --title string              An override value for the \`info.title\` field in the API definition    
   --dryRun                    Runs the command without creating/updating any API Definitions in     
                               ReadMe. Useful for debugging.                                         
   -h, --help                  Display this usage guide                                              
@@ -100,6 +102,7 @@ Options
   --create                    Bypasses the create/update prompt and creates a new API definition.   
   --update                    Automatically update an existing API definition in ReadMe if it's the 
                               only one associated with the current version.                         
+  --title string              An override value for the \`info.title\` field in the API definition    
   --dryRun                    Runs the command without creating/updating any API Definitions in     
                               ReadMe. Useful for debugging.                                         
   -h, --help                  Display this usage guide                                              

--- a/__tests__/cmds/openapi/__snapshots__/index.test.ts.snap
+++ b/__tests__/cmds/openapi/__snapshots__/index.test.ts.snap
@@ -539,6 +539,242 @@ exports[`rdme openapi upload should bundle and upload the expected content 1`] =
 }
 `;
 
+exports[`rdme openapi upload should update title, bundle and upload the expected content 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "api_key",
+        "type": "apiKey",
+      },
+      "petstore_auth": {
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+            "scopes": {
+              "read:pets": "read your pets",
+              "write:pets": "modify pets in your account",
+            },
+          },
+        },
+        "type": "oauth2",
+      },
+    },
+  },
+  "info": {
+    "title": "some alternative title",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/pet": {
+      "post": {
+        "description": "",
+        "operationId": "addPet",
+        "requestBody": {
+          "$ref": "#/paths/~1pet/put/requestBody",
+        },
+        "responses": {
+          "405": {
+            "description": "Invalid input",
+          },
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets",
+            ],
+          },
+        ],
+        "summary": "Add a new pet to the store",
+        "tags": [
+          "pet",
+        ],
+      },
+      "put": {
+        "description": "",
+        "operationId": "updatePet",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/paths/~1pet~1%7BpetId%7D/get/responses/200/content/application~1xml/schema",
+              },
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/paths/~1pet~1%7BpetId%7D/get/responses/200/content/application~1xml/schema",
+              },
+            },
+          },
+          "description": "Pet object that needs to be added to the store",
+          "required": true,
+        },
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied",
+          },
+          "404": {
+            "description": "Pet not found",
+          },
+          "405": {
+            "description": "Validation exception",
+          },
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets",
+            ],
+          },
+        ],
+        "summary": "Update an existing pet",
+        "tags": [
+          "pet",
+        ],
+      },
+    },
+    "/pet/{petId}": {
+      "get": {
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "description": "ID of pet to return",
+            "in": "path",
+            "name": "petId",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1pet~1%7BpetId%7D/get/responses/200/content/application~1xml/schema",
+                },
+              },
+              "application/xml": {
+                "schema": {
+                  "properties": {
+                    "category": {
+                      "properties": {
+                        "id": {
+                          "format": "int64",
+                          "type": "integer",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                      "xml": {
+                        "name": "Category",
+                      },
+                    },
+                    "id": {
+                      "default": 40,
+                      "example": 25,
+                      "format": "int64",
+                      "type": "integer",
+                    },
+                    "name": {
+                      "example": "doggie",
+                      "type": "string",
+                    },
+                    "photoUrls": {
+                      "items": {
+                        "example": "https://example.com/photo.png",
+                        "type": "string",
+                      },
+                      "type": "array",
+                      "xml": {
+                        "name": "photoUrl",
+                        "wrapped": true,
+                      },
+                    },
+                    "status": {
+                      "description": "pet status in the store",
+                      "enum": [
+                        "available",
+                        "pending",
+                        "sold",
+                      ],
+                      "type": "string",
+                    },
+                    "tags": {
+                      "items": {
+                        "properties": {
+                          "id": {
+                            "format": "int64",
+                            "type": "integer",
+                          },
+                          "name": {
+                            "type": "string",
+                          },
+                        },
+                        "type": "object",
+                        "xml": {
+                          "name": "Tag",
+                        },
+                      },
+                      "type": "array",
+                      "xml": {
+                        "name": "tag",
+                        "wrapped": true,
+                      },
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "photoUrls",
+                  ],
+                  "type": "object",
+                  "xml": {
+                    "name": "Pet",
+                  },
+                },
+              },
+            },
+            "description": "successful operation",
+          },
+          "400": {
+            "description": "Invalid ID supplied",
+          },
+          "404": {
+            "description": "Pet not found",
+          },
+          "default": {
+            "description": "successful response",
+          },
+        },
+        "security": [
+          {
+            "api_key": [],
+          },
+        ],
+        "summary": "Find pet by ID",
+        "tags": [
+          "pet",
+        ],
+      },
+    },
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v2",
+    },
+  ],
+}
+`;
+
 exports[`rdme openapi upload should use specified working directory and upload the expected content 1`] = `
 {
   "components": {

--- a/__tests__/cmds/openapi/reduce.test.ts
+++ b/__tests__/cmds/openapi/reduce.test.ts
@@ -167,6 +167,37 @@ describe('rdme openapi:reduce', () => {
         expect(Object.keys(reducedSpec.paths['/pet'])).toStrictEqual(['post']);
         expect(Object.keys(reducedSpec.paths['/pet/{petId}'])).toStrictEqual(['get']);
       });
+
+      it('should reduce and update title with no prompts via opts', async () => {
+        const spec = 'petstore.json';
+        const title = 'some alternative title';
+
+        let reducedSpec;
+        fs.writeFileSync = jest.fn((fileName, data) => {
+          reducedSpec = JSON.parse(data as string);
+        });
+
+        await expect(
+          reducer.run({
+            workingDirectory: './__tests__/__fixtures__/relative-ref-oas',
+            path: ['/pet', '/pet/{petId}'],
+            method: ['get', 'post'],
+            title,
+            out: 'output.json',
+          })
+        ).resolves.toBe(successfulReduction());
+
+        expect(console.info).toHaveBeenCalledTimes(1);
+
+        const output = getCommandOutput();
+        expect(output).toBe(chalk.yellow(`ℹ️  We found ${spec} and are attempting to reduce it.`));
+
+        expect(fs.writeFileSync).toHaveBeenCalledWith('output.json', expect.any(String));
+        expect(Object.keys(reducedSpec.paths)).toStrictEqual(['/pet', '/pet/{petId}']);
+        expect(Object.keys(reducedSpec.paths['/pet'])).toStrictEqual(['post']);
+        expect(Object.keys(reducedSpec.paths['/pet/{petId}'])).toStrictEqual(['get']);
+        expect(reducedSpec.info.title).toBe(title);
+      });
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "form-data": "^4.0.0",
         "gray-matter": "^4.0.1",
         "ignore": "^5.2.0",
-        "jsonpath-plus": "^7.2.0",
         "mime-types": "^2.1.35",
         "node-fetch": "^2.6.1",
         "oas": "^20.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6827,9 +6827,9 @@
       }
     },
     "node_modules/oas": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-20.2.0.tgz",
-      "integrity": "sha512-FNRjIOiBVqlvW6c0LZ1oCvj73QGJyhj8L/GUpkrFD04Xm5r00zh1xecnCWEdOBxEM931AQRis4ec9r0Eg9nC1w==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-20.2.1.tgz",
+      "integrity": "sha512-3kYohpRPOK5RvLAK8bBi+E8RbKp7Vlr5HMH/bGC8JtYuxieL6KtZCqFCzA1TwC6wYh5TfbGqIvoWNq2n5AAiug==",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.2.0",
         "@types/json-schema": "^7.0.11",
@@ -14271,9 +14271,9 @@
       }
     },
     "oas": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-20.2.0.tgz",
-      "integrity": "sha512-FNRjIOiBVqlvW6c0LZ1oCvj73QGJyhj8L/GUpkrFD04Xm5r00zh1xecnCWEdOBxEM931AQRis4ec9r0Eg9nC1w==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-20.2.1.tgz",
+      "integrity": "sha512-3kYohpRPOK5RvLAK8bBi+E8RbKp7Vlr5HMH/bGC8JtYuxieL6KtZCqFCzA1TwC6wYh5TfbGqIvoWNq2n5AAiug==",
       "requires": {
         "@readme/json-schema-ref-parser": "^1.2.0",
         "@types/json-schema": "^7.0.11",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "form-data": "^4.0.0",
     "gray-matter": "^4.0.1",
     "ignore": "^5.2.0",
-    "jsonpath-plus": "^7.2.0",
     "mime-types": "^2.1.35",
     "node-fetch": "^2.6.1",
     "oas": "^20.2.0",

--- a/src/cmds/openapi/convert.ts
+++ b/src/cmds/openapi/convert.ts
@@ -1,4 +1,5 @@
 import type { CommandOptions } from '../../lib/baseCommand';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import fs from 'fs';
 import path from 'path';
@@ -52,7 +53,7 @@ export default class OpenAPIConvertCommand extends Command {
     }
 
     const { preparedSpec, specPath, specType } = await prepareOas(spec, 'openapi:convert', { convertToLatest: true });
-    const parsedPreparedSpec = JSON.parse(preparedSpec);
+    const parsedPreparedSpec: OASDocument = JSON.parse(preparedSpec);
 
     if (specType === 'OpenAPI') {
       throw new Error("Sorry, this API definition is already an OpenAPI definition and doesn't need to be converted.");

--- a/src/cmds/openapi/convert.ts
+++ b/src/cmds/openapi/convert.ts
@@ -38,11 +38,7 @@ export default class OpenAPIConvertCommand extends Command {
         type: String,
         description: 'Output file path to write converted file to',
       },
-      {
-        name: 'workingDirectory',
-        type: String,
-        description: 'Working directory (for usage with relative external references)',
-      },
+      this.getWorkingDirArg(),
     ];
   }
 

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -23,6 +23,7 @@ export interface Options {
   version?: string;
   create?: boolean;
   raw?: boolean;
+  title?: string;
   useSpecVersion?: boolean;
   workingDirectory?: string;
   update?: boolean;
@@ -77,6 +78,7 @@ export default class OpenAPICommand extends Command {
         description:
           "Automatically update an existing API definition in ReadMe if it's the only one associated with the current version.",
       },
+      this.getTitleArg(),
       {
         name: 'dryRun',
         type: Boolean,
@@ -88,7 +90,7 @@ export default class OpenAPICommand extends Command {
   async run(opts: CommandOptions<Options>) {
     await super.run(opts);
 
-    const { dryRun, key, id, spec, create, raw, useSpecVersion, version, workingDirectory, update } = opts;
+    const { dryRun, key, id, spec, create, raw, title, useSpecVersion, version, workingDirectory, update } = opts;
 
     let selectedVersion = version;
     let isUpdate: boolean;
@@ -131,7 +133,7 @@ export default class OpenAPICommand extends Command {
 
     // Reason we're hardcoding in command here is because `swagger` command
     // relies on this and we don't want to use `swagger` in this function
-    const { preparedSpec, specPath, specType, specVersion } = await prepareOas(spec, 'openapi');
+    const { preparedSpec, specPath, specType, specVersion } = await prepareOas(spec, 'openapi', { title });
 
     if (useSpecVersion) {
       Command.info(

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -53,11 +53,7 @@ export default class OpenAPICommand extends Command {
         type: String,
         defaultOption: true,
       },
-      {
-        name: 'workingDirectory',
-        type: String,
-        description: 'Working directory (for usage with relative external references)',
-      },
+      this.getWorkingDirArg(),
       {
         name: 'useSpecVersion',
         type: Boolean,

--- a/src/cmds/openapi/inspect.ts
+++ b/src/cmds/openapi/inspect.ts
@@ -1,5 +1,6 @@
 import type { Analysis, AnalyzedFeature } from '../../lib/analyzeOas';
 import type { CommandOptions } from '../../lib/baseCommand';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import chalk from 'chalk';
 import config from 'config';
@@ -240,7 +241,7 @@ export default class OpenAPIInspectCommand extends Command {
 
     const { preparedSpec, definitionVersion } = await prepareOas(spec, 'openapi:inspect', { convertToLatest: true });
     this.definitionVersion = definitionVersion.version;
-    const parsedPreparedSpec = JSON.parse(preparedSpec);
+    const parsedPreparedSpec: OASDocument = JSON.parse(preparedSpec);
 
     const spinner = ora({ ...oraOptions() });
     if (features?.length) {

--- a/src/cmds/openapi/inspect.ts
+++ b/src/cmds/openapi/inspect.ts
@@ -39,11 +39,7 @@ export default class OpenAPIInspectCommand extends Command {
         type: String,
         defaultOption: true,
       },
-      {
-        name: 'workingDirectory',
-        type: String,
-        description: 'Working directory (for usage with relative external references)',
-      },
+      this.getWorkingDirArg(),
       {
         name: 'feature',
         type: String,

--- a/src/cmds/openapi/reduce.ts
+++ b/src/cmds/openapi/reduce.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 
 import chalk from 'chalk';
-import { JSONPath } from 'jsonpath-plus';
+import Oas from 'oas';
 import oasReducer from 'oas/dist/lib/reducer';
 import ora from 'ora';
 import prompts from 'prompts';
@@ -112,13 +112,9 @@ export default class OpenAPIReduceCommand extends Command {
         message: 'Choose which tags to reduce by:',
         min: 1,
         choices: () => {
-          const tags: string[] = JSONPath({
-            path: '$..paths[*].tags',
-            json: parsedPreparedSpec,
-            resultType: 'value',
-          }).flat();
+          const tags = new Oas(parsedPreparedSpec).getTags();
 
-          return [...new Set(tags)].map(tag => ({
+          return tags.map(tag => ({
             title: tag,
             value: tag,
           }));

--- a/src/cmds/openapi/reduce.ts
+++ b/src/cmds/openapi/reduce.ts
@@ -22,6 +22,7 @@ export interface Options {
   path?: string[];
   method?: string[];
   out?: string;
+  title?: string;
   workingDirectory?: string;
 }
 
@@ -64,6 +65,7 @@ export default class OpenAPIReduceCommand extends Command {
         type: String,
         description: 'Output file path to write reduced file to',
       },
+      this.getTitleArg(),
       this.getWorkingDirArg(),
     ];
   }
@@ -71,13 +73,13 @@ export default class OpenAPIReduceCommand extends Command {
   async run(opts: CommandOptions<Options>) {
     await super.run(opts);
 
-    const { spec, workingDirectory } = opts;
+    const { spec, title, workingDirectory } = opts;
 
     if (workingDirectory) {
       process.chdir(workingDirectory);
     }
 
-    const { preparedSpec, specPath, specType } = await prepareOas(spec, 'openapi:reduce');
+    const { preparedSpec, specPath, specType } = await prepareOas(spec, 'openapi:reduce', { title });
     const parsedPreparedSpec: OASDocument = JSON.parse(preparedSpec);
 
     if (specType !== 'OpenAPI') {

--- a/src/cmds/openapi/reduce.ts
+++ b/src/cmds/openapi/reduce.ts
@@ -1,4 +1,5 @@
 import type { CommandOptions } from '../../lib/baseCommand';
+import type { OASDocument } from 'oas/dist/rmoas.types';
 
 import fs from 'fs';
 import path from 'path';
@@ -77,7 +78,7 @@ export default class OpenAPIReduceCommand extends Command {
     }
 
     const { preparedSpec, specPath, specType } = await prepareOas(spec, 'openapi:reduce');
-    const parsedPreparedSpec = JSON.parse(preparedSpec);
+    const parsedPreparedSpec: OASDocument = JSON.parse(preparedSpec);
 
     if (specType !== 'OpenAPI') {
       throw new Error('Sorry, this reducer feature in rdme only supports OpenAPI 3.0+ definitions.');

--- a/src/cmds/openapi/reduce.ts
+++ b/src/cmds/openapi/reduce.ts
@@ -63,11 +63,7 @@ export default class OpenAPIReduceCommand extends Command {
         type: String,
         description: 'Output file path to write reduced file to',
       },
-      {
-        name: 'workingDirectory',
-        type: String,
-        description: 'Working directory (for usage with relative external references)',
-      },
+      this.getWorkingDirArg(),
     ];
   }
 

--- a/src/cmds/openapi/validate.ts
+++ b/src/cmds/openapi/validate.ts
@@ -27,11 +27,7 @@ export default class OpenAPIValidateCommand extends Command {
         type: String,
         defaultOption: true,
       },
-      {
-        name: 'workingDirectory',
-        type: String,
-        description: 'Working directory (for usage with relative external references)',
-      },
+      this.getWorkingDirArg(),
       this.getGitHubArg(),
     ];
   }

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -187,7 +187,7 @@ export default class Command {
   }
 
   /**
-   * Used in any command where `workingDirectory` is an option.
+   * Used in the `openapi` family of commands where `workingDirectory` is an option.
    */
   getWorkingDirArg(): OptionDefinition {
     return {

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -159,7 +159,7 @@ export default class Command {
   /**
    * Used in the `versions:create` and `versions:update` commands.
    */
-  getVersionOpts() {
+  getVersionOpts(): OptionDefinition[] {
     return [
       {
         name: 'codename',

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -145,6 +145,17 @@ export default class Command {
   }
 
   /**
+   * Used in the `openapi` family of commands where `title` is an option.
+   */
+  getTitleArg(): OptionDefinition {
+    return {
+      name: 'title',
+      type: String,
+      description: 'An override value for the `info.title` field in the API definition',
+    };
+  }
+
+  /**
    * Used in any command where `version` is an option.
    */
   getVersionArg(): OptionDefinition {

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -186,6 +186,17 @@ export default class Command {
     ];
   }
 
+  /**
+   * Used in any command where `workingDirectory` is an option.
+   */
+  getWorkingDirArg(): OptionDefinition {
+    return {
+      name: 'workingDirectory',
+      type: String,
+      description: 'Working directory (for usage with relative external references)',
+    };
+  }
+
   static debug(msg: string) {
     debug(msg);
   }

--- a/src/lib/prepareOas.ts
+++ b/src/lib/prepareOas.ts
@@ -43,6 +43,11 @@ export default async function prepareOas(
      * Optionally convert the supplied or discovered API definition to the latest OpenAPI release.
      */
     convertToLatest?: boolean;
+    /**
+     * An optional title to replace the value in the `info.title` field.
+     * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#info-object}
+     */
+    title?: string;
   } = {
     convertToLatest: false,
   }
@@ -177,6 +182,11 @@ export default async function prepareOas(
   debug(api);
   debug('👆👆👆👆👆 finished logging spec 👆👆👆👆👆');
   debug(`spec type: ${specType}`);
+
+  if (opts.title) {
+    debug(`renaming title field to ${opts.title}`);
+    api.info.title = opts.title;
+  }
 
   // No need to optional chain here since `info.version` is required to pass validation
   const specVersion: string = api.info.version;


### PR DESCRIPTION
| 🚥 Fixes #716 |
| :---------------- |

## 🧰 Changes

This PR adds a new `--title` flag to both the `openapi` and `openapi:reduce` commands that overrides the `info.title` field in an API definition prior to syncing/reducing the output definition. The bulk of this change can be found in this commit: https://github.com/readmeio/rdme/pull/718/commits/8b088622338f683c0da4c6c8a4c279a03f3d455f

As part of this process, I made a few related cleanups/refactors:
- [x] Refactored some of the bundling logic https://github.com/readmeio/rdme/pull/718/commits/95fcdc2a26050f7f29df8d4682a84e59e570f385
- [x] Consolidated the `workingDirectory` arg definition https://github.com/readmeio/rdme/pull/718/commits/a1a4176f847c8c7c8843774d8e7c7b260faf0989
- [x] Backfilled a few types https://github.com/readmeio/rdme/pull/718/commits/5b8e465bc4064854fd82bd68af89897a07a4c0e1 https://github.com/readmeio/rdme/pull/718/commits/a605834b2cae9d5a74f7e37c8eed6f3ecce8ecf0
- [x] Fixed a bug where tags weren't properly being returned in the prompts for the `openapi:reduce` command https://github.com/readmeio/rdme/pull/718/commits/9575b70facae0dbbde754fbe403e0cdfc1fe7b8f
  - [x] Bumped `oas` (https://github.com/readmeio/rdme/pull/718/commits/9b3dfe203b51f1cd33620940c64691b2487cbe6f) and removed `jsonpath-plus` (https://github.com/readmeio/rdme/pull/718/commits/ef4d53be3c6791e5261823d8c4d9841cb55c9cb1) accordingly

## 🧬 QA & Testing

You can test this out by running `openapi:reduce`:

```sh
npm run debug -- openapi:reduce __tests__/__fixtures__/petstore-simple-weird-version.json --title "some alternative title"
```
