### PR TITLE
ci: use var instead of secret

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Sync docs to ReadMe (dry run)
         uses: ./
         with:
-          rdme: docs ./documentation --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ secrets.README_DEVELOPERS_MAIN_VERSION }} --dryRun
+          rdme: docs ./documentation --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ vars.README_DEVELOPERS_MAIN_VERSION }} --dryRun
 
       # And finally, we perform an actual sync to ReadMe if we're on the main branch
       - name: Sync docs to ReadMe
@@ -61,4 +61,4 @@ jobs:
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
         uses: readmeio/rdme@main
         with:
-          rdme: docs ./documentation --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ secrets.README_DEVELOPERS_MAIN_VERSION }}
+          rdme: docs ./documentation --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ vars.README_DEVELOPERS_MAIN_VERSION }}


### PR DESCRIPTION
## 🧰 Changes

GitHub Actions now supports variables, so swapping out the version secret for a version variable.

Further reading: https://github.blog/changelog/2023-01-10-github-actions-support-for-configuration-variables-in-workflows/

## 🧬 QA & Testing

In the [docs syncing dry run step](https://github.com/readmeio/rdme/actions/runs/4008520309/jobs/6882778511#step:8:10), note how the version is no longer masked:

![CleanShot 2023-01-25 at 11 48 03@2x](https://user-images.githubusercontent.com/8854718/214642326-f6bb571a-2110-49d5-8f6c-5c5809f86acd.png)

Here's what it looks like for [the same workflow in `main`](https://github.com/readmeio/rdme/actions/runs/3877892669/jobs/6613439893#step:8:10):

![CleanShot 2023-01-25 at 11 48 56@2x](https://user-images.githubusercontent.com/8854718/214642584-c785069d-ada2-4d50-8131-33bb0e2841ea.png)

