### PR TITLE
feat(GHA): add req header containing file URL

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,6 +55,10 @@
             "name": "node-fetch",
             "importNames": ["default"],
             "message": "Avoid using `node-fetch` directly and instead use the fetch wrapper located in `lib/fetch.ts`. See CONTRIBUTING.md for more information."
+          },
+          {
+            "name": "ci-info",
+            "message": "The `ci-info` package is difficult to test because misleading results will appear when running tests in the GitHub Actions runner. Instead of importing this package directly, create a wrapper function in `lib/isCI.ts` and import that instead."
           }
         ]
       }

--- a/__tests__/cmds/docs/index.test.ts
+++ b/__tests__/cmds/docs/index.test.ts
@@ -620,9 +620,9 @@ describe('rdme docs', () => {
   });
 
   describe('command execution in GitHub Actions runner', () => {
-    beforeEach(() => beforeGHAEnv());
+    beforeEach(beforeGHAEnv);
 
-    afterEach(() => afterGHAEnv());
+    afterEach(afterGHAEnv);
 
     it('should error in CI if no API key provided', () => {
       return expect(docs.run({})).rejects.toStrictEqual(new Error('No project API key provided. Please use `--key`.'));

--- a/__tests__/cmds/docs/single.test.ts
+++ b/__tests__/cmds/docs/single.test.ts
@@ -344,9 +344,9 @@ describe('rdme docs (single)', () => {
   });
 
   describe('command execution in GitHub Actions runner', () => {
-    beforeEach(() => beforeGHAEnv());
+    beforeEach(beforeGHAEnv);
 
-    afterEach(() => afterGHAEnv());
+    afterEach(afterGHAEnv);
 
     it('should error in CI if no API key provided', () => {
       return expect(docs.run({})).rejects.toStrictEqual(new Error('No project API key provided. Please use `--key`.'));

--- a/__tests__/cmds/docs/single.test.ts
+++ b/__tests__/cmds/docs/single.test.ts
@@ -10,6 +10,7 @@ import DocsCommand from '../../../src/cmds/docs';
 import APIError from '../../../src/lib/apiError';
 import getAPIMock, { getAPIMockWithVersionHeader } from '../../helpers/get-api-mock';
 import hashFileContents from '../../helpers/hash-file-contents';
+import { after as afterGHAEnv, before as beforeGHAEnv } from '../../helpers/setup-gha-env';
 
 const docs = new DocsCommand();
 
@@ -30,12 +31,6 @@ describe('rdme docs (single)', () => {
     prompts.inject(['this-is-not-an-email', 'password', 'subdomain']);
     await expect(docs.run({})).rejects.toStrictEqual(new Error('You must provide a valid email address.'));
     consoleInfoSpy.mockRestore();
-  });
-
-  it('should error in CI if no API key provided', async () => {
-    process.env.TEST_RDME_CI = 'true';
-    await expect(docs.run({})).rejects.toStrictEqual(new Error('No project API key provided. Please use `--key`.'));
-    delete process.env.TEST_RDME_CI;
   });
 
   it('should error if no file path provided', async () => {
@@ -343,6 +338,109 @@ describe('rdme docs (single)', () => {
           expect(skippedDocs).toBe('🎭 dry run! `simple-doc` will not be updated because there were no changes.');
 
           getMock.done();
+          versionMock.done();
+        });
+    });
+  });
+
+  describe('command execution in GitHub Actions runner', () => {
+    beforeEach(() => beforeGHAEnv());
+
+    afterEach(() => afterGHAEnv());
+
+    it('should error in CI if no API key provided', () => {
+      return expect(docs.run({})).rejects.toStrictEqual(new Error('No project API key provided. Please use `--key`.'));
+    });
+
+    it('should sync new doc with correct headers', async () => {
+      const slug = 'new-doc';
+      const id = '1234';
+      const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
+      const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/new-docs/${slug}.md`)));
+
+      const getMock = getAPIMockWithVersionHeader(version)
+        .get(`/api/v1/docs/${slug}`)
+        .basicAuth({ user: key })
+        .reply(404, {
+          error: 'DOC_NOTFOUND',
+          message: `The doc with the slug '${slug}' couldn't be found`,
+          suggestion: '...a suggestion to resolve the issue...',
+          help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+        });
+
+      const postMock = getAPIMock({
+        'x-rdme-ci': 'GitHub Actions (test)',
+        'x-readme-source': 'cli-gh',
+        'x-readme-source-url':
+          'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/__tests__/__fixtures__/docs/new-docs/new-doc.md',
+        'x-readme-version': version,
+      })
+        .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
+        .basicAuth({ user: key })
+        .reply(201, { slug, _id: id, body: doc.content, ...doc.data, lastUpdatedHash: hash });
+
+      const versionMock = getAPIMock()
+        .get(`/api/v1/version/${version}`)
+        .basicAuth({ user: key })
+        .reply(200, { version });
+
+      await expect(
+        docs.run({ filePath: `./__tests__/${fixturesBaseDir}/new-docs/new-doc.md`, key, version })
+      ).resolves.toBe(
+        `🌱 successfully created 'new-doc' (ID: 1234) with contents from ./__tests__/${fixturesBaseDir}/new-docs/new-doc.md`
+      );
+
+      getMock.done();
+      postMock.done();
+      versionMock.done();
+    });
+
+    it('should sync existing doc with correct headers', () => {
+      const fileContents = fs.readFileSync(path.join(fullFixturesDir, '/existing-docs/simple-doc.md'));
+      const simpleDoc = {
+        slug: 'simple-doc',
+        doc: frontMatter(fileContents),
+        hash: hashFileContents(fileContents),
+      };
+
+      const getMock = getAPIMockWithVersionHeader(version)
+        .get('/api/v1/docs/simple-doc')
+        .basicAuth({ user: key })
+        .reply(200, { category, slug: simpleDoc.slug, lastUpdatedHash: 'anOldHash' });
+
+      const updateMock = getAPIMock({
+        'x-rdme-ci': 'GitHub Actions (test)',
+        'x-readme-source': 'cli-gh',
+        'x-readme-source-url':
+          'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/__tests__/__fixtures__/docs/existing-docs/simple-doc.md',
+        'x-readme-version': version,
+      })
+        .put('/api/v1/docs/simple-doc', {
+          body: simpleDoc.doc.content,
+          lastUpdatedHash: simpleDoc.hash,
+          ...simpleDoc.doc.data,
+        })
+        .basicAuth({ user: key })
+        .reply(200, {
+          category,
+          slug: simpleDoc.slug,
+          body: simpleDoc.doc.content,
+        });
+
+      const versionMock = getAPIMock()
+        .get(`/api/v1/version/${version}`)
+        .basicAuth({ user: key })
+        .reply(200, { version });
+
+      return docs
+        .run({ filePath: `__tests__/${fixturesBaseDir}/existing-docs/simple-doc.md`, key, version })
+        .then(updatedDocs => {
+          expect(updatedDocs).toBe(
+            `✏️ successfully updated 'simple-doc' with contents from __tests__/${fixturesBaseDir}/existing-docs/simple-doc.md`
+          );
+
+          getMock.done();
+          updateMock.done();
           versionMock.done();
         });
     });

--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -762,45 +762,6 @@ describe('rdme openapi', () => {
       return mock.done();
     });
 
-    describe('CI version handling', () => {
-      beforeEach(() => {
-        process.env.TEST_RDME_CI = 'true';
-      });
-
-      afterEach(() => {
-        delete process.env.TEST_RDME_CI;
-      });
-
-      it('should omit version header in CI environment', async () => {
-        expect.assertions(2);
-        let requestBody = '';
-        const registryUUID = getRandomRegistryId();
-        const mock = getAPIMock()
-          .post('/api/v1/api-registry', body => {
-            requestBody = body.substring(body.indexOf('{'), body.lastIndexOf('}') + 1);
-            requestBody = JSON.parse(requestBody);
-
-            return body.match('form-data; name="spec"');
-          })
-          .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
-          .get('/api/v1/api-specification')
-          .basicAuth({ user: key })
-          .reply(200, [])
-          .post('/api/v1/api-specification', { registryUUID })
-          .basicAuth({ user: key })
-          .reply(function (uri, rBody, cb) {
-            expect(this.req.headers['x-readme-version']).toBeUndefined();
-            return cb(null, [201, { _id: 1 }, { location: exampleRefLocation }]);
-          });
-
-        const spec = './__tests__/__fixtures__/ref-oas/petstore.json';
-
-        await expect(openapi.run({ spec, key })).resolves.toBe(successfulUpload(spec));
-
-        return mock.done();
-      });
-    });
-
     it('should error if version flag sent to API returns a 404', async () => {
       const invalidVersion = 'v1000';
 
@@ -866,14 +827,6 @@ describe('rdme openapi', () => {
     it('should prompt for login if no API key provided', () => {
       prompts.inject(['this-is-not-an-email', 'password', 'subdomain']);
       return expect(openapi.run({})).rejects.toStrictEqual(new Error('You must provide a valid email address.'));
-    });
-
-    it('should error in CI if no API key provided', async () => {
-      process.env.TEST_RDME_CI = 'true';
-      await expect(openapi.run({})).rejects.toStrictEqual(
-        new Error('No project API key provided. Please use `--key`.')
-      );
-      delete process.env.TEST_RDME_CI;
     });
 
     it('should error if `--create` and `--update` flags are passed simultaneously', () => {
@@ -1467,6 +1420,12 @@ describe('rdme openapi', () => {
 
     afterEach(() => afterGHAEnv());
 
+    it('should error in CI if no API key provided', () => {
+      return expect(openapi.run({})).rejects.toStrictEqual(
+        new Error('No project API key provided. Please use `--key`.')
+      );
+    });
+
     it('should error out if multiple possible spec matches were found', () => {
       return expect(
         openapi.run({
@@ -1474,6 +1433,35 @@ describe('rdme openapi', () => {
           version,
         })
       ).rejects.toStrictEqual(new Error('Multiple API definitions found in current directory. Please specify file.'));
+    });
+
+    it('should omit version header in CI environment', async () => {
+      expect.assertions(2);
+      let requestBody = '';
+      const registryUUID = getRandomRegistryId();
+      const mock = getAPIMock()
+        .post('/api/v1/api-registry', body => {
+          requestBody = body.substring(body.indexOf('{'), body.lastIndexOf('}') + 1);
+          requestBody = JSON.parse(requestBody);
+
+          return body.match('form-data; name="spec"');
+        })
+        .reply(201, { registryUUID, spec: { openapi: '3.0.0' } })
+        .get('/api/v1/api-specification')
+        .basicAuth({ user: key })
+        .reply(200, [])
+        .post('/api/v1/api-specification', { registryUUID })
+        .basicAuth({ user: key })
+        .reply(function (uri, rBody, cb) {
+          expect(this.req.headers['x-readme-version']).toBeUndefined();
+          return cb(null, [201, { _id: 1 }, { location: exampleRefLocation }]);
+        });
+
+      const spec = './__tests__/__fixtures__/ref-oas/petstore.json';
+
+      await expect(openapi.run({ spec, key })).resolves.toBe(successfulUpload(spec));
+
+      return mock.done();
     });
 
     it('should send proper headers in GitHub Actions CI for local spec file', async () => {

--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -1455,9 +1455,9 @@ describe('rdme openapi', () => {
   });
 
   describe('command execution in GitHub Actions runner', () => {
-    beforeEach(() => beforeGHAEnv());
+    beforeEach(beforeGHAEnv);
 
-    afterEach(() => afterGHAEnv());
+    afterEach(afterGHAEnv);
 
     it('should error in CI if no API key provided', () => {
       return expect(openapi.run({})).rejects.toStrictEqual(

--- a/__tests__/helpers/get-gha-setup.ts
+++ b/__tests__/helpers/get-gha-setup.ts
@@ -11,7 +11,7 @@ import getGitRemoteMock from './get-git-mock';
 const testWorkingDir = process.cwd();
 
 /**
- *  A helper function for setting up tests for our GitHub Action onboarding.
+ * A helper function for setting up tests for our GitHub Action onboarding.
  *
  * @param writeFileSyncCb the mock function that should be called
  * in place of `fs.writeFileSync`

--- a/__tests__/helpers/setup-gha-env.ts
+++ b/__tests__/helpers/setup-gha-env.ts
@@ -1,0 +1,40 @@
+import * as isCI from '../../src/lib/isCI';
+
+/**
+ * A helper function for setting up tests for simulating a GitHub Actions runner environment
+ */
+export function before() {
+  // List of all GitHub Actions env variables:
+  // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+  process.env.GITHUB_ACTION = '__repo-owner_name-of-action-repo';
+  process.env.GITHUB_ACTIONS = 'true';
+  process.env.GITHUB_REPOSITORY = 'octocat/Hello-World';
+  process.env.GITHUB_RUN_ATTEMPT = '3';
+  process.env.GITHUB_RUN_ID = '1658821493';
+  process.env.GITHUB_RUN_NUMBER = '3';
+  process.env.GITHUB_SERVER_URL = 'https://github.com';
+  process.env.GITHUB_SHA = 'ffac537e6cbbf934b08745a378932722df287a53';
+  process.env.TEST_RDME_CI = 'true';
+
+  const isGHASpy = jest.spyOn(isCI, 'isGHA');
+  isGHASpy.mockReturnValue(true);
+
+  const ciNameSpy = jest.spyOn(isCI, 'ciName');
+  ciNameSpy.mockReturnValue('GitHub Actions (test)');
+}
+
+/**
+ * A helper function for tearing down tests after simulating a GitHub Actions runner environment
+ */
+export function after() {
+  delete process.env.GITHUB_ACTION;
+  delete process.env.GITHUB_ACTIONS;
+  delete process.env.GITHUB_REPOSITORY;
+  delete process.env.GITHUB_RUN_ATTEMPT;
+  delete process.env.GITHUB_RUN_ID;
+  delete process.env.GITHUB_RUN_NUMBER;
+  delete process.env.GITHUB_SERVER_URL;
+  delete process.env.GITHUB_SHA;
+  delete process.env.TEST_RDME_CI;
+  jest.resetAllMocks();
+}

--- a/__tests__/helpers/setup-gha-env.ts
+++ b/__tests__/helpers/setup-gha-env.ts
@@ -1,9 +1,12 @@
 import * as isCI from '../../src/lib/isCI';
 
+const env = process.env;
+
 /**
  * A helper function for setting up tests for simulating a GitHub Actions runner environment
  */
 export function before() {
+  jest.resetModules();
   // List of all GitHub Actions env variables:
   // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
   process.env.GITHUB_ACTION = '__repo-owner_name-of-action-repo';
@@ -27,14 +30,7 @@ export function before() {
  * A helper function for tearing down tests after simulating a GitHub Actions runner environment
  */
 export function after() {
-  delete process.env.GITHUB_ACTION;
-  delete process.env.GITHUB_ACTIONS;
-  delete process.env.GITHUB_REPOSITORY;
-  delete process.env.GITHUB_RUN_ATTEMPT;
-  delete process.env.GITHUB_RUN_ID;
-  delete process.env.GITHUB_RUN_NUMBER;
-  delete process.env.GITHUB_SERVER_URL;
-  delete process.env.GITHUB_SHA;
+  process.env = env;
   delete process.env.TEST_RDME_CI;
   jest.resetAllMocks();
 }

--- a/__tests__/lib/fetch.test.ts
+++ b/__tests__/lib/fetch.test.ts
@@ -4,46 +4,14 @@ import { Headers } from 'node-fetch';
 
 import pkg from '../../package.json';
 import fetch, { cleanHeaders, handleRes } from '../../src/lib/fetch';
-import * as isCI from '../../src/lib/isCI';
 import getAPIMock from '../helpers/get-api-mock';
+import { after, before } from '../helpers/setup-gha-env';
 
 describe('#fetch()', () => {
   describe('GitHub Actions environment', () => {
-    let isGHASpy: jest.SpyInstance;
-    let ciNameSpy: jest.SpyInstance;
+    beforeEach(() => before());
 
-    // List of all GitHub Actions env variables:
-    // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-    beforeEach(() => {
-      process.env.GITHUB_ACTION = '__repo-owner_name-of-action-repo';
-      process.env.GITHUB_ACTIONS = 'true';
-      process.env.GITHUB_REPOSITORY = 'octocat/Hello-World';
-      process.env.GITHUB_RUN_ATTEMPT = '3';
-      process.env.GITHUB_RUN_ID = '1658821493';
-      process.env.GITHUB_RUN_NUMBER = '3';
-      process.env.GITHUB_SERVER_URL = 'https://github.com';
-      process.env.GITHUB_SHA = 'ffac537e6cbbf934b08745a378932722df287a53';
-      process.env.TEST_RDME_CI = 'true';
-
-      isGHASpy = jest.spyOn(isCI, 'isGHA');
-      isGHASpy.mockReturnValue(true);
-
-      ciNameSpy = jest.spyOn(isCI, 'ciName');
-      ciNameSpy.mockReturnValue('GitHub Actions (test)');
-    });
-
-    afterEach(() => {
-      delete process.env.GITHUB_ACTION;
-      delete process.env.GITHUB_ACTIONS;
-      delete process.env.GITHUB_REPOSITORY;
-      delete process.env.GITHUB_RUN_ATTEMPT;
-      delete process.env.GITHUB_RUN_ID;
-      delete process.env.GITHUB_RUN_NUMBER;
-      delete process.env.GITHUB_SERVER_URL;
-      delete process.env.GITHUB_SHA;
-      delete process.env.TEST_RDME_CI;
-      jest.resetAllMocks();
-    });
+    afterEach(() => after());
 
     it('should have correct headers for requests in GitHub Action env', async () => {
       const key = 'API_KEY';

--- a/__tests__/lib/fetch.test.ts
+++ b/__tests__/lib/fetch.test.ts
@@ -9,7 +9,8 @@ import getAPIMock from '../helpers/get-api-mock';
 
 describe('#fetch()', () => {
   describe('GitHub Actions environment', () => {
-    let spy: jest.SpyInstance;
+    let isGHASpy: jest.SpyInstance;
+    let ciNameSpy: jest.SpyInstance;
 
     // List of all GitHub Actions env variables:
     // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
@@ -23,8 +24,12 @@ describe('#fetch()', () => {
       process.env.GITHUB_SERVER_URL = 'https://github.com';
       process.env.GITHUB_SHA = 'ffac537e6cbbf934b08745a378932722df287a53';
       process.env.TEST_RDME_CI = 'true';
-      spy = jest.spyOn(isCI, 'isGHA');
-      spy.mockReturnValue(true);
+
+      isGHASpy = jest.spyOn(isCI, 'isGHA');
+      isGHASpy.mockReturnValue(true);
+
+      ciNameSpy = jest.spyOn(isCI, 'ciName');
+      ciNameSpy.mockReturnValue('GitHub Actions (test)');
     });
 
     afterEach(() => {
@@ -37,7 +42,7 @@ describe('#fetch()', () => {
       delete process.env.GITHUB_SERVER_URL;
       delete process.env.GITHUB_SHA;
       delete process.env.TEST_RDME_CI;
-      spy.mockReset();
+      jest.resetAllMocks();
     });
 
     it('should have correct headers for requests in GitHub Action env', async () => {
@@ -62,9 +67,7 @@ describe('#fetch()', () => {
       expect(headers['x-github-run-id'].shift()).toBe('1658821493');
       expect(headers['x-github-run-number'].shift()).toBe('3');
       expect(headers['x-github-sha'].shift()).toBe('ffac537e6cbbf934b08745a378932722df287a53');
-      // in reality this header value should be 'GitHub', but I'm
-      // having troubles mocking the `ci-info` package
-      expect(headers['x-rdme-ci'].shift()).toBe('n/a');
+      expect(headers['x-rdme-ci'].shift()).toBe('GitHub Actions (test)');
       mock.done();
     });
 

--- a/__tests__/lib/fetch.test.ts
+++ b/__tests__/lib/fetch.test.ts
@@ -9,9 +9,9 @@ import { after, before } from '../helpers/setup-gha-env';
 
 describe('#fetch()', () => {
   describe('GitHub Actions environment', () => {
-    beforeEach(() => before());
+    beforeEach(before);
 
-    afterEach(() => after());
+    afterEach(after);
 
     it('should have correct headers for requests in GitHub Action env', async () => {
       const key = 'API_KEY';

--- a/__tests__/lib/fetch.test.ts
+++ b/__tests__/lib/fetch.test.ts
@@ -39,29 +39,80 @@ describe('#fetch()', () => {
       mock.done();
     });
 
-    it('should include file URL header if applicable', async () => {
-      const key = 'API_KEY';
+    describe('source URL header', () => {
+      it('should include source URL header with simple path', async () => {
+        const key = 'API_KEY';
 
-      const mock = getAPIMock()
-        .get('/api/v1')
-        .basicAuth({ user: key })
-        .reply(200, function () {
-          return this.req.headers;
-        });
+        const mock = getAPIMock()
+          .get('/api/v1')
+          .basicAuth({ user: key })
+          .reply(200, function () {
+            return this.req.headers;
+          });
 
-      const headers = await fetch(
-        `${config.get('host')}/api/v1`,
-        {
-          method: 'get',
-          headers: cleanHeaders(key),
-        },
-        'openapi.json'
-      ).then(handleRes);
+        const headers = await fetch(
+          `${config.get('host')}/api/v1`,
+          {
+            method: 'get',
+            headers: cleanHeaders(key),
+          },
+          { filePath: 'openapi.json', fileType: 'path' }
+        ).then(handleRes);
 
-      expect(headers['x-readme-source-url'].shift()).toBe(
-        'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/openapi.json'
-      );
-      mock.done();
+        expect(headers['x-readme-source-url'].shift()).toBe(
+          'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/openapi.json'
+        );
+        mock.done();
+      });
+
+      it('should include source URL header with relative path', async () => {
+        const key = 'API_KEY';
+
+        const mock = getAPIMock()
+          .get('/api/v1')
+          .basicAuth({ user: key })
+          .reply(200, function () {
+            return this.req.headers;
+          });
+
+        const headers = await fetch(
+          `${config.get('host')}/api/v1`,
+          {
+            method: 'get',
+            headers: cleanHeaders(key),
+          },
+          { filePath: './openapi.json', fileType: 'path' }
+        ).then(handleRes);
+
+        expect(headers['x-readme-source-url'].shift()).toBe(
+          'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/openapi.json'
+        );
+        mock.done();
+      });
+
+      it('should include source URL header with URL path', async () => {
+        const key = 'API_KEY';
+        const filePath = 'https://example.com/openapi.json';
+
+        const mock = getAPIMock()
+          .get('/api/v1')
+          .basicAuth({ user: key })
+          .reply(200, function () {
+            return this.req.headers;
+          });
+
+        const headers = await fetch(
+          `${config.get('host')}/api/v1`,
+          {
+            method: 'get',
+            headers: cleanHeaders(key),
+          },
+          { filePath, fileType: 'url' }
+        ).then(handleRes);
+
+        expect(headers['x-readme-source-url'].shift()).toBe(filePath);
+        mock.done();
+      });
     });
   });
 

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -235,7 +235,7 @@ export default class OpenAPICommand extends Command {
 
       options.method = 'post';
       spinner.start('Creating your API docs in ReadMe...');
-      return fetch(`${config.get('host')}/api/v1/api-specification`, options).then(res => {
+      return fetch(`${config.get('host')}/api/v1/api-specification`, options, specPath).then(res => {
         if (res.ok) {
           spinner.succeed(`${spinner.text} done! 🦉`);
           return success(res);
@@ -253,7 +253,7 @@ export default class OpenAPICommand extends Command {
       isUpdate = true;
       options.method = 'put';
       spinner.start('Updating your API docs in ReadMe...');
-      return fetch(`${config.get('host')}/api/v1/api-specification/${specId}`, options).then(res => {
+      return fetch(`${config.get('host')}/api/v1/api-specification/${specId}`, options, specPath).then(res => {
         if (res.ok) {
           spinner.succeed(`${spinner.text} done! 🦉`);
           return success(res);

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -133,7 +133,9 @@ export default class OpenAPICommand extends Command {
 
     // Reason we're hardcoding in command here is because `swagger` command
     // relies on this and we don't want to use `swagger` in this function
-    const { preparedSpec, specPath, specType, specVersion } = await prepareOas(spec, 'openapi', { title });
+    const { preparedSpec, specFileType, specPath, specType, specVersion } = await prepareOas(spec, 'openapi', {
+      title,
+    });
 
     if (useSpecVersion) {
       Command.info(
@@ -235,7 +237,10 @@ export default class OpenAPICommand extends Command {
 
       options.method = 'post';
       spinner.start('Creating your API docs in ReadMe...');
-      return fetch(`${config.get('host')}/api/v1/api-specification`, options, specPath).then(res => {
+      return fetch(`${config.get('host')}/api/v1/api-specification`, options, {
+        filePath: specPath,
+        fileType: specFileType,
+      }).then(res => {
         if (res.ok) {
           spinner.succeed(`${spinner.text} done! 🦉`);
           return success(res);
@@ -253,7 +258,10 @@ export default class OpenAPICommand extends Command {
       isUpdate = true;
       options.method = 'put';
       spinner.start('Updating your API docs in ReadMe...');
-      return fetch(`${config.get('host')}/api/v1/api-specification/${specId}`, options, specPath).then(res => {
+      return fetch(`${config.get('host')}/api/v1/api-specification/${specId}`, options, {
+        filePath: specPath,
+        fileType: specFileType,
+      }).then(res => {
         if (res.ok) {
           spinner.succeed(`${spinner.text} done! 🦉`);
           return success(res);

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -87,6 +87,8 @@ function getUserAgent() {
 /**
  * Wrapper for the `fetch` API so we can add rdme-specific headers to all API requests.
  *
+ * @param filePath local path for the file that's being sent. We use this to construct
+ * a full URL that points to the file in version control systems.
  */
 export default function fetch(url: string, options: RequestInit = { headers: new Headers() }, filePath = '') {
   let source = 'cli';

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -85,6 +85,15 @@ function getUserAgent() {
 }
 
 /**
+ * Sanitizes and stringifies the `Headers` object for logging purposes
+ */
+function sanitizeHeaders(headers: Headers) {
+  const raw = new Headers(headers).raw();
+  if (raw.Authorization) raw.Authorization = ['redacted'];
+  return JSON.stringify(raw);
+}
+
+/**
  * Wrapper for the `fetch` API so we can add rdme-specific headers to all API requests.
  *
  * @param filePath local path for the file that's being sent. We use this to construct
@@ -129,7 +138,9 @@ export default function fetch(url: string, options: RequestInit = { headers: new
 
   const fullUrl = `${getProxy()}${url}`;
 
-  debug(`making ${(options.method || 'get').toUpperCase()} request to ${fullUrl}`);
+  debug(
+    `making ${(options.method || 'get').toUpperCase()} request to ${fullUrl} with headers: ${sanitizeHeaders(headers)}`
+  );
 
   return nodeFetch(fullUrl, {
     ...options,

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -118,13 +118,13 @@ function sanitizeHeaders(headers: Headers) {
 
 /**
  * Wrapper for the `fetch` API so we can add rdme-specific headers to all API requests.
- *
- * @param filePath local path for the file that's being sent. We use this to construct
- * a full URL that points to the file in version control systems.
  */
 export default function fetch(
   url: string,
   options: RequestInit = { headers: new Headers() },
+  /**
+   * Details about the file path being sent. We use this to construct
+   * a full URL that points to the source file. */
   fileOpts: FilePathDetails = { filePath: '', fileType: false }
 ) {
   let source = 'cli';

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -127,8 +127,8 @@ function sanitizeHeaders(headers: Headers) {
 /**
  * Wrapper for the `fetch` API so we can add rdme-specific headers to all API requests.
  *
- * @param filePath local path for the file that's being sent. We use this to construct
- * a full URL that points to the file in version control systems.
+ * @param fileOpts optional object containing information about the file being sent.
+ * We use this to construct a full source URL for the file.
  */
 export default async function fetch(
   url: string,

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,6 +1,5 @@
 import type { RequestInit, Response } from 'node-fetch';
 
-import { name } from 'ci-info';
 import mime from 'mime-types';
 // eslint-disable-next-line no-restricted-imports
 import nodeFetch, { Headers } from 'node-fetch';
@@ -8,7 +7,7 @@ import nodeFetch, { Headers } from 'node-fetch';
 import pkg from '../../package.json';
 
 import APIError from './apiError';
-import isCI, { isGHA } from './isCI';
+import isCI, { ciName, isGHA } from './isCI';
 import { debug, warn } from './logger';
 
 const SUCCESS_NO_CONTENT = 204;
@@ -121,7 +120,7 @@ export default function fetch(url: string, options: RequestInit = { headers: new
   }
 
   if (isCI()) {
-    headers.set('x-rdme-ci', name || 'n/a');
+    headers.set('x-rdme-ci', ciName());
   }
 
   headers.set('x-readme-source', source);

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -118,13 +118,13 @@ function sanitizeHeaders(headers: Headers) {
 
 /**
  * Wrapper for the `fetch` API so we can add rdme-specific headers to all API requests.
+ *
+ * @param filePath local path for the file that's being sent. We use this to construct
+ * a full URL that points to the file in version control systems.
  */
 export default function fetch(
   url: string,
   options: RequestInit = { headers: new Headers() },
-  /**
-   * Details about the file path being sent. We use this to construct
-   * a full URL that points to the source file. */
   fileOpts: FilePathDetails = { filePath: '', fileType: false }
 ) {
   let source = 'cli';

--- a/src/lib/isCI.ts
+++ b/src/lib/isCI.ts
@@ -1,5 +1,12 @@
 import ci from 'ci-info'; // eslint-disable-line no-restricted-imports
 
+/**
+ * Wrapper function that returns the name of the current CI environment
+ * (or "n/a" if it's not available).
+ *
+ * Full list of vendors available here:
+ * https://github.com/watson/ci-info#supported-ci-tools
+ */
 export function ciName() {
   return ci.name || 'n/a';
 }

--- a/src/lib/isCI.ts
+++ b/src/lib/isCI.ts
@@ -1,5 +1,9 @@
 import ci from 'ci-info';
 
+export function ciName() {
+  return ci.name || 'n/a';
+}
+
 /**
  * Small env check to determine if we're in a GitHub Actions environment.
  *

--- a/src/lib/isCI.ts
+++ b/src/lib/isCI.ts
@@ -1,4 +1,4 @@
-import ci from 'ci-info';
+import ci from 'ci-info'; // eslint-disable-line no-restricted-imports
 
 export function ciName() {
   return ci.name || 'n/a';

--- a/src/lib/prepareOas.ts
+++ b/src/lib/prepareOas.ts
@@ -9,6 +9,8 @@ import { debug, info, oraOptions } from './logger';
 import promptTerminal from './promptWrapper';
 import readdirRecursive from './readdirRecursive';
 
+export type SpecFileType = OASNormalize['type'];
+
 interface FoundSpecFile {
   /** path to the spec file */
   filePath: string;
@@ -188,6 +190,8 @@ export default async function prepareOas(
     api.info.title = opts.title;
   }
 
+  const specFileType = oas.type;
+
   // No need to optional chain here since `info.version` is required to pass validation
   const specVersion: string = api.info.version;
   debug(`version in spec: ${specVersion}`);
@@ -200,6 +204,8 @@ export default async function prepareOas(
 
   return {
     preparedSpec: JSON.stringify(api),
+    /** A string indicating whether the spec file is a local path, a URL, etc. */
+    specFileType,
     /** The path/URL to the spec file */
     specPath,
     /** A string indicating whether the spec file is OpenAPI, Swagger, etc. */

--- a/src/lib/prepareOas.ts
+++ b/src/lib/prepareOas.ts
@@ -200,7 +200,9 @@ export default async function prepareOas(
 
   return {
     preparedSpec: JSON.stringify(api),
+    /** The path/URL to the spec file */
     specPath,
+    /** A string indicating whether the spec file is OpenAPI, Swagger, etc. */
     specType,
     /**
      * The `info.version` field, extracted from the normalized spec.

--- a/src/lib/syncDocsPath.ts
+++ b/src/lib/syncDocsPath.ts
@@ -62,20 +62,24 @@ async function pushDoc(
     }
 
     return (
-      fetch(`${config.get('host')}/api/v1/${type}`, {
-        method: 'post',
-        headers: cleanHeaders(
-          key,
-          new Headers({
-            'x-readme-version': selectedVersion,
-            'Content-Type': 'application/json',
-          })
-        ),
-        body: JSON.stringify({
-          slug,
-          ...payload,
-        }),
-      })
+      fetch(
+        `${config.get('host')}/api/v1/${type}`,
+        {
+          method: 'post',
+          headers: cleanHeaders(
+            key,
+            new Headers({
+              'x-readme-version': selectedVersion,
+              'Content-Type': 'application/json',
+            })
+          ),
+          body: JSON.stringify({
+            slug,
+            ...payload,
+          }),
+        },
+        filepath
+      )
         .then(handleRes)
         // eslint-disable-next-line no-underscore-dangle
         .then(res => `🌱 successfully created '${res.slug}' (ID: ${res._id}) with contents from ${filepath}`)
@@ -95,21 +99,25 @@ async function pushDoc(
       )}`;
     }
 
-    return fetch(`${config.get('host')}/api/v1/${type}/${slug}`, {
-      method: 'put',
-      headers: cleanHeaders(
-        key,
-        new Headers({
-          'x-readme-version': selectedVersion,
-          'Content-Type': 'application/json',
-        })
-      ),
-      body: JSON.stringify(
-        Object.assign(existingDoc, {
-          ...payload,
-        })
-      ),
-    })
+    return fetch(
+      `${config.get('host')}/api/v1/${type}/${slug}`,
+      {
+        method: 'put',
+        headers: cleanHeaders(
+          key,
+          new Headers({
+            'x-readme-version': selectedVersion,
+            'Content-Type': 'application/json',
+          })
+        ),
+        body: JSON.stringify(
+          Object.assign(existingDoc, {
+            ...payload,
+          })
+        ),
+      },
+      filepath
+    )
       .then(handleRes)
       .then(res => `✏️ successfully updated '${res.slug}' with contents from ${filepath}`);
   }

--- a/src/lib/syncDocsPath.ts
+++ b/src/lib/syncDocsPath.ts
@@ -19,7 +19,7 @@ import readDoc from './readDoc';
  * @param key the project API key
  * @param selectedVersion the project version
  * @param dryRun boolean indicating dry run mode
- * @param filepath path to file
+ * @param filePath path to file
  * @param type module within ReadMe to update (e.g. docs, changelogs, etc.)
  * @returns A promise-wrapped string with the result
  */
@@ -27,16 +27,16 @@ async function pushDoc(
   key: string,
   selectedVersion: string,
   dryRun: boolean,
-  filepath: string,
+  filePath: string,
   type: CommandCategories
 ) {
-  const { content, data, hash, slug } = readDoc(filepath);
+  const { content, data, hash, slug } = readDoc(filePath);
 
   // TODO: ideally we should offer a zero-configuration approach that doesn't
   // require YAML front matter, but that will have to be a breaking change
   if (!Object.keys(data).length) {
-    debug(`No front matter attributes found for ${filepath}, not syncing`);
-    return `⏭️  no front matter attributes found for ${filepath}, skipping`;
+    debug(`No front matter attributes found for ${filePath}, not syncing`);
+    return `⏭️  no front matter attributes found for ${filePath}, skipping`;
   }
 
   let payload: {
@@ -47,7 +47,7 @@ async function pushDoc(
   } = { body: content, ...data, lastUpdatedHash: hash };
 
   if (type === CommandCategories.CUSTOM_PAGES) {
-    if (filepath.endsWith('.html')) {
+    if (filePath.endsWith('.html')) {
       payload = { html: content, htmlmode: true, ...data, lastUpdatedHash: hash };
     } else {
       payload = { body: content, htmlmode: false, ...data, lastUpdatedHash: hash };
@@ -56,7 +56,7 @@ async function pushDoc(
 
   function createDoc() {
     if (dryRun) {
-      return `🎭 dry run! This will create '${slug}' with contents from ${filepath} with the following metadata: ${JSON.stringify(
+      return `🎭 dry run! This will create '${slug}' with contents from ${filePath} with the following metadata: ${JSON.stringify(
         data
       )}`;
     }
@@ -78,11 +78,11 @@ async function pushDoc(
             ...payload,
           }),
         },
-        filepath
+        filePath
       )
         .then(handleRes)
         // eslint-disable-next-line no-underscore-dangle
-        .then(res => `🌱 successfully created '${res.slug}' (ID: ${res._id}) with contents from ${filepath}`)
+        .then(res => `🌱 successfully created '${res.slug}' (ID: ${res._id}) with contents from ${filePath}`)
     );
   }
 
@@ -94,7 +94,7 @@ async function pushDoc(
     }
 
     if (dryRun) {
-      return `🎭 dry run! This will update '${slug}' with contents from ${filepath} with the following metadata: ${JSON.stringify(
+      return `🎭 dry run! This will update '${slug}' with contents from ${filePath} with the following metadata: ${JSON.stringify(
         data
       )}`;
     }
@@ -112,10 +112,10 @@ async function pushDoc(
         ),
         body: JSON.stringify(payload),
       },
-      filepath
+      filePath
     )
       .then(handleRes)
-      .then(res => `✏️ successfully updated '${res.slug}' with contents from ${filepath}`);
+      .then(res => `✏️ successfully updated '${res.slug}' with contents from ${filePath}`);
   }
 
   return fetch(`${config.get('host')}/api/v1/${type}/${slug}`, {
@@ -140,7 +140,7 @@ async function pushDoc(
     })
     .catch(err => {
       // eslint-disable-next-line no-param-reassign
-      err.message = `Error uploading ${chalk.underline(filepath)}:\n\n${err.message}`;
+      err.message = `Error uploading ${chalk.underline(filePath)}:\n\n${err.message}`;
       throw err;
     });
 }

--- a/src/lib/syncDocsPath.ts
+++ b/src/lib/syncDocsPath.ts
@@ -78,7 +78,7 @@ async function pushDoc(
             ...payload,
           }),
         },
-        filePath
+        { filePath, fileType: 'path' }
       )
         .then(handleRes)
         // eslint-disable-next-line no-underscore-dangle
@@ -112,7 +112,7 @@ async function pushDoc(
         ),
         body: JSON.stringify(payload),
       },
-      filePath
+      { filePath, fileType: 'path' }
     )
       .then(handleRes)
       .then(res => `✏️ successfully updated '${res.slug}' with contents from ${filePath}`);


### PR DESCRIPTION
| 🚥 Fixes RM-6466 |
| :---------------- |

## 🧰 Changes

**tl;dr** we're adding two new request headers when hitting the ReadMe API! This will facilitate some upcoming changes (see RM-5907) 👀

Here are the two new request headers:

1. **`x-rdme-ci`**: if the command is being run in a CI environment, this will be set to the name of the CI environment as determined by [`ci-info`](https://github.com/watson/ci-info) (e.g., `GitHub Actions`[^1])
1. **`x-readme-source-url`**: if the command is syncing an OpenAPI or Markdown doc to ReadMe, this header[^3] contains the source URL for the file (if applicable). There are two ways that we determine the source file:
    1. If the command is being run via GitHub Actions and a local file is being synced, we use a variety of [default environment variables](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) to construct a full URL to the file that looks something like [this](https://github.com/readmeio/rdme/blob/cb4129d5c7b51ff3b50f933a9c7d0c3d0d33d62c/documentation/rdme.md).
    2. If the `openapi` command is being run and the file in question is located at an external URL[^2], that URL is used.

As expected, a bunch of other stuff was done in this PR to facilitate these changes:
- [x] I added a new restricted import ESLint rule for [`ci-info`](https://npm.im/ci-info) — it continues to be very annoying to write tests with and we should confine all usage of the package to our helper functions in `src/lib/isCI.ts`.
- [x] A buttload of tests (including a new test helper and rearranging a few existing tests) 🍑
- [x] Created a few types derived from `oas-normalize` (see https://github.com/readmeio/oas-normalize/pull/248)
- [x] Enhanced our debug logs to include sanitized request headers for API requests
- [x] A few JSDoc additions/cleanups and variable renaming

## 🧬 QA & Testing

Well since each of these CI runs hit the ReadMe API to update [this test project's reference docs](https://rdme-test.readme.io), I was able to go into our Metrics dashboard for the ReadMe API and confirm that the request headers are showing up as expected:

<img width="433" alt="CleanShot 2023-01-31 at 19 07 20@2x" src="https://user-images.githubusercontent.com/8854718/215920189-4e5b8b99-a9e9-4a02-a7c6-18ce180dca2a.png">

If you go to the API Calls section in the dashboard, filter for my email address, and look for the `rdme-test` in the **user** column, you can click into any one of the API logs and peep the request headers. Note that the URL is off because we rely on [unconventional checkout pathing logic in this workflow](https://github.com/readmeio/rdme/blob/e3c7f22352d6f7e3d24c7fa762df788c905f25e4/.github/workflows/ci.yml#L42-L51), but I feel good about these changes with the test coverage.


[^1]: See the full list here: https://github.com/watson/ci-info#supported-ci-tools (the **Name** column is what will be used)

[^2]: For example, `rdme openapi https://github.com/readmeio/oas-examples/blob/main/3.0/json/petstore.json`

[^3]: For commands like `docs` and `openapi`, we do a lot of GET requests as part of the general workflow, but this request header will only be added to the `POST`/`PUT` requests that directly update Markdown/OpenAPI files.