### PR TITLE
feat(api): surface `Warning` response headers

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -23,6 +23,7 @@ function getProxy() {
 }
 
 /**
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Warning}
  * @see {@link https://www.rfc-editor.org/rfc/rfc7234#section-5.5}
  * @see {@link https://github.com/marcbachmann/warning-header-parser}
  */
@@ -41,6 +42,7 @@ function stripQuotes(s: string) {
 /**
  * Parses Warning header into an array of warning header objects
  * @param header raw `Warning` header
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Warning}
  * @see {@link https://www.rfc-editor.org/rfc/rfc7234#section-5.5}
  * @see {@link https://github.com/marcbachmann/warning-header-parser}
  */

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -22,7 +22,11 @@ function getProxy() {
   return '';
 }
 
-interface WarningHeaderObject {
+/**
+ * @see {@link https://www.rfc-editor.org/rfc/rfc7234#section-5.5}
+ * @see {@link https://github.com/marcbachmann/warning-header-parser}
+ */
+interface WarningHeader {
   code: string;
   agent: string;
   message: string;
@@ -35,16 +39,16 @@ function stripQuotes(s: string) {
 }
 
 /**
- * Parses Warning header into actionable object
+ * Parses Warning header into an array of warning header objects
  * @param header raw `Warning` header
  * @see {@link https://www.rfc-editor.org/rfc/rfc7234#section-5.5}
  * @see {@link https://github.com/marcbachmann/warning-header-parser}
  */
-function parseWarningHeader(header: string): WarningHeaderObject[] {
+function parseWarningHeader(header: string): WarningHeader[] {
   try {
     const warnings = header.split(/([0-9]{3} [a-z0-9.@\-/]*) /g);
 
-    let previous: WarningHeaderObject;
+    let previous: WarningHeader;
 
     return warnings.reduce((all, w) => {
       // eslint-disable-next-line no-param-reassign

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -8,7 +8,7 @@ import pkg from '../../package.json';
 
 import APIError from './apiError';
 import { isGHA } from './isCI';
-import { debug } from './logger';
+import { debug, warn } from './logger';
 
 const SUCCESS_NO_CONTENT = 204;
 
@@ -20,6 +20,52 @@ function getProxy() {
     return proxy.endsWith('/') ? proxy : `${proxy}/`;
   }
   return '';
+}
+
+interface WarningHeaderObject {
+  code: string;
+  agent: string;
+  message: string;
+  date?: string;
+}
+
+function stripQuotes(s: string) {
+  if (!s) return '';
+  return s.replace(/(^"|[",]*$)/g, '');
+}
+
+/**
+ * Parses Warning header into actionable object
+ * @param header raw `Warning` header
+ * @see {@link https://www.rfc-editor.org/rfc/rfc7234#section-5.5}
+ * @see {@link https://github.com/marcbachmann/warning-header-parser}
+ */
+function parseWarningHeader(header: string): WarningHeaderObject[] {
+  try {
+    const warnings = header.split(/([0-9]{3} [a-z0-9.@\-/]*) /g);
+
+    let previous: WarningHeaderObject;
+
+    return warnings.reduce((all, w) => {
+      // eslint-disable-next-line no-param-reassign
+      w = w.trim();
+      const newError = w.match(/^([0-9]{3}) (.*)/);
+      if (newError) {
+        previous = { code: newError[1], agent: newError[2], message: '' };
+      } else if (w) {
+        const errorContent = w.split(/" "/);
+        if (errorContent) {
+          previous.message = stripQuotes(errorContent[0]);
+          previous.date = stripQuotes(errorContent[1]);
+          all.push(previous);
+        }
+      }
+      return all;
+    }, []);
+  } catch (e) {
+    debug(`error parsing warning header: ${e.message}`);
+    return [{ code: '199', agent: '-', message: header }];
+  }
 }
 
 /**
@@ -64,6 +110,16 @@ export default function fetch(url: string, options: RequestInit = { headers: new
   return nodeFetch(fullUrl, {
     ...options,
     headers,
+  }).then(res => {
+    const warningHeader = res.headers.get('Warning');
+    if (warningHeader) {
+      debug(`received warning header: ${warningHeader}`);
+      const warnings = parseWarningHeader(warningHeader);
+      warnings.forEach(warning => {
+        warn(warning.message, 'ReadMe API Warning:');
+      });
+    }
+    return res;
   });
 }
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -68,12 +68,14 @@ function oraOptions() {
 
 /**
  * Wrapper for warn statements.
+ * @param prefix Text that precedes the warning.
+ * This is *not* used in the GitHub Actions-formatted warning.
  */
-function warn(input: string) {
+function warn(input: string, prefix = 'Warning!') {
   /* istanbul ignore next */
   if (isGHA() && !isTest()) return core.warning(input);
   // eslint-disable-next-line no-console
-  return console.warn(chalk.yellow(`⚠️  Warning! ${input}`));
+  return console.warn(chalk.yellow(`⚠️  ${prefix} ${input}`));
 }
 
 export { debug, error, info, oraOptions, warn };


### PR DESCRIPTION
## 🧰 Changes

As we start surfacing [`Warning` headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Warning) from the ReadMe API, we can now surface them in our formatted warning output.

## 🧬 QA & Testing

Don't have an example API request but do tests pass?
