### PR TITLE
feat: container registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,13 @@ jobs:
           path: oas-examples-repo
           repository: readmeio/oas-examples
 
+      - name: Update action.yml to build locally
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: 'image:.*'
+          replace: "image: 'Dockerfile'"
+          include: rdme-repo/action.yml
+
       - name: Run `openapi:validate` command
         uses: ./rdme-repo/
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,12 @@ jobs:
           repository: readmeio/oas-examples
 
       - name: Run `openapi:validate` command
-        uses: readmeio/rdme@v8
+        uses: ./rdme-repo/
         with:
           rdme: openapi:validate oas-examples-repo/3.1/json/petstore.json
 
       # Docs: https://rdme-test.readme.io
       - name: Run `openapi` command
-        uses: readmeio/rdme@v8
+        uses: ./rdme-repo/
         with:
           rdme: openapi oas-examples-repo/3.1/json/petstore.json --key=${{ secrets.RDME_TEST_PROJECT_API_KEY }} --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,12 @@ jobs:
           path: oas-examples-repo
           repository: readmeio/oas-examples
 
-      - name: Update action.yml to build locally
+      # For every GitHub Action release, we deploy our Docker images
+      # to the GitHub Container Registry for performance reasons.
+      # Instead of testing against the pre-built image, we can build
+      # an image from the currently checked-out repo contents by doing a
+      # li'l update in the action.yml file to point to the current Dockerfile.
+      - name: Replace Docker image value in action.yml
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: 'image:.*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,12 @@ jobs:
           repository: readmeio/oas-examples
 
       - name: Run `openapi:validate` command
-        uses: ./rdme-repo/
+        uses: readmeio/rdme@496c511ce3a46b03e5726858271dd22d4cdc12d1
         with:
           rdme: openapi:validate oas-examples-repo/3.1/json/petstore.json
 
       # Docs: https://rdme-test.readme.io
       - name: Run `openapi` command
-        uses: ./rdme-repo/
+        uses: readmeio/rdme@496c511ce3a46b03e5726858271dd22d4cdc12d1
         with:
           rdme: openapi oas-examples-repo/3.1/json/petstore.json --key=${{ secrets.RDME_TEST_PROJECT_API_KEY }} --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,12 @@ jobs:
           repository: readmeio/oas-examples
 
       - name: Run `openapi:validate` command
-        uses: readmeio/rdme@496c511ce3a46b03e5726858271dd22d4cdc12d1
+        uses: readmeio/rdme@v8
         with:
           rdme: openapi:validate oas-examples-repo/3.1/json/petstore.json
 
       # Docs: https://rdme-test.readme.io
       - name: Run `openapi` command
