### PR TITLE
fix(versions): fix ability to set main version

### DIFF
--- a/__tests__/cmds/versions/create.test.ts
+++ b/__tests__/cmds/versions/create.test.ts
@@ -98,6 +98,34 @@ describe('rdme versions:create', () => {
     mockRequest.done();
   });
 
+  it('should create successfully a main version', async () => {
+    const newVersion = '1.0.1';
+
+    const mockRequest = getAPIMock()
+      .post('/api/v1/version', {
+        version: newVersion,
+        from: '1.0.0',
+        is_beta: false,
+        is_stable: true,
+      })
+      .basicAuth({ user: key })
+      .reply(201, { version: newVersion });
+
+    await expect(
+      createVersion.run({
+        key,
+        version: newVersion,
+        fork: version,
+        beta: 'false',
+        main: 'true',
+        isPublic: 'false',
+        deprecated: 'true',
+      }),
+    ).resolves.toBe(`Version ${newVersion} created successfully.`);
+
+    mockRequest.done();
+  });
+
   it('should catch any post request errors', async () => {
     const errorResponse = {
       error: 'VERSION_EMPTY',

--- a/__tests__/cmds/versions/update.test.ts
+++ b/__tests__/cmds/versions/update.test.ts
@@ -211,6 +211,41 @@ describe('rdme versions:update', () => {
     mockRequest.done();
   });
 
+  it('should update a version to be the main one', async () => {
+    const versionToChange = '1.1.0';
+    const renamedVersion = '1.1.0-update';
+
+    const updatedVersionObject = {
+      version: renamedVersion,
+      is_beta: false,
+      is_stable: true,
+    };
+
+    const mockRequest = getAPIMock()
+      .get(`/api/v1/version/${versionToChange}`)
+      .basicAuth({ user: key })
+      .reply(200, { version: versionToChange })
+      .get(`/api/v1/version/${versionToChange}`)
+      .basicAuth({ user: key })
+      .reply(200, { version: versionToChange })
+      .put(`/api/v1/version/${versionToChange}`, updatedVersionObject)
+      .basicAuth({ user: key })
+      .reply(201, updatedVersionObject);
+
+    await expect(
+      updateVersion.run({
+        key,
+        version: versionToChange,
+        newVersion: renamedVersion,
+        deprecated: 'true',
+        beta: 'false',
+        main: 'true',
+        isPublic: 'false',
+      }),
+    ).resolves.toBe(`Version ${versionToChange} updated successfully.`);
+    mockRequest.done();
+  });
+
   // Note: this test is a bit bizarre since the flag management
   // in our version commands is really confusing to follow.
   // I'm not sure if it's technically possible to demote a stable version
@@ -222,11 +257,12 @@ describe('rdme versions:update', () => {
     const updatedVersionObject = {
       version: renamedVersion,
       is_beta: true,
+      is_deprecated: true,
       is_hidden: true,
       is_stable: false,
     };
 
-    prompts.inject([renamedVersion, true]);
+    prompts.inject([renamedVersion, true, false, true]);
 
     const errorResponse = {
       error: 'VERSION_CANT_DEMOTE_STABLE',

--- a/src/cmds/versions/create.ts
+++ b/src/cmds/versions/create.ts
@@ -82,7 +82,8 @@ export default class CreateVersionCommand extends Command {
       from: promptResponse.from,
       is_beta: promptResponse.is_beta,
       is_deprecated: promptResponse.is_deprecated,
-      is_hidden: !promptResponse.is_public,
+      // if the "is public" question was never asked, we should omit that from the payload
+      is_hidden: typeof promptResponse.is_public === 'undefined' ? undefined : !promptResponse.is_public,
       is_stable: promptResponse.is_stable,
     };
 

--- a/src/cmds/versions/update.ts
+++ b/src/cmds/versions/update.ts
@@ -69,7 +69,8 @@ export default class UpdateVersionCommand extends Command {
       version: promptResponse.newVersion || version,
       is_beta: promptResponse.is_beta,
       is_deprecated: promptResponse.is_deprecated,
-      is_hidden: !promptResponse.is_public,
+      // if the "is public" question was never asked, we should omit that from the payload
+      is_hidden: typeof promptResponse.is_public === 'undefined' ? undefined : !promptResponse.is_public,
       is_stable: promptResponse.is_stable,
     };
 

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -179,7 +179,7 @@ export function versionPrompt(
     },
     {
       type: (prev, values) => {
-        // if user previously wanted this version to be the main version
+        // if user wants this version to be the main version
         // it can't also be hidden.
         return values.is_stable ? null : 'confirm';
       },
@@ -188,7 +188,7 @@ export function versionPrompt(
     },
     {
       type: (prev, values) => {
-        // if user previously wanted this version to be the main version
+        // if user wants this version to be the main version
         // it can't also be deprecated.
         return values.is_stable ? null : 'confirm';
       },


### PR DESCRIPTION
| 🚥 Resolves https://github.com/readmeio/rdme/issues/871 |
| :------------------- |

## 🧰 Changes

#861 introduced a regression where the CLI will always set `is_hidden: true` in the API payload if the `main` flag is set to `true`, which throws an error in our version model validation 😬 this PR fixes that.

## 🧬 QA & Testing

Confirmed the fix locally and added tests with strict payload assertions to make sure everything checks out.
