### PR TITLE
fix: upgrading `oas-normalize` to move to our `postman-to-openapi` fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1759,6 +1759,21 @@
         "openapi-types": ">=7"
       }
     },
+    "node_modules/@readme/postman-to-openapi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/postman-to-openapi/-/postman-to-openapi-4.0.0.tgz",
+      "integrity": "sha512-LOwlzby87Njj6k6OofCmWSsl+EcnZjKp/wBQe/Loqxi+2m4TGnpALRP62zFjHw23ZUTVZvst8PIF6LMsK8xUHw==",
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "jsonc-parser": "3.2.0",
+        "lodash.camelcase": "^4.3.0",
+        "marked": "^4.2.12",
+        "mustache": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
@@ -3228,14 +3243,6 @@
       "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/comment-parser": {
@@ -7601,15 +7608,15 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-8.3.2.tgz",
-      "integrity": "sha512-xjPRdN9l27BxaR4+LYnJo/0SMw9nMBtCQ/NPejXT5dxw+is0j05PTgVnGxm6G+QTk2Y35hND4F9lNuPKk9Zw2A==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-8.3.3.tgz",
+      "integrity": "sha512-lzNXbIH01EpIDvdW5aH8LfaPdWSjcqW2CvIQiyFPWqY7OBze2qJHdYQoyfa0CAW5yRIO58+eNVrdhV2smXZhyw==",
       "dependencies": {
         "@readme/openapi-parser": "^2.4.0",
+        "@readme/postman-to-openapi": "^4.0.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "openapi-types": "^12.1.0",
-        "postman-to-openapi": "^3.0.1",
         "swagger2openapi": "^7.0.8"
       },
       "engines": {
@@ -8084,25 +8091,6 @@
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/postman-to-openapi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/postman-to-openapi/-/postman-to-openapi-3.0.1.tgz",
-      "integrity": "sha512-OUenC7fi5moe41nhO0yUj8jqVj6tchLCjPxG2d28Ai//Oujt3lL7tiFCL2P6pKUV1a7p5X/BJh7op65jjbrs3Q==",
-      "dependencies": {
-        "commander": "^8.3.0",
-        "js-yaml": "^4.1.0",
-        "jsonc-parser": "3.2.0",
-        "lodash.camelcase": "^4.3.0",
-        "marked": "^4.2.5",
-        "mustache": "^4.2.0"
-      },
-      "bin": {
-        "p2o": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=14 <20"
       }
     },
     "node_modules/prelude-ls": {
@@ -11425,6 +11413,18 @@
         "call-me-maybe": "^1.0.1"
       }
     },
+    "@readme/postman-to-openapi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/postman-to-openapi/-/postman-to-openapi-4.0.0.tgz",
+      "integrity": "sha512-LOwlzby87Njj6k6OofCmWSsl+EcnZjKp/wBQe/Loqxi+2m4TGnpALRP62zFjHw23ZUTVZvst8PIF6LMsK8xUHw==",
+      "requires": {
+        "js-yaml": "^4.1.0",
+        "jsonc-parser": "3.2.0",
+        "lodash.camelcase": "^4.3.0",
+        "marked": "^4.2.12",
+        "mustache": "^4.2.0"
+      }
+    },
     "@sinclair/typebox": {
       "version": "0.25.24",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
@@ -12513,11 +12513,6 @@
           "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
         }
       }
-    },
-    "commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
     },
     "comment-parser": {
       "version": "1.3.1",
@@ -15757,15 +15752,15 @@
       }
     },
     "oas-normalize": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-8.3.2.tgz",
-      "integrity": "sha512-xjPRdN9l27BxaR4+LYnJo/0SMw9nMBtCQ/NPejXT5dxw+is0j05PTgVnGxm6G+QTk2Y35hND4F9lNuPKk9Zw2A==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-8.3.3.tgz",
+      "integrity": "sha512-lzNXbIH01EpIDvdW5aH8LfaPdWSjcqW2CvIQiyFPWqY7OBze2qJHdYQoyfa0CAW5yRIO58+eNVrdhV2smXZhyw==",
       "requires": {
         "@readme/openapi-parser": "^2.4.0",
+        "@readme/postman-to-openapi": "^4.0.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "openapi-types": "^12.1.0",
-        "postman-to-openapi": "^3.0.1",
         "swagger2openapi": "^7.0.8"
       }
     },
@@ -16102,19 +16097,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
-    },
-    "postman-to-openapi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/postman-to-openapi/-/postman-to-openapi-3.0.1.tgz",
-      "integrity": "sha512-OUenC7fi5moe41nhO0yUj8jqVj6tchLCjPxG2d28Ai//Oujt3lL7tiFCL2P6pKUV1a7p5X/BJh7op65jjbrs3Q==",
-      "requires": {
-        "commander": "^8.3.0",
-        "js-yaml": "^4.1.0",
-        "jsonc-parser": "3.2.0",
-        "lodash.camelcase": "^4.3.0",
-        "marked": "^4.2.5",
-        "mustache": "^4.2.0"
-      }
     },
     "prelude-ls": {
       "version": "1.2.1",


### PR DESCRIPTION
| 🚥 Fixes RM-6112 |
| :---------------- |

## 🧰 Changes

Upgrades `oas-normalize` to move to our `postman-to-openapi` fork as we have some fixes for `undefined` response HTTP status codes that have been plaguing some users.