### PR TITLE
fix(docs): don't merge payloads for PUT requests

### DIFF
--- a/__tests__/cmds/changelogs/index.test.ts
+++ b/__tests__/cmds/changelogs/index.test.ts
@@ -90,7 +90,6 @@ describe('rdme changelogs', () => {
 
       const updateMocks = getAPIMock()
         .put('/api/v1/changelogs/simple-doc', {
-          slug: simpleDoc.slug,
           body: simpleDoc.doc.content,
           lastUpdatedHash: simpleDoc.hash,
           ...simpleDoc.doc.data,
@@ -101,7 +100,6 @@ describe('rdme changelogs', () => {
           body: simpleDoc.doc.content,
         })
         .put('/api/v1/changelogs/another-doc', {
-          slug: anotherDoc.slug,
           body: anotherDoc.doc.content,
           lastUpdatedHash: anotherDoc.hash,
           ...anotherDoc.doc.data,

--- a/__tests__/cmds/changelogs/single.test.ts
+++ b/__tests__/cmds/changelogs/single.test.ts
@@ -198,7 +198,6 @@ describe('rdme changelogs (single)', () => {
 
       const updateMock = getAPIMock()
         .put('/api/v1/changelogs/simple-doc', {
-          slug: simpleDoc.slug,
           body: simpleDoc.doc.content,
           lastUpdatedHash: simpleDoc.hash,
           ...simpleDoc.doc.data,

--- a/__tests__/cmds/custompages/index.test.ts
+++ b/__tests__/cmds/custompages/index.test.ts
@@ -90,7 +90,6 @@ describe('rdme custompages', () => {
 
       const updateMocks = getAPIMock()
         .put('/api/v1/custompages/simple-doc', {
-          slug: simpleDoc.slug,
           body: simpleDoc.doc.content,
           htmlmode: false,
           lastUpdatedHash: simpleDoc.hash,
@@ -103,7 +102,6 @@ describe('rdme custompages', () => {
           body: simpleDoc.doc.content,
         })
         .put('/api/v1/custompages/another-doc', {
-          slug: anotherDoc.slug,
           body: anotherDoc.doc.content,
           htmlmode: false,
           lastUpdatedHash: anotherDoc.hash,

--- a/__tests__/cmds/custompages/single.test.ts
+++ b/__tests__/cmds/custompages/single.test.ts
@@ -229,7 +229,6 @@ describe('rdme custompages (single)', () => {
 
       const updateMock = getAPIMock()
         .put('/api/v1/custompages/simple-doc', {
-          slug: simpleDoc.slug,
           body: simpleDoc.doc.content,
           htmlmode: false,
           lastUpdatedHash: simpleDoc.hash,

--- a/__tests__/cmds/docs/index.test.ts
+++ b/__tests__/cmds/docs/index.test.ts
@@ -139,8 +139,6 @@ describe('rdme docs', () => {
 
       const updateMocks = getAPIMockWithVersionHeader(version)
         .put('/api/v1/docs/simple-doc', {
-          category,
-          slug: simpleDoc.slug,
           body: simpleDoc.doc.content,
           lastUpdatedHash: simpleDoc.hash,
           ...simpleDoc.doc.data,
@@ -152,8 +150,6 @@ describe('rdme docs', () => {
           body: simpleDoc.doc.content,
         })
         .put('/api/v1/docs/another-doc', {
-          category,
-          slug: anotherDoc.slug,
           body: anotherDoc.doc.content,
           lastUpdatedHash: anotherDoc.hash,
           ...anotherDoc.doc.data,

--- a/__tests__/cmds/docs/single.test.ts
+++ b/__tests__/cmds/docs/single.test.ts
@@ -243,8 +243,6 @@ describe('rdme docs (single)', () => {
 
       const updateMock = getAPIMockWithVersionHeader(version)
         .put('/api/v1/docs/simple-doc', {
-          category,
-          slug: simpleDoc.slug,
           body: simpleDoc.doc.content,
           lastUpdatedHash: simpleDoc.hash,
           ...simpleDoc.doc.data,

--- a/src/lib/syncDocsPath.ts
+++ b/src/lib/syncDocsPath.ts
@@ -104,11 +104,7 @@ async function pushDoc(
           'Content-Type': 'application/json',
         })
       ),
-      body: JSON.stringify(
-        Object.assign(existingDoc, {
-          ...payload,
-        })
-      ),
+      body: JSON.stringify(payload),
     })
       .then(handleRes)
       .then(res => `✏️ successfully updated '${res.slug}' with contents from ${filepath}`);


### PR DESCRIPTION
| 🚥 Fixes #738 |
| :---------------- |

## 🧰 Changes

For some background, here's the general workflow for when syncing a Markdown file to ReadMe via the `rdme docs` (or `changelogs`/`custompages`) command:

1. Grab the slug from the page
2. Make [a `GET` request](https://docs.readme.com/main/reference/getdoc) to the ReadMe API to confirm that the page exists
3. If the page exists, update the page via [a `PUT` request](https://docs.readme.com/main/reference/updatedoc)
4. If the page does **not** exist, create the page via [a `POST` request](https://docs.readme.com/main/reference/createdoc)

The problem in step 3 is that we take the response body from the `GET` request (called `existingDoc` in the code below) and merge that with the Markdown file's data when making the `PUT` request:

https://github.com/readmeio/rdme/blob/d311af92a0981e3faa4030838d6b4edd8a480dc7/src/lib/syncDocsPath.ts#L107-L111

This isn't really necessary since the API already merges the `PUT` request body with the existing doc, and it's creating adverse side effects when our API expects one field and not another (see #738 for an example).

## 🧬 QA & Testing

Do tests pass?
