### PR TITLE
chore: remove outdated `oas` language, testbed cleanup 🧹

### DIFF
--- a/__tests__/cmds/docs/edit.test.ts
+++ b/__tests__/cmds/docs/edit.test.ts
@@ -53,8 +53,8 @@ describe('rdme docs:edit', () => {
   });
 
   it('should error if no slug provided', () => {
-    return expect(docsEdit.run({ key, version: '1.0.0' })).rejects.toThrow(
-      'No slug provided. Usage `rdme docs:edit <slug> [options]`.'
+    return expect(docsEdit.run({ key, version: '1.0.0' })).rejects.toStrictEqual(
+      new Error('No slug provided. Usage `rdme docs:edit <slug> [options]`.')
     );
   });
 
@@ -165,7 +165,7 @@ describe('rdme docs:edit', () => {
       return cb(1);
     }
 
-    await expect(docsEdit.run({ slug, key, version: '1.0.0', mockEditor })).rejects.toThrow(
+    await expect(docsEdit.run({ slug, key, version: '1.0.0', mockEditor })).rejects.toStrictEqual(
       new Error('Non zero exit code from $EDITOR')
     );
 

--- a/__tests__/cmds/open.test.ts
+++ b/__tests__/cmds/open.test.ts
@@ -17,7 +17,7 @@ describe('rdme open', () => {
   it('should error if no project provided', () => {
     configStore.delete('project');
 
-    return expect(cmd.run({})).rejects.toThrow(`Please login using \`${config.get('cli')} login\`.`);
+    return expect(cmd.run({})).rejects.toStrictEqual(new Error(`Please login using \`${config.get('cli')} login\`.`));
   });
 
   it('should open the project', () => {

--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -900,8 +900,10 @@ describe('rdme openapi', () => {
     });
 
     it('should error if no file was provided or able to be discovered', () => {
-      return expect(openapi.run({ key, version, workingDirectory: 'config' })).rejects.toThrow(
-        /We couldn't find an OpenAPI or Swagger definition./
+      return expect(openapi.run({ key, version, workingDirectory: 'config' })).rejects.toStrictEqual(
+        new Error(
+          "We couldn't find an OpenAPI or Swagger definition.\n\nPlease specify the path to your definition with `rdme openapi ./path/to/api/definition`."
+        )
       );
     });
 

--- a/__tests__/cmds/openapi/inspect.test.ts
+++ b/__tests__/cmds/openapi/inspect.test.ts
@@ -17,8 +17,8 @@ describe('rdme openapi:inspect', () => {
       '@readme/oas-examples/3.0/json/petstore.json',
       '@readme/oas-examples/3.0/json/readme.json',
       '@readme/oas-examples/3.0/json/readme-extensions.json',
-    ])('should generate a report for %s', async spec => {
-      await expect(
+    ])('should generate a report for %s', spec => {
+      return expect(
         analyzer.run({
           spec: require.resolve(spec),
         })
@@ -27,15 +27,15 @@ describe('rdme openapi:inspect', () => {
   });
 
   describe('feature reports', () => {
-    it('should throw an error if an invalid feature is supplied', async () => {
+    it('should throw an error if an invalid feature is supplied', () => {
       const spec = require.resolve('@readme/oas-examples/3.0/json/readme-extensions.json');
 
-      await expect(
+      return expect(
         analyzer.run({
           spec,
           feature: ['style', 'reamde'],
         })
-      ).rejects.toThrow('Unknown features: reamde. See `rdme help openapi:inspect` for help');
+      ).rejects.toStrictEqual(new Error('Unknown features: reamde. See `rdme help openapi:inspect` for help.'));
     });
 
     const cases: { spec: string; feature: string[]; shouldSoftError?: true }[] = [

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -37,28 +37,6 @@ describe('cli', () => {
   });
 
   describe('--help', () => {
-    beforeEach(() => {
-      // The `table-layout` dependency within `command-line-usage` has a quirk in the 1.x family where if it's being
-      // run within a Jest environment it won't always use the same amount of columns for tables, resulting in cases
-      // where Jest snapshots will randomly return back different results.
-      //
-      // This issue has been fixed in later versions of `table-layout` but `command-line-usage` is still targeting the
-      // 1.x series.
-      //
-      // See https://github.com/75lb/table-layout/issues/9 for more information.
-      process.stdout.columns = 100;
-      process.stderr.columns = 100;
-    });
-
-    /* eslint-disable @typescript-eslint/ban-ts-comment */
-    afterEach(() => {
-      // @ts-ignore This is the only way we can disable columns within the `table-layout` library.
-      process.stdout.columns = undefined;
-      // @ts-ignore
-      process.stderr.columns = undefined;
-    });
-    /* eslint-enable @typescript-eslint/ban-ts-comment */
-
     it('should print help', () => {
       return expect(cli(['--help'])).resolves.toContain('a utility for interacting with ReadMe');
     });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -8,28 +8,30 @@ import getAPIMock from './helpers/get-api-mock';
 import { after, before } from './helpers/get-gha-setup';
 
 describe('cli', () => {
-  it('command not found', async () => {
-    await expect(cli(['no-such-command'])).rejects.toThrow('Command not found');
+  it('command not found', () => {
+    return expect(cli(['no-such-command'])).rejects.toStrictEqual(
+      new Error('Command not found.\n\nType `rdme help` to see all commands')
+    );
   });
 
   describe('--version', () => {
-    it('should return version from package.json', async () => {
-      await expect(cli(['--version'])).resolves.toBe(pkgVersion);
+    it('should return version from package.json', () => {
+      return expect(cli(['--version'])).resolves.toBe(pkgVersion);
     });
 
-    it('should return version if the `-V` alias is supplied', async () => {
-      await expect(cli(['-V'])).resolves.toBe(pkgVersion);
+    it('should return version if the `-V` alias is supplied', () => {
+      return expect(cli(['-V'])).resolves.toBe(pkgVersion);
     });
 
-    it('should return version from package.json for help command', async () => {
-      await expect(cli(['help', '--version'])).resolves.toBe(pkgVersion);
+    it('should return version from package.json for help command', () => {
+      return expect(cli(['help', '--version'])).resolves.toBe(pkgVersion);
     });
 
     // This is necessary because we use --version for other commands like `docs`
-    it('should only return version if no command', async () => {
-      await expect(cli(['no-such-command', '--version'])).rejects.toThrow(
+    it('should only return version if no command', () => {
+      return expect(cli(['no-such-command', '--version'])).rejects.toStrictEqual(
         // This can be ignored as it's just going to be a command not found error
-        'Command not found.'
+        new Error('Command not found.\n\nType `rdme help` to see all commands')
       );
     });
   });
@@ -57,39 +59,41 @@ describe('cli', () => {
     });
     /* eslint-enable @typescript-eslint/ban-ts-comment */
 
-    it('should print help', async () => {
-      await expect(cli(['--help'])).resolves.toContain('a utility for interacting with ReadMe');
+    it('should print help', () => {
+      return expect(cli(['--help'])).resolves.toContain('a utility for interacting with ReadMe');
     });
 
-    it('should print help for the `-H` alias', async () => {
-      await expect(cli(['-H'])).resolves.toContain('a utility for interacting with ReadMe');
+    it('should print help for the `-H` alias', () => {
+      return expect(cli(['-H'])).resolves.toContain('a utility for interacting with ReadMe');
     });
 
-    it('should print usage for a given command', async () => {
-      await expect(cli(['openapi', '--help'])).resolves.toMatchSnapshot();
+    it('should print usage for a given command', () => {
+      return expect(cli(['openapi', '--help'])).resolves.toMatchSnapshot();
     });
 
-    it('should print usage for a given command if supplied as `help <command>`', async () => {
-      await expect(cli(['help', 'openapi'])).resolves.toMatchSnapshot();
+    it('should print usage for a given command if supplied as `help <command>`', () => {
+      return expect(cli(['help', 'openapi'])).resolves.toMatchSnapshot();
     });
 
-    it('should not surface args that are designated as hidden', async () => {
-      await expect(cli(['openapi', '--help'])).resolves.toMatchSnapshot();
+    it('should not surface args that are designated as hidden', () => {
+      return expect(cli(['openapi', '--help'])).resolves.toMatchSnapshot();
     });
 
-    it('should show related commands for a subcommands help menu', async () => {
-      await expect(cli(['versions', '--help'])).resolves.toMatchSnapshot();
+    it('should show related commands for a subcommands help menu', () => {
+      return expect(cli(['versions', '--help'])).resolves.toMatchSnapshot();
     });
   });
 
   describe('subcommands', () => {
-    it('should load subcommands from the folder', async () => {
-      await expect(cli(['openapi:validate', 'package.json'])).rejects.not.toThrow('Command not found.');
+    it('should load subcommands from the folder', () => {
+      return expect(
+        cli(['openapi:validate', '__tests__/__fixtures__/petstore-simple-weird-version.json'])
+      ).resolves.toBe('__tests__/__fixtures__/petstore-simple-weird-version.json is a valid OpenAPI API definition!');
     });
   });
 
-  it('should not error with undefined cmd', async () => {
-    await expect(cli([])).resolves.toContain('OpenAPI / Swagger');
+  it('should not error with undefined cmd', () => {
+    return expect(cli([])).resolves.toContain('a utility for interacting with ReadMe');
   });
 
   describe('stored API key', () => {
@@ -130,8 +134,8 @@ describe('cli', () => {
       });
 
       it('should inform a logged in user which project is being updated', async () => {
-        await expect(cli(['openapi', '--create', '--update'])).rejects.toThrow(
-          'The `--create` and `--update` options cannot be used simultaneously. Please use one or the other!'
+        await expect(cli(['openapi', '--create', '--update'])).rejects.toStrictEqual(
+          new Error('The `--create` and `--update` options cannot be used simultaneously. Please use one or the other!')
         );
 
         expect(getCommandOutput()).toMatch(
@@ -140,8 +144,8 @@ describe('cli', () => {
       });
 
       it('should not inform a logged in user when they pass their own key', async () => {
-        await expect(cli(['openapi', '--create', '--update', '--key=asdf'])).rejects.toThrow(
-          'The `--create` and `--update` options cannot be used simultaneously. Please use one or the other!'
+        await expect(cli(['openapi', '--create', '--update', '--key=asdf'])).rejects.toStrictEqual(
+          new Error('The `--create` and `--update` options cannot be used simultaneously. Please use one or the other!')
         );
 
         expect(getCommandOutput()).toBe('');
@@ -187,16 +191,16 @@ describe('cli', () => {
       });
 
       it('should not inform a logged in user which project is being updated', async () => {
-        await expect(cli(['openapi', '--create', '--update'])).rejects.toThrow(
-          'The `--create` and `--update` options cannot be used simultaneously. Please use one or the other!'
+        await expect(cli(['openapi', '--create', '--update'])).rejects.toStrictEqual(
+          new Error('The `--create` and `--update` options cannot be used simultaneously. Please use one or the other!')
         );
 
         expect(getCommandOutput()).toBe('');
       });
 
       it('should not inform a logged in user when they pass their own key', async () => {
-        await expect(cli(['openapi', '--create', '--update', '--key=asdf'])).rejects.toThrow(
-          'The `--create` and `--update` options cannot be used simultaneously. Please use one or the other!'
+        await expect(cli(['openapi', '--create', '--update', '--key=asdf'])).rejects.toStrictEqual(
+          new Error('The `--create` and `--update` options cannot be used simultaneously. Please use one or the other!')
         );
 
         expect(getCommandOutput()).toBe('');
@@ -204,8 +208,12 @@ describe('cli', () => {
     });
   });
 
-  it('should error with `rdme oas` arguments passed in', async () => {
-    await expect(cli(['oas', 'endpoint'])).rejects.toThrow(/.*/);
+  it('should error with `rdme oas` arguments passed in', () => {
+    return expect(cli(['oas', 'endpoint'])).rejects.toStrictEqual(
+      new Error(
+        "This `oas` integration is now inactive.\n\nIf you're looking to create an OpenAPI definition, we recommend https://npm.im/swagger-inline"
+      )
+    );
   });
 
   describe('GHA onboarding via @supportsGHA decorator', () => {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -28,7 +28,7 @@ describe('cli', () => {
     });
 
     // This is necessary because we use --version for other commands like `docs`
-    it('should only return version if no command', () => {
+    it('should error if command does not exist', () => {
       return expect(cli(['no-such-command', '--version'])).rejects.toStrictEqual(
         // This can be ignored as it's just going to be a command not found error
         new Error('Command not found.\n\nType `rdme help` to see all commands')

--- a/__tests__/lib/commands.test.ts
+++ b/__tests__/lib/commands.test.ts
@@ -9,7 +9,7 @@ import * as commands from '../../src/lib/commands';
 describe('utils', () => {
   describe('#list', () => {
     it('should have commands returned', () => {
-      expect(commands.list()).not.toHaveLength(0);
+      return expect(commands.list()).not.toHaveLength(0);
     });
 
     describe('commands', () => {
@@ -40,7 +40,7 @@ describe('utils', () => {
           (_, command) => {
             it('should have a description that ends with punctuation', () => {
               const description = command.description.replace('[inactive]', '').replace('[deprecated]', '').trim();
-              expect(description).toEndWith('.');
+              return expect(description).toEndWith('.');
             });
 
             it('should have standardized argument constructs', () => {
@@ -70,11 +70,11 @@ describe('utils', () => {
 
   describe('#load', () => {
     it('should load a valid command', () => {
-      expect(commands.load('docs')).toBeInstanceOf(DocsCommand);
+      return expect(commands.load('docs')).toBeInstanceOf(DocsCommand);
     });
 
     it('should throw an error on an invalid command', () => {
-      expect(() => {
+      return expect(() => {
         // @ts-expect-error Testing a valid failure case.
         commands.load('buster');
       }).toThrow('Command not found');
@@ -83,13 +83,13 @@ describe('utils', () => {
 
   describe('#listByCategory', () => {
     it('should list commands by category', () => {
-      expect(commands.listByCategory()).toMatchSnapshot();
+      return expect(commands.listByCategory()).toMatchSnapshot();
     });
   });
 
   describe('#getSimilar', () => {
     it('should pull similar commands', () => {
-      expect(commands.getSimilar(CommandCategories.ADMIN, 'login')).toStrictEqual([
+      return expect(commands.getSimilar(CommandCategories.ADMIN, 'login')).toStrictEqual([
         {
           name: 'logout',
           description: 'Logs the currently authenticated user out of ReadMe.',

--- a/src/cmds/oas.ts
+++ b/src/cmds/oas.ts
@@ -21,7 +21,6 @@ export default class OASCommand extends Command {
 
     const message = [
       'This `oas` integration is now inactive.',
-      "If you're looking to use the `oas` CLI directly, head over to https://npm.im/oas.",
       "If you're looking to create an OpenAPI definition, we recommend https://npm.im/swagger-inline",
     ];
 


### PR DESCRIPTION
## 🧰 Changes

Writing some tests as part of #788 and ended up going down a bit of a rabbit hole 🕳️

- [x] Removes outdated guidance on recommending the `oas` CLI
- [x] Moves every usage of `toThrow` to `toStrictEqual` where possible (the latter is a stricter assertion)
- [x] Returns `expect` statements instead of `await`-ing them where possible
- [x] Removed some weird `table-layout` workaround logic in [`__tests__/index.test.ts`](https://github.com/readmeio/rdme/pull/796/files#diff-8881961dc913eabb59bf9bbd8d06147865e4db2399f71578f1a54131a99a0195) since this was fixed in the most recent major version bump of `command-line-usage`.

## 🧬 QA & Testing

Do tests still pass?
