### PR TITLE
ci: re-enable tests on node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          # - 14
+          - 14
           - 16
           - 18
           - 20


### PR DESCRIPTION
Accidentally forgot to re-enable Node 14 tests in #859, so this PR does that.