### PR TITLE
feat: add GHA output with command result

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   rdme:
     description: Command to pass into rdme
     required: true
+outputs:
+  rdme:
+    description: The rdme command result output
 runs:
   using: docker
   image: docker://ghcr.io/readmeio/rdme:8.6.0-next.16

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,8 +13,13 @@ updateNotifier({ pkg }).notify();
 
 rdme(process.argv.slice(2))
   .then((msg: string) => {
-    // eslint-disable-next-line no-console
-    if (msg) console.log(msg);
+    if (msg) {
+      // eslint-disable-next-line no-console
+      console.log(msg);
+      if (isGHA()) {
+        core.setOutput('rdme', msg);
+      }
+    }
     return process.exit(0);
   })
   .catch((err: Error) => {


### PR DESCRIPTION
## 🧰 Changes

When digging into #778 I realized that it'd be useful for commands like `rdme versions` and `rdme openapi --raw` to be able to use those JSON output in subsequent GitHub workflow steps. This PR does the following:

- Makes a tiny change to our CLI wrapper file to set the command results [as output parameters](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter)
- Documents this new output in `action.yml` (which I don't even think is surfaced anywhere in the marketplace or anything)

## 🧬 QA & Testing

Do tests still pass?