### PR TITLE
chore: add debug statements for `process.chdir`

### DIFF
--- a/src/cmds/openapi/convert.ts
+++ b/src/cmds/openapi/convert.ts
@@ -49,7 +49,9 @@ export default class OpenAPIConvertCommand extends Command {
     const { spec, workingDirectory } = opts;
 
     if (workingDirectory) {
+      const previousWorkingDirectory = process.cwd();
       process.chdir(workingDirectory);
+      Command.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
     const { preparedSpec, specPath, specType } = await prepareOas(spec, 'openapi:convert', { convertToLatest: true });

--- a/src/cmds/openapi/index.ts
+++ b/src/cmds/openapi/index.ts
@@ -111,7 +111,9 @@ export default class OpenAPICommand extends Command {
     }
 
     if (workingDirectory) {
+      const previousWorkingDirectory = process.cwd();
       process.chdir(workingDirectory);
+      Command.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
     if (version && id) {

--- a/src/cmds/openapi/inspect.ts
+++ b/src/cmds/openapi/inspect.ts
@@ -235,7 +235,9 @@ export default class OpenAPIInspectCommand extends Command {
     }
 
     if (workingDirectory) {
+      const previousWorkingDirectory = process.cwd();
       process.chdir(workingDirectory);
+      Command.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
     const { preparedSpec, definitionVersion } = await prepareOas(spec, 'openapi:inspect', { convertToLatest: true });

--- a/src/cmds/openapi/reduce.ts
+++ b/src/cmds/openapi/reduce.ts
@@ -76,7 +76,9 @@ export default class OpenAPIReduceCommand extends Command {
     const { spec, title, workingDirectory } = opts;
 
     if (workingDirectory) {
+      const previousWorkingDirectory = process.cwd();
       process.chdir(workingDirectory);
+      Command.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
     const { preparedSpec, specPath, specType } = await prepareOas(spec, 'openapi:reduce', { title });

--- a/src/cmds/openapi/validate.ts
+++ b/src/cmds/openapi/validate.ts
@@ -38,7 +38,9 @@ export default class OpenAPIValidateCommand extends Command {
     const { spec, workingDirectory } = opts;
 
     if (workingDirectory) {
+      const previousWorkingDirectory = process.cwd();
       process.chdir(workingDirectory);
+      Command.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
     const { specPath, specType } = await prepareOas(spec, 'openapi:validate');

--- a/src/lib/createGHA/index.ts
+++ b/src/lib/createGHA/index.ts
@@ -209,7 +209,11 @@ export default async function createGHA(
     );
   }
 
-  if (repoRoot) process.chdir(repoRoot);
+  if (repoRoot) {
+    const previousWorkingDirectory = process.cwd();
+    process.chdir(repoRoot);
+    debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
+  }
 
   prompts.override({ shouldCreateGHA: opts.github });
 


### PR DESCRIPTION
As part of the work I was doing in #858, this adds some helpful debugging for such situations.