### PR TITLE
fix(openapi): yaml strings would be improperly parsed as Date objects

### DIFF
--- a/__tests__/helpers/github-workflow-schema.json
+++ b/__tests__/helpers/github-workflow-schema.json
@@ -1099,7 +1099,8 @@
                         },
                         "required": {
                           "$comment": "https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callsecretssecret_idrequired",
-                          "description": "A boolean specifying whether the secret must be supplied."
+                          "description": "A boolean specifying whether the secret must be supplied.",
+                          "type": "boolean"
                         }
                       },
                       "required": ["required"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "mime-types": "^2.1.35",
         "node-fetch": "^2.6.1",
         "oas": "^20.2.0",
-        "oas-normalize": "^8.1.3",
+        "oas-normalize": "^8.3.4",
         "open": "^8.2.1",
         "ora": "^5.4.1",
         "parse-link-header": "^2.0.0",
@@ -7608,9 +7608,9 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-8.3.3.tgz",
-      "integrity": "sha512-lzNXbIH01EpIDvdW5aH8LfaPdWSjcqW2CvIQiyFPWqY7OBze2qJHdYQoyfa0CAW5yRIO58+eNVrdhV2smXZhyw==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-8.3.4.tgz",
+      "integrity": "sha512-aPc2Y+zBD5Sv/CGuv/g0FWCsq1Ze2Rle+Se4G/JbytzBDCoo0m/Krk6gEt+o5dDw7mwbsVtnumhBmOhTWj/a8g==",
       "dependencies": {
         "@readme/openapi-parser": "^2.4.0",
         "@readme/postman-to-openapi": "^4.0.0",
@@ -15752,9 +15752,9 @@
       }
     },
     "oas-normalize": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-8.3.3.tgz",
-      "integrity": "sha512-lzNXbIH01EpIDvdW5aH8LfaPdWSjcqW2CvIQiyFPWqY7OBze2qJHdYQoyfa0CAW5yRIO58+eNVrdhV2smXZhyw==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-8.3.4.tgz",
+      "integrity": "sha512-aPc2Y+zBD5Sv/CGuv/g0FWCsq1Ze2Rle+Se4G/JbytzBDCoo0m/Krk6gEt+o5dDw7mwbsVtnumhBmOhTWj/a8g==",
       "requires": {
         "@readme/openapi-parser": "^2.4.0",
         "@readme/postman-to-openapi": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mime-types": "^2.1.35",
     "node-fetch": "^2.6.1",
     "oas": "^20.2.0",
-    "oas-normalize": "^8.1.3",
+    "oas-normalize": "^8.3.4",
     "open": "^8.2.1",
     "ora": "^5.4.1",
     "parse-link-header": "^2.0.0",


### PR DESCRIPTION
| 🚥 Fixes https://github.com/readmeio/rdme/issues/778 |
| :---------------- |

## 🧰 Changes

Resolve a bug in our YAML parsing in [oas-normalize](https://npm.im/oas-normalize) where if you had an `info.version` string in an OpenAPI definition that looked like `2015-04-22T10:03:19.323-07:00` it would be improperly parsed out as a `Date` object -- causing any command that depends on that to fail as it expects to be working with a string.