### PR TITLE
fix(openapi/inspect): small url formatting error

### DIFF
--- a/__tests__/cmds/openapi/__snapshots__/inspect.test.ts.snap
+++ b/__tests__/cmds/openapi/__snapshots__/inspect.test.ts.snap
@@ -196,8 +196,6 @@ OpenAPI Features
 ├──────────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────┤
 │ webhooks             │       │ Webhooks allow you to describe out of band requests that may be initiated by     │
 │                      │       │ your users.                                                                      │
-│                      │       │                                                                                  │
-│                      │       │ [object Object]                                                                  │
 ├──────────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────┤
 │ xml                  │ ✅    │ Any parameter and/or request body that accepts XML or responses that return XML  │
 │                      │       │ payloads.                                                                        │
@@ -306,8 +304,6 @@ OpenAPI Features
 ├──────────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────┤
 │ webhooks             │       │ Webhooks allow you to describe out of band requests that may be initiated by     │
 │                      │       │ your users.                                                                      │
-│                      │       │                                                                                  │
-│                      │       │ [object Object]                                                                  │
 ├──────────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────┤
 │ xml                  │       │ Any parameter and/or request body that accepts XML or responses that return XML  │
 │                      │       │ payloads.                                                                        │
@@ -416,8 +412,6 @@ OpenAPI Features
 ├──────────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────┤
 │ webhooks             │       │ Webhooks allow you to describe out of band requests that may be initiated by     │
 │                      │       │ your users.                                                                      │
-│                      │       │                                                                                  │
-│                      │       │ [object Object]                                                                  │
 ├──────────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────┤
 │ xml                  │       │ Any parameter and/or request body that accepts XML or responses that return XML  │
 │                      │       │ payloads.                                                                        │

--- a/__tests__/cmds/openapi/__snapshots__/inspect.test.ts.snap
+++ b/__tests__/cmds/openapi/__snapshots__/inspect.test.ts.snap
@@ -196,6 +196,8 @@ OpenAPI Features
 ├──────────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────┤
 │ webhooks             │       │ Webhooks allow you to describe out of band requests that may be initiated by     │
 │                      │       │ your users.                                                                      │
+│                      │       │                                                                                  │
+│                      │       │ This feature is not available on OpenAPI v3.0.                                   │
 ├──────────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────┤
 │ xml                  │ ✅    │ Any parameter and/or request body that accepts XML or responses that return XML  │
 │                      │       │ payloads.                                                                        │
@@ -304,6 +306,8 @@ OpenAPI Features
 ├──────────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────┤
 │ webhooks             │       │ Webhooks allow you to describe out of band requests that may be initiated by     │
 │                      │       │ your users.                                                                      │
+│                      │       │                                                                                  │
+│                      │       │ This feature is not available on OpenAPI v3.0.                                   │
 ├──────────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────┤
 │ xml                  │       │ Any parameter and/or request body that accepts XML or responses that return XML  │
 │                      │       │ payloads.                                                                        │
@@ -412,6 +416,8 @@ OpenAPI Features
 ├──────────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────┤
 │ webhooks             │       │ Webhooks allow you to describe out of band requests that may be initiated by     │
 │                      │       │ your users.                                                                      │
+│                      │       │                                                                                  │
+│                      │       │ This feature is not available on OpenAPI v3.0.                                   │
 ├──────────────────────┼───────┼──────────────────────────────────────────────────────────────────────────────────┤
 │ xml                  │       │ Any parameter and/or request body that accepts XML or responses that return XML  │
 │                      │       │ payloads.                                                                        │

--- a/src/cmds/openapi/inspect.ts
+++ b/src/cmds/openapi/inspect.ts
@@ -66,9 +66,9 @@ export default class OpenAPIInspectCommand extends Command {
       // We don't need to do any Swagger or Postman determination here because this command
       // always converts their spec to OpenAPI 3.0.
       if (this.definitionVersion.startsWith('3.0')) {
-        return feature.url?.['3.0'];
+        return feature.url?.['3.0'] || 'This feature is not available on OpenAPI v3.0.';
       } else if (this.definitionVersion.startsWith('3.1')) {
-        return feature.url?.['3.1'];
+        return feature.url?.['3.1'] || 'This feature is not available on OpenAPI v3.1.';
       }
       return '';
     }

--- a/src/cmds/openapi/inspect.ts
+++ b/src/cmds/openapi/inspect.ts
@@ -57,7 +57,7 @@ export default class OpenAPIInspectCommand extends Command {
       .reduce((prev, next) => Object.assign(prev, next));
   }
 
-  getFeatureDocsURL(feature: AnalyzedFeature) {
+  getFeatureDocsURL(feature: AnalyzedFeature): string {
     if (!feature.url) {
       return undefined;
     }
@@ -66,12 +66,11 @@ export default class OpenAPIInspectCommand extends Command {
       // We don't need to do any Swagger or Postman determination here because this command
       // always converts their spec to OpenAPI 3.0.
       if (this.definitionVersion.startsWith('3.0')) {
-        if (feature.url?.['3.0']) {
-          return feature.url['3.0'];
-        }
-      } else {
-        return feature.url['3.1'];
+        return feature.url?.['3.0'];
+      } else if (this.definitionVersion.startsWith('3.1')) {
+        return feature.url?.['3.1'];
       }
+      return '';
     }
 
     return feature.url;


### PR DESCRIPTION
## 🧰 Changes

Noticed a tiny formatting error when running `openapi:inspect` against an OpenAPI 3.0 definition:

<img width="814" alt="CleanShot 2023-08-09 at 16 17 40@2x" src="https://github.com/readmeio/rdme/assets/8854718/be268555-1707-427c-8927-d13efae45cfb">

I made the type a little stricter and tweaked the logic a bit so now it looks like this:

<img width="815" alt="CleanShot 2023-08-09 at 16 22 31@2x" src="https://github.com/readmeio/rdme/assets/8854718/b326f56c-db15-43bb-967e-9e6ac13b5906">

I don't love how the URL and this disclaimer text have the same formatting, but this is probably good enough for now.

## 🧬 QA & Testing

Do tests pass and does this change look good?
