### PR TITLE
ci: fix code coverage in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Run tests
-        run: sudo npm test
+        run: npm test
 
   action:
     name: GitHub Action Dry Run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Run tests
-        run: npm test
+        run: sudo npm test
 
   action:
     name: GitHub Action Dry Run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Build dist
         run: npm run build
 
+      - run: mkdir coverage/
+      - run: chmod -R 777 coverage/
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
       - name: Build dist
         run: npm run build
 
-      - run: mkdir coverage/
-      - run: chmod -R 777 coverage/
       - name: Run tests
         run: npm test
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['<rootDir>/dist', '<rootDir>/node_modules'],
   coverageThreshold: {
     global: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,9 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
+
 module.exports = {
+  coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['<rootDir>/dist', '<rootDir>/node_modules'],
+  coverageReporters: ['text-summary'],
   coverageThreshold: {
     global: {
       branches: 80,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
-
 module.exports = {
   coveragePathIgnorePatterns: ['/dist', '/node_modules'],
   coverageThreshold: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  coveragePathIgnorePatterns: ['/dist', '/node_modules'],
+  coverageDirectory: 'coverage',
+  coveragePathIgnorePatterns: ['<rootDir>/dist', '<rootDir>/node_modules'],
   coverageThreshold: {
     global: {
       branches: 80,
@@ -9,9 +10,8 @@ module.exports = {
       statements: 90,
     },
   },
-  modulePaths: ['<rootDir>'],
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
-  roots: ['<rootDir>'],
+  rootDir: __dirname,
   setupFiles: ['./__tests__/setup'],
   setupFilesAfterEnv: ['jest-extended/all'],
   testPathIgnorePatterns: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['<rootDir>/dist', '<rootDir>/node_modules'],
-  coverageReporters: ['text-summary'],
+  coverageReporters: ['text'],
   coverageThreshold: {
     global: {
       branches: 80,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['<rootDir>/dist', '<rootDir>/node_modules'],
   coverageReporters: ['text'],
   coverageThreshold: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
-
 module.exports = {
   coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['<rootDir>/dist', '<rootDir>/node_modules'],


### PR DESCRIPTION
| 🚥 Fixes #617 |
| :---------------- |

## 🧰 Changes

Code coverage in Github Actions is broken due to Jest, for whatever reason, not automatically creating code coverage directories. I was able to partialy fix this by first creating a `coverage/` directory but even after chmod'ing with 777 permissions it still wouldn't create `coverage/lconv-report/`.

As `coverage/lconv-report` has a whole bunch of subdirectories that I have no desire to try to keep up with in a CI workflow, I've just changed our Jest code coverage to use a simpler reporter that dumps to the console.

![Screen Shot 2023-02-01 at 11 19 38 AM](https://user-images.githubusercontent.com/33762/216141690-bd321b3b-a127-4e7e-bc74-0ca7d9280f09.png)
