### PR TITLE
fix(fetch): stricter source URL type-checking

### DIFF
--- a/__tests__/lib/fetch.test.ts
+++ b/__tests__/lib/fetch.test.ts
@@ -89,6 +89,30 @@ describe('#fetch()', () => {
         mock.done();
       });
 
+      it('should omit source URL header if URL is invalid', async () => {
+        const key = 'API_KEY';
+        delete process.env.GITHUB_SERVER_URL;
+
+        const mock = getAPIMock()
+          .get('/api/v1')
+          .basicAuth({ user: key })
+          .reply(200, function () {
+            return this.req.headers;
+          });
+
+        const headers = await readmeAPIFetch(
+          '/api/v1',
+          {
+            method: 'get',
+            headers: cleanHeaders(key),
+          },
+          { filePath: './📈 Dashboard & Metrics/openapi.json', fileType: 'path' }
+        ).then(handleRes);
+
+        expect(headers['x-readme-source-url']).toBeUndefined();
+        mock.done();
+      });
+
       it('should include source URL header with relative path', async () => {
         const key = 'API_KEY';
 

--- a/src/lib/readmeAPIFetch.ts
+++ b/src/lib/readmeAPIFetch.ts
@@ -162,12 +162,14 @@ export default async function readmeAPIFetch(
        * @see {@link https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables}
        * @example https://github.com/readmeio/rdme/blob/cb4129d5c7b51ff3b50f933a9c7d0c3d0d33d62c/documentation/rdme.md
        */
-      headers.set(
-        'x-readme-source-url',
-        encodeURI(
+      try {
+        const sourceUrl = new URL(
           `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/blob/${process.env.GITHUB_SHA}/${filePath}`
-        )
-      );
+        ).href;
+        headers.set('x-readme-source-url', sourceUrl);
+      } catch (e) {
+        debug(`error constructing github source url: ${e.message}`);
+      }
     }
   }
 


### PR DESCRIPTION
| 🚥 Fixes #816 |
| :---------------- |

## 🧰 Changes

This reworks the fix I had in #817 to utilize [the `URL` constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) to construct the URL that we pass in the `x-readme-source-url` header. That way we can properly encode weird characters like in #817, in addition to also ensuring that the string itself is a valid URL.

## 🧬 QA & Testing

Check out the new test case I added.
