### PR TITLE
fix: page deletion order in `docs:prune`

### DIFF
--- a/__tests__/cmds/docs/prune.test.ts
+++ b/__tests__/cmds/docs/prune.test.ts
@@ -88,7 +88,7 @@ describe('rdme docs:prune', () => {
         confirm: true,
         version,
       })
-    ).resolves.toBe('🗑️ successfully deleted `this-doc-should-be-missing-in-folder`.');
+    ).resolves.toBe('🗑️  successfully deleted `this-doc-should-be-missing-in-folder`.');
 
     apiMocks.done();
     versionMock.done();
@@ -116,7 +116,7 @@ describe('rdme docs:prune', () => {
         key,
         version,
       })
-    ).resolves.toBe('🗑️ successfully deleted `this-doc-should-be-missing-in-folder`.');
+    ).resolves.toBe('🗑️  successfully deleted `this-doc-should-be-missing-in-folder`.');
 
     apiMocks.done();
     versionMock.done();
@@ -151,7 +151,7 @@ describe('rdme docs:prune', () => {
         version,
       })
     ).resolves.toBe(
-      '🗑️ successfully deleted `this-doc-should-be-missing-in-folder`.\n🗑️ successfully deleted `this-child-is-also-missing`.'
+      '🗑️  successfully deleted `this-doc-should-be-missing-in-folder`.\n🗑️  successfully deleted `this-child-is-also-missing`.'
     );
 
     apiMocks.done();

--- a/__tests__/cmds/docs/prune.test.ts
+++ b/__tests__/cmds/docs/prune.test.ts
@@ -151,7 +151,7 @@ describe('rdme docs:prune', () => {
         version,
       })
     ).resolves.toBe(
-      '🗑️  successfully deleted `this-doc-should-be-missing-in-folder`.\n🗑️  successfully deleted `this-child-is-also-missing`.'
+      '🗑️  successfully deleted `this-child-is-also-missing`.\n🗑️  successfully deleted `this-doc-should-be-missing-in-folder`.'
     );
 
     apiMocks.done();

--- a/src/lib/deleteDoc.ts
+++ b/src/lib/deleteDoc.ts
@@ -36,5 +36,5 @@ export default async function deleteDoc(
     ),
   })
     .then(handleRes)
-    .then(() => `🗑️ successfully deleted \`${slug}\`.`);
+    .then(() => `🗑️  successfully deleted \`${slug}\`.`);
 }

--- a/src/lib/getDocs.ts
+++ b/src/lib/getDocs.ts
@@ -24,6 +24,11 @@ function flatten(data: Document[][]): Document[] {
       });
     }
   });
+
+  // Docs with children cannot be deleted unless the children are deleted first,
+  // so move those parent docs to the back of the list
+  allDocs.sort(a => (a.children?.length ? 1 : -1));
+
   return allDocs;
 }
 


### PR DESCRIPTION
## 🧰 Changes

Noticed two tiny issues in the `docs:prune` command that are fixed in this PR:

- [x] Noticed that folks would see this error if attempting to delete a page that contained children, so I just added a little array sorting into the mix so pages with children are deleted after pages without children.

<img width="1003" alt="CleanShot 2023-01-30 at 18 25 36@2x" src="https://user-images.githubusercontent.com/8854718/215627147-b448e594-1eba-4309-bdd0-27e81e776141.png">


- [x] Added an extra space between the 🗑️ bin and the confirmation message because yikes:

<img width="362" alt="CleanShot 2023-01-30 at 18 24 42@2x" src="https://user-images.githubusercontent.com/8854718/215627050-4c2935fe-6794-4c60-bd2e-13b72111bd95.png">


## 🧬 QA & Testing

Do tests pass?