-        uses: readmeio/rdme@496c511ce3a46b03e5726858271dd22d4cdc12d1
+        uses: readmeio/rdme@v8
         with:
           rdme: openapi oas-examples-repo/3.1/json/petstore.json --key=${{ secrets.RDME_TEST_PROJECT_API_KEY }} --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,18 @@ jobs:
           regex: false
           include: documentation/*
 
+      # For every GitHub Action release, we deploy our Docker images
+      # to the GitHub Container Registry for performance reasons.
+      # Instead of testing against the pre-built image, we can build
+      # an image from the currently checked-out repo contents by doing a
+      # li'l update in the action.yml file to point to the current Dockerfile.
+      - name: Replace Docker image value in action.yml
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: 'image:.*'
+          replace: "image: 'Dockerfile'"
+          include: action.yml
+
       # And finally, with our updated documentation,
       # we run the `rdme` GitHub Action to sync the Markdown file
       # in the `documentation` directory.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
       # First we're going to perform a dry run of syncing process.
       # We do this on every push to ensure that an actual sync will work properly
       - name: Sync docs to ReadMe (dry run)
-        uses: readmeio/rdme@v8
+        uses: ./
         with:
           rdme: docs ./documentation --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ vars.README_DEVELOPERS_MAIN_VERSION }} --dryRun
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
       # First we're going to perform a dry run of syncing process.
       # We do this on every push to ensure that an actual sync will work properly
       - name: Sync docs to ReadMe (dry run)
-        uses: readmeio/rdme@496c511ce3a46b03e5726858271dd22d4cdc12d1
+        uses: readmeio/rdme@v8
         with:
           rdme: docs ./documentation --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ vars.README_DEVELOPERS_MAIN_VERSION }} --dryRun
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
       # First we're going to perform a dry run of syncing process.
       # We do this on every push to ensure that an actual sync will work properly
       - name: Sync docs to ReadMe (dry run)
-        uses: ./
+        uses: readmeio/rdme@496c511ce3a46b03e5726858271dd22d4cdc12d1
         with:
           rdme: docs ./documentation --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ vars.README_DEVELOPERS_MAIN_VERSION }} --dryRun
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: 'RDME_VERSION'
-          replace: ${{ steps.rdme-version.outputs.RDME_VERSION }}
+          replace: ${{ steps.rdme-version.outputs.RDME_LATEST_MAJOR_VERSION }}
           regex: false
           include: documentation/*
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: 'RDME_VERSION'
-          replace: ${{ steps.rdme-version.outputs.RDME_LATEST_MAJOR_VERSION }}
+          replace: ${{ steps.rdme-version.outputs.RDME_VERSION }}
           regex: false
           include: documentation/*
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
       # First we're going to perform a dry run of syncing process.
       # We do this on every push to ensure that an actual sync will work properly
       - name: Sync docs to ReadMe (dry run)
-        uses: ./
+        uses: readmeio/rdme@088ebcbea6beeb0813fe54c018b2c5729a4ad9fb
         with:
           rdme: docs ./documentation --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ vars.README_DEVELOPERS_MAIN_VERSION }} --dryRun
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
       # First we're going to perform a dry run of syncing process.
       # We do this on every push to ensure that an actual sync will work properly
       - name: Sync docs to ReadMe (dry run)
-        uses: readmeio/rdme@088ebcbea6beeb0813fe54c018b2c5729a4ad9fb
+        uses: ./
         with:
           rdme: docs ./documentation --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ vars.README_DEVELOPERS_MAIN_VERSION }} --dryRun
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,6 @@ jobs:
             type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
-      - name: log metadata
-        run: echo $DOCKER_METADATA_OUTPUT_JSON
-
       - name: Build (but do NOT push)
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 on:
   push:
-    branches:
-      - main
-      - next
+    # branches:
+    #   - main
+    #   - next
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ secrets.RELEASE_GH_TOKEN }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=8.6.0-next.13
+            type=ref,event=branch
 
       - name: log metadata
         run: echo $DOCKER_METADATA_OUTPUT_JSON

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,16 @@ jobs:
         run: npm i --no-save semantic-release@19 @semantic-release/changelog@6 @semantic-release/exec@6 @semantic-release/git@10
 
       - name: Run semantic-release workflow
-        id: release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
+
+      # TODO: Remove this step and set the previous step id to `release`
+      - name: Temporarily set version output
+        id: release
+        run: ./bin/set-action-image.js 8.6.0-next.13
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -48,10 +52,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get current package version
-        id: rdme-version
-        run: ./bin/set-version-output.js
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
@@ -59,7 +59,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.rdme-version.outputs.RDME_PKG_VERSION }}
+            type=semver,pattern={{version}},value=${{ steps.release.outputs.newVersion }}
             type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,6 @@ jobs:
         run: npx semantic-release --dry-run
         id: release
 
-      # TODO: remove this! just seeing if docker is a thing in GHA runners
-      - run: docker -v
-
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Dry run of semantic-release workflow
         run: npx semantic-release --dry-run
         id: release
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,16 @@ jobs:
       - name: Install dependencies and build TS
         run: npm ci && npm run build
 
-      # - name: Install semantic-release and friends
-      #   run: npm i --no-save semantic-release@19 @semantic-release/changelog@6 @semantic-release/exec@6 @semantic-release/git@10
-      # - name: Run semantic-release workflow
-      #   env:
-      #     GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      #   run: npx semantic-release
+      - name: Install semantic-release and friends
+        run: npm i --no-save semantic-release@19 @semantic-release/changelog@6 @semantic-release/exec@6 @semantic-release/git@10
+
+      - name: Run semantic-release workflow
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
         run: npx semantic-release --dry-run
         id: release
 
+      # TODO: remove this! just seeing if docker is a thing in GHA runners
+      - run: docker -v
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.release.outputs.newVersion }}
-            type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build (but do NOT push)
@@ -68,4 +67,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           labels: ${{ steps.meta.outputs.labels }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 on:
   push:
-    branches:
-      - main
-      - next
+    # branches:
+    #   - main
+    #   - next
 
 env:
   REGISTRY: ghcr.io
@@ -12,9 +12,9 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    # permissions:
+    #   contents: read
+    #   packages: write
 
     steps:
       - uses: actions/checkout@v3
@@ -60,7 +60,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.release.outputs.newVersion }}
-            type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build (but do NOT push)
@@ -69,3 +68,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
+          push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,55 @@
 name: Release
 on:
   push:
-    branches:
-      - main
-      - next
+    # branches:
+    #   - main
+    #   - next
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_GH_TOKEN }}
-      - uses: actions/setup-node@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
-          node-version: 16
-          cache: 'npm'
-      - name: Install dependencies and build TS
-        run: npm ci && npm run build
-      - name: Install semantic-release and friends
-        run: npm i --no-save semantic-release@19 @semantic-release/changelog@6 @semantic-release/exec@6 @semantic-release/git@10
-      - name: Run semantic-release workflow
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: log metadata
+        run: echo $DOCKER_METADATA_OUTPUT_JSON
+
+      # - uses: actions/setup-node@v3
+      #   with:
+      #     node-version: 16
+      #     cache: 'npm'
+      # - name: Install dependencies and build TS
+      #   run: npm ci && npm run build
+      # - name: Install semantic-release and friends
+      #   run: npm i --no-save semantic-release@19 @semantic-release/changelog@6 @semantic-release/exec@6 @semantic-release/git@10
+      # - name: Run semantic-release workflow
+      #   env:
+      #     GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #   run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build (but do NOT push)
-        uses: docker/build-push-action@v4
+      - name: Get current package version
+        id: rdme-version
+        run: ./bin/set-version-output.js
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -39,13 +40,18 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}},value=8.6.0-next.13
+            type=semver,pattern={{version}},value=${{ steps.rdme-version.outputs.RDME_PKG_VERSION }}
             type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: log metadata
         run: echo $DOCKER_METADATA_OUTPUT_JSON
-      - name: log actor
-        run: echo ${{ github.actor }}
+
+      - name: Build (but do NOT push)
+        uses: docker/build-push-action@v4
+        with:
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
 
       # - uses: actions/setup-node@v3
       #   with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 on:
   push:
-    # branches:
-    #   - main
-    #   - next
+    branches:
+      - main
+      - next
 
 env:
   REGISTRY: ghcr.io
@@ -12,10 +12,6 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # permissions:
-    #   contents: read
-    #   packages: write
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -60,6 +56,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.release.outputs.newVersion }}
+            type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build (but do NOT push)
@@ -68,4 +65,3 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
-          push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # For every release we had 2-3 tags to the docker build:
+          # 1. A semver tag (e.g., 8.0.0, 8.0.0-next.0)
+          # 2. A branch tag (e.g., next, main)
+          # 3. A `latest` tag (only on the main branch)
           tags: |
             type=semver,pattern={{version}},value=${{ steps.release.outputs.newVersion }}
             type=ref,event=branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,5 +64,6 @@ jobs:
       - name: Build (but do NOT push)
         uses: docker/build-push-action@v4
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,17 +29,11 @@ jobs:
       - name: Install semantic-release and friends
         run: npm i --no-save semantic-release@19 @semantic-release/changelog@6 @semantic-release/exec@6 @semantic-release/git@10
 
-      - name: Run semantic-release workflow
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
-
-      # TODO: Remove this step and set the previous step id to `release`
-      - name: Temporarily set version output
+      # We do a dry run here to analyze the commits and grab the next version
+      # for usage in the Docker metadata action
+      - name: Dry run of semantic-release workflow
+        run: npx semantic-release --dry-run
         id: release
-        run: ./bin/set-action-image.js 8.6.0-next.13
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -59,9 +53,16 @@ jobs:
           # 2. A branch tag (e.g., next, main)
           # 3. A `latest` tag (only on the main branch)
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.release.outputs.newVersion }}
+            type=semver,pattern={{version}},value=${{ steps.release.outputs.nextVersion }}
             type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+      - name: Run semantic-release workflow
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release
 
       - name: Build (but do NOT push)
         uses: docker/build-push-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 on:
   push:
-    # branches:
-    #   - main
-    #   - next
+    branches:
+      - main
+      - next
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # For every release we had 2-3 tags to the docker build:
+          # For every release we add 2-3 tags to the docker build:
           # 1. A semver tag (e.g., 8.0.0, 8.0.0-next.0)
           # 2. A branch tag (e.g., next, main)
           # 3. A `latest` tag (only on the main branch)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.release.outputs.newVersion }}
+            type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build (but do NOT push)
@@ -67,5 +68,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 on:
   push:
-    # branches:
-    #   - main
-    #   - next
+    branches:
+      - main
+      - next
 
 env:
   REGISTRY: ghcr.io
@@ -60,6 +60,7 @@ jobs:
           # 3. A `latest` tag (only on the main branch)
           tags: |
             type=semver,pattern={{version}},value=${{ steps.release.outputs.newVersion }}
+            type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build (but do NOT push)
@@ -67,4 +68,3 @@ jobs:
         with:
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
-          push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 on:
   push:
-    branches:
-      - main
-      - next
+    # branches:
+    #   - main
+    #   - next
 
 env:
   REGISTRY: ghcr.io
@@ -60,7 +60,6 @@ jobs:
           # 3. A `latest` tag (only on the main branch)
           tags: |
             type=semver,pattern={{version}},value=${{ steps.release.outputs.newVersion }}
-            type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build (but do NOT push)
@@ -68,3 +67,4 @@ jobs:
         with:
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
+          push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release -d
-
-      - name: Build (but do NOT push)
-        uses: docker/build-push-action@v4
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,5 @@ jobs:
       - name: Build (but do NOT push)
         uses: docker/build-push-action@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build (but do NOT push)
+        uses: docker/build-push-action@v4
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 on:
   push:
-    # branches:
-    #   - main
-    #   - next
+    branches:
+      - main
+      - next
 
 env:
   REGISTRY: ghcr.io
@@ -64,4 +64,4 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release -d
+        run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,23 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_GH_TOKEN }}
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+
+      - name: Install dependencies and build TS
+        run: npm ci && npm run build
+
+      # - name: Install semantic-release and friends
+      #   run: npm i --no-save semantic-release@19 @semantic-release/changelog@6 @semantic-release/exec@6 @semantic-release/git@10
+      # - name: Run semantic-release workflow
+      #   env:
+      #     GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #   run: npx semantic-release
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -52,18 +69,3 @@ jobs:
         with:
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
-
-      # - uses: actions/setup-node@v3
-      #   with:
-      #     node-version: 16
-      #     cache: 'npm'
-      # - name: Install dependencies and build TS
-      #   run: npm ci && npm run build
-      # - name: Install semantic-release and friends
-      #   run: npm i --no-save semantic-release@19 @semantic-release/changelog@6 @semantic-release/exec@6 @semantic-release/git@10
-      # - name: Run semantic-release workflow
-      #   env:
-      #     GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      #   run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+        run: npx semantic-release -d
 
       - name: Build (but do NOT push)
         uses: docker/build-push-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: log metadata
         run: echo $DOCKER_METADATA_OUTPUT_JSON
+      - name: log actor
+        run: echo ${{ github.actor }}
 
       # - uses: actions/setup-node@v3
       #   with:

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,8 +1,7 @@
 branches:
   - name: main
-  - name: container-registry-v2
-    prerelease: true
-    channel: next
+  - name: next
+
 plugins:
   - '@semantic-release/commit-analyzer'
   - '@semantic-release/release-notes-generator'

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,7 +1,8 @@
 branches:
   - name: main
-  - name: next
+  - name: container-registry-v2
     prerelease: true
+    channel: next
 plugins:
   - '@semantic-release/commit-analyzer'
   - '@semantic-release/release-notes-generator'

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -12,6 +12,10 @@ plugins:
   - [
       '@semantic-release/exec',
       {
+        # Sets the next version as a GitHub Actions output parameter
+        # for usage in subsequent workflow steps
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+        'verifyReleaseCmd': 'echo nextVersion=${nextRelease.version} >> $GITHUB_OUTPUT',
         # Updates our action.yml file to reflect current Docker image version
         'prepareCmd': './bin/set-action-image.js ${nextRelease.version}',
       },

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -19,10 +19,7 @@ plugins:
   - [
       '@semantic-release/git',
       {
-        # TODO: once docker builds are a thing, we're going to have to manually add the assets
-        # since we're also updating the action.yml file with every release!
-        # Uncomment this line below once those changes are live:
-        # assets: ['action.yml', 'CHANGELOG.md', 'package.json', 'package-lock.json'],
+        assets: ['action.yml', 'CHANGELOG.md', 'package.json', 'package-lock.json'],
         message: "build(release): 🚀 v${nextRelease.version} 🦉\n\n${nextRelease.notes}\n[skip ci]",
       },
     ]

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -14,8 +14,9 @@ plugins:
       '@semantic-release/exec',
       {
         # Updates our action.yml file to reflect current Docker image version.
-        # This needs to happen before `git` so we can to commit this file
-        'prepareCmd': './bin/set-action-image.js',
+        # This needs to happen before `git` so we can to commit this file.
+        # The second command builds the Docker image
+        'prepareCmd': './bin/set-action-image.js && ./bin/docker.js build',
       },
     ]
   - [
@@ -36,6 +37,7 @@ plugins:
         # Adds a couple extra tags as aliases for our GitHub Actions users
         'prepareCmd': 'git tag ${nextRelease.version} && ./bin/set-major-version-tag.js',
         # Lightweight alternative to `@semantic-release/github` that creates a draft release
-        'publishCmd': 'gh release create ${nextRelease.version} --draft --generate-notes',
+        # The second command pushes the docker image to the registry
+        'publishCmd': 'gh release create ${nextRelease.version} --draft --generate-notes && ./bin/docker.js push',
       },
     ]

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -12,11 +12,8 @@ plugins:
   - [
       '@semantic-release/exec',
       {
-        # Sets the next version as a GitHub Actions output parameter
-        # for usage in subsequent workflow steps
-        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
-        'verifyReleaseCmd': 'echo nextVersion=${nextRelease.version} >> $GITHUB_OUTPUT',
-        # Updates our action.yml file to reflect current Docker image version
+        # Updates our action.yml file to reflect current Docker image version.
+        # This needs to happen before `git` so we can to commit this file
         'prepareCmd': './bin/set-action-image.js ${nextRelease.version}',
       },
     ]
@@ -30,6 +27,9 @@ plugins:
   - [
       '@semantic-release/exec',
       {
+        # Sets the next version as a GitHub Actions output parameter for usage in subsequent workflow steps
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+        'verifyReleaseCmd': 'echo nextVersion=${nextRelease.version} >> $GITHUB_OUTPUT',
         # Adds a couple extra tags as aliases for our GitHub Actions users
         'prepareCmd': 'git tag ${nextRelease.version} && ./bin/set-major-version-tag.js',
         # Lightweight alternative to `@semantic-release/github` that creates a draft release

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -10,6 +10,13 @@ plugins:
   # the package*.json files before we commit the changes
   - '@semantic-release/npm'
   - [
+      '@semantic-release/exec',
+      {
+        # Updates our action.yml file to reflect current Docker image version
+        'prepareCmd': './bin/set-action-image.js ${nextRelease.version}',
+      },
+    ]
+  - [
       '@semantic-release/git',
       {
         # TODO: once docker builds are a thing, we're going to have to manually add the assets

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -15,7 +15,7 @@ plugins:
       {
         # Updates our action.yml file to reflect current Docker image version.
         # This needs to happen before `git` so we can to commit this file
-        'prepareCmd': './bin/set-action-image.js ${nextRelease.version}',
+        'prepareCmd': './bin/set-action-image.js',
       },
     ]
   - [

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -28,6 +28,8 @@ plugins:
   - [
       '@semantic-release/exec',
       {
+        # Verify existence of gh and docker CLIs
+        'verifyConditionsCmd': './bin/verify-clis.sh',
         # Sets the next version as a GitHub Actions output parameter for usage in subsequent workflow steps
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
         'verifyReleaseCmd': 'echo nextVersion=${nextRelease.version} >> $GITHUB_OUTPUT',

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -7,16 +7,18 @@ plugins:
   - '@semantic-release/commit-analyzer'
   - '@semantic-release/release-notes-generator'
   - '@semantic-release/changelog'
-  # `npm` must be before `git` so the `npm` command can properly bump
-  # the package*.json files before we commit the changes
+  # `@semantic-release/npm` must be before `@semantic-release/git`
+  # so the `@semantic-release/npm` plugin can properly update the version
+  # in the package*.json files before we commit the changes in `@semantic-release/git`
   - '@semantic-release/npm'
   - [
       '@semantic-release/exec',
       {
-        # Updates our action.yml file to reflect current Docker image version.
-        # This needs to happen before `git` so we can to commit this file.
-        # The second command builds the Docker image
-        'prepareCmd': './bin/set-action-image.js && ./bin/docker.js build',
+        # Runs two commands:
+        # 1. Updates our action.yml file to reflect current Docker image version.
+        #   This needs to happen before `@semantic-release/git` so we can commit this file.
+        # 2. Builds and pushes the Docker image
+        'prepareCmd': './bin/set-action-image.js && ./bin/docker.js',
       },
     ]
   - [
@@ -36,8 +38,7 @@ plugins:
         'verifyReleaseCmd': 'echo nextVersion=${nextRelease.version} >> $GITHUB_OUTPUT',
         # Adds a couple extra tags as aliases for our GitHub Actions users
         'prepareCmd': 'git tag ${nextRelease.version} && ./bin/set-major-version-tag.js',
-        # Lightweight alternative to `@semantic-release/github` that creates a draft release
-        # The second command pushes the docker image to the registry
-        'publishCmd': 'gh release create ${nextRelease.version} --draft --generate-notes && ./bin/docker.js push',
+        # Lightweight alternative to `@semantic-release/github` that creates a draft GitHub release
+        'publishCmd': 'gh release create ${nextRelease.version} --draft --generate-notes',
       },
     ]

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,6 +1,7 @@
 branches:
   - name: main
   - name: next
+    prerelease: true
 
 plugins:
   - '@semantic-release/commit-analyzer'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16-alpine as builder
 
 COPY . /rdme
 
-RUN cd /rdme && npm ci && npm run build && npx pkg . --target host --out-path exe
+RUN cd /rdme && npm ci && npm run build && npx pkg@5 . --target host --out-path exe
 
 FROM alpine:3.14
 

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
     required: true
 runs:
   using: docker
-  image: 'docker://ghcr.io/readmeio/rdme:8.6.0-next.13'
+  image: docker://ghcr.io/readmeio/rdme:8.6.0-next.13

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://ghcr.io/readmeio/rdme:8.6.0-next.13
+  image: docker://ghcr.io/readmeio/rdme:8.6.0-next.15

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
     required: true
 runs:
   using: docker
-  image: 'ghcr.io/readmeio/rdme:8.6.0-next.13'
+  image: 'docker://ghcr.io/readmeio/rdme:8.6.0-next.13'

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
     required: true
 runs:
   using: docker
-  image: 'docker://ghcr.io/readmeio/rdme:next'
+  image: 'ghcr.io/readmeio/rdme:8.6.0-next.13'

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,4 @@ inputs:
     required: true
 runs:
   using: docker
-  image: Dockerfile
+  image: 'docker://ghcr.io/readmeio/rdme:next'

--- a/bin/docker.js
+++ b/bin/docker.js
@@ -6,9 +6,11 @@ const execFile = util.promisify(require('child_process').execFile);
 /**
  * Retrieves and parses the docker image metadata
  * @see {@link https://github.com/docker/metadata-action}
+ * @see {@link https://gist.github.com/kanadgupta/801c8335e7e2e3d80463c34bdd41c7e6}
  */
 function getMetadata() {
   try {
+    // See here for an example JSON output: https://gist.github.com/kanadgupta/801c8335e7e2e3d80463c34bdd41c7e6
     const raw = process.env.DOCKER_METADATA_OUTPUT_JSON;
     const metadata = JSON.parse(raw);
     if (!Object.keys(metadata.labels || {})?.length) {

--- a/bin/docker.js
+++ b/bin/docker.js
@@ -77,11 +77,11 @@ async function run() {
 
     const pushArgs = ['push', '--all-tags', imageWithoutTag];
 
-    console.log(`🐳 🛠️ Running docker build command: ${buildArgs}`);
+    console.log(`🐳 🛠️  Running docker build command: docker ${buildArgs.join(' ')}`);
 
     await runDockerCmd(buildArgs);
 
-    console.log(`🐳 📌 Running docker push command: ${pushArgs}`);
+    console.log(`🐳 📌 Running docker push command: docker ${pushArgs.join(' ')}`);
 
     await runDockerCmd(pushArgs);
   } catch (e) {

--- a/bin/docker.js
+++ b/bin/docker.js
@@ -1,0 +1,101 @@
+#! /usr/bin/env node
+/* eslint-disable no-console */
+const { exec } = require('child_process');
+
+/**
+ * Retrieves and parses the docker image metadata
+ * @see {@link https://github.com/docker/metadata-action}
+ */
+function getMetadata() {
+  try {
+    const raw = process.env.DOCKER_METADATA_OUTPUT_JSON;
+    const metadata = JSON.parse(raw);
+    if (!Object.keys(metadata.labels || {})?.length) {
+      throw new Error('Invalid shape (missing labels data)');
+    }
+    if (!metadata?.tags?.length) {
+      throw new Error('Invalid shape (missing tags data)');
+    }
+    return metadata;
+  } catch (e) {
+    console.error('Error retrieving docker metadata:', e.message);
+    return process.exit(1);
+  }
+}
+
+/**
+ * Runs command and logs all output
+ */
+function runCmd(cmd) {
+  const child = exec(cmd, (err, stdout, stderr) => {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    }
+    if (stdout) console.log(stdout);
+    if (stderr) console.error(stderr);
+  });
+
+  child.stdout.on('data', chunk => {
+    console.log(chunk.toString());
+  });
+
+  child.stderr.on('data', chunk => {
+    console.error(chunk.toString());
+  });
+}
+
+/**
+ * Constructs and executes `docker build` command
+ */
+function build() {
+  const metadata = getMetadata();
+  // start constructing command
+  let cmd = 'docker build --platform linux/amd64';
+  // add labels
+  Object.keys(metadata.labels).forEach(label => {
+    cmd += ` --label "${label}=${metadata.labels[label]}"`;
+  });
+  // add tags
+  metadata.tags.forEach(tag => {
+    cmd += ` --tag ${tag}`;
+  });
+  // point to local Dockerfile
+  cmd += ' .';
+
+  console.log(`🐳 🛠️ Running docker build command: ${cmd}`);
+
+  runCmd(cmd);
+}
+
+/**
+ * Constructs and executes `docker push` command
+ */
+function push() {
+  const metadata = getMetadata();
+  const image = metadata.tags[0]?.split(':')?.[0];
+
+  if (!image) {
+    console.error(`Unable to extract image name from tag: ${metadata.tags[0]}`);
+    return process.exit(1);
+  }
+
+  const cmd = `docker push --all-tags ${image}`;
+  console.log(`🐳 📌 Running docker push command: ${cmd}`);
+
+  return runCmd(cmd);
+}
+
+function run() {
+  const cmd = process.argv.slice(2)[0];
+  if (cmd === 'build') {
+    return build();
+  } else if (cmd === 'push') {
+    return push();
+  }
+
+  console.error("Docker command must be 'build' or 'push'.");
+  return process.exit(1);
+}
+
+run();

--- a/bin/set-action-image.js
+++ b/bin/set-action-image.js
@@ -1,0 +1,38 @@
+#! /usr/bin/env node
+const fs = require('fs/promises');
+
+const core = require('@actions/core');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const jsYaml = require('js-yaml');
+
+/**
+ * Updates our `action.yml` file so it properly points to
+ * the correct docker image, and also sets a version output
+ * for usage in subsequent workflow Docker image building steps
+ * @see {@link https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-docker-container-actions}
+ * @see {@link https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter}
+ */
+async function setActionImage() {
+  // Grab version from args
+  const newVersion = process.argv.slice(2)?.[0];
+  if (!newVersion) {
+    // eslint-disable-next-line no-console
+    console.error('Missing version in setActionImage()');
+    process.exit(1);
+  }
+  // Set GitHub Output
+  core.setOutput('newVersion', newVersion);
+  // Grabs Docker image URL from action.yml, updates version value,
+  // and writes changes back to action.yml file
+  const actionFile = await fs.readFile('./action.yml', 'utf-8');
+  const actionObj = jsYaml.load(actionFile);
+  const imageURL = new URL(actionObj.runs.image);
+  imageURL.pathname = imageURL.pathname.replace(/:.*/g, `:${newVersion}`);
+  actionObj.runs.image = imageURL.toString();
+  const actionYaml = jsYaml.dump(actionObj, { lineWidth: -1 });
+  await fs.writeFile('./action.yml', actionYaml, { encoding: 'utf-8' });
+  // eslint-disable-next-line no-console
+  console.log('action.yml file successfully updated!');
+}
+
+setActionImage();

--- a/bin/set-action-image.js
+++ b/bin/set-action-image.js
@@ -1,16 +1,13 @@
 #! /usr/bin/env node
 const fs = require('fs/promises');
 
-const core = require('@actions/core');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const jsYaml = require('js-yaml');
 
 /**
  * Updates our `action.yml` file so it properly points to
- * the correct docker image, and also sets a version output
- * for usage in subsequent workflow Docker image building steps
+ * the correct docker image
  * @see {@link https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-docker-container-actions}
- * @see {@link https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter}
  */
 async function setActionImage() {
   // Grab version from args
@@ -20,8 +17,6 @@ async function setActionImage() {
     console.error('Missing version in setActionImage()');
     process.exit(1);
   }
-  // Set GitHub Output
-  core.setOutput('newVersion', newVersion);
   // Grabs Docker image URL from action.yml, updates version value,
   // and writes changes back to action.yml file
   const actionFile = await fs.readFile('./action.yml', 'utf-8');

--- a/bin/set-action-image.js
+++ b/bin/set-action-image.js
@@ -4,25 +4,20 @@ const fs = require('fs/promises');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const jsYaml = require('js-yaml');
 
+const pkg = require('../package.json');
+
 /**
  * Updates our `action.yml` file so it properly points to
  * the correct docker image
  * @see {@link https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-docker-container-actions}
  */
 async function setActionImage() {
-  // Grab version from args
-  const newVersion = process.argv.slice(2)?.[0];
-  if (!newVersion) {
-    // eslint-disable-next-line no-console
-    console.error('Missing version in setActionImage()');
-    process.exit(1);
-  }
   // Grabs Docker image URL from action.yml, updates version value,
   // and writes changes back to action.yml file
   const actionFile = await fs.readFile('./action.yml', 'utf-8');
   const actionObj = jsYaml.load(actionFile);
   const imageURL = new URL(actionObj.runs.image);
-  imageURL.pathname = imageURL.pathname.replace(/:.*/g, `:${newVersion}`);
+  imageURL.pathname = imageURL.pathname.replace(/:.*/g, `:${pkg.version}`);
   actionObj.runs.image = imageURL.toString();
   const actionYaml = jsYaml.dump(actionObj, { lineWidth: -1 });
   await fs.writeFile('./action.yml', actionYaml, { encoding: 'utf-8' });

--- a/bin/set-version-output.js
+++ b/bin/set-version-output.js
@@ -1,18 +1,16 @@
 #! /usr/bin/env node
 const core = require('@actions/core');
 
-const { getMajorPkgVersion, getNodeVersion, getPkgVersion } = require('../dist/src/lib/getPkgVersion');
+const { getNodeVersion, getMajorPkgVersion } = require('../dist/src/lib/getPkgVersion');
 
 /**
  * Sets output parameters for GitHub Actions workflow so we can do
  * a find-and-replace in our docs prior to syncing them to ReadMe
- * and also to tag our Docker images properly
  * Docs: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
  */
 async function setOutputs() {
+  core.setOutput('RDME_VERSION', `v${await getMajorPkgVersion('latest')}`);
   core.setOutput('NODE_VERSION', getNodeVersion());
-  core.setOutput('RDME_LATEST_MAJOR_VERSION', `v${await getMajorPkgVersion('latest')}`);
-  core.setOutput('RDME_PKG_VERSION', await getPkgVersion());
 }
 
 setOutputs();

--- a/bin/set-version-output.js
+++ b/bin/set-version-output.js
@@ -1,16 +1,18 @@
 #! /usr/bin/env node
 const core = require('@actions/core');
 
-const { getNodeVersion, getMajorPkgVersion } = require('../dist/src/lib/getPkgVersion');
+const { getMajorPkgVersion, getNodeVersion, getPkgVersion } = require('../dist/src/lib/getPkgVersion');
 
 /**
  * Sets output parameters for GitHub Actions workflow so we can do
  * a find-and-replace in our docs prior to syncing them to ReadMe
+ * and also to tag our Docker images properly
  * Docs: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
  */
 async function setOutputs() {
-  core.setOutput('RDME_VERSION', `v${await getMajorPkgVersion('latest')}`);
   core.setOutput('NODE_VERSION', getNodeVersion());
+  core.setOutput('RDME_LATEST_MAJOR_VERSION', `v${await getMajorPkgVersion('latest')}`);
+  core.setOutput('RDME_PKG_VERSION', await getPkgVersion());
 }
 
 setOutputs();

--- a/bin/verify-clis.sh
+++ b/bin/verify-clis.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Verify existence of gh and docker CLIs
+# https://stackoverflow.com/a/677212
+set -e
+if ! command -v docker &> /dev/null
+then
+    echo "docker could not be found"
+    exit 1
+fi
+if ! command -v gh &> /dev/null
+then
+    echo "gh could not be found"
+    exit 1
+fi

--- a/bin/verify-clis.sh
+++ b/bin/verify-clis.sh
@@ -3,7 +3,7 @@
 # Verify existence of gh and docker CLIs
 # https://stackoverflow.com/a/677212
 set -e
-if ! command -v dockerasdf &> /dev/null
+if ! command -v docker &> /dev/null
 then
     echo "docker could not be found"
     exit 1

--- a/bin/verify-clis.sh
+++ b/bin/verify-clis.sh
@@ -5,11 +5,11 @@
 set -e
 if ! command -v docker &> /dev/null
 then
-    echo "docker could not be found"
+    echo "docker CLI could not be found"
     exit 1
 fi
 if ! command -v gh &> /dev/null
 then
-    echo "gh could not be found"
+    echo "gh CLI could not be found"
     exit 1
 fi

--- a/bin/verify-clis.sh
+++ b/bin/verify-clis.sh
@@ -3,7 +3,7 @@
 # Verify existence of gh and docker CLIs
 # https://stackoverflow.com/a/677212
 set -e
-if ! command -v docker &> /dev/null
+if ! command -v dockerasdf &> /dev/null
 then
     echo "docker could not be found"
     exit 1


### PR DESCRIPTION
| 🚥 Fixes RM-6538 |
| :---------------- |

## 🧰 Changes

The moment we've been waiting for y'all: enhancing our `semantic-release` workflow to automatically publish docker images to the GitHub Container Registry!

There are a bunch of moving parts, but if you look at the Linear ticket, I've added comments with links to a couple internal videos that I created

## 🧬 QA & Testing

I did a couple of test pushes to the Container Registry and confirmed that a working, containerized version of `rdme` is pushed to the registry!

- You can see the release workflow here: https://github.com/readmeio/rdme/actions/runs/4350052453/jobs/7600379201
- And the corresponding image in the container registry here: https://github.com/readmeio/rdme/pkgs/container/rdme/75372142

And the performance gains are pretty incredible. Here's [the before](https://github.com/readmeio/rdme/actions/runs/4328524620/jobs/7558303832):

<img width="478" alt="image" src="https://user-images.githubusercontent.com/8854718/223309676-de235010-baba-48cb-bd29-426bb00befa9.png">


And here's [the after](https://github.com/readmeio/rdme/actions/runs/4328516747/jobs/7596996985):

<img width="472" alt="image" src="https://user-images.githubusercontent.com/8854718/223309707-f25dd079-2ed5-41f8-ab0e-45d3d0082a8b.png">

There are a few aspects of this process that we can only test once we merge into `next`, but that's why we're doing pre-releases now amirite?