### PR TITLE
ci: validate PR titles

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,16 @@
+name: 'Lint PR Title'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 🧰 Changes

Our release process relies on `semantic-release` and on our PR titles following conventional commit guidelines, so this PR adds a workflow to validate PR titles accordingly.

I also updated our repository settings so we now default to the PR title when merging PRs in (weird how that's not the default):

![CleanShot 2023-09-05 at 09 57 35@2x](https://github.com/readmeio/rdme/assets/8854718/c67cd331-eb07-4ea6-98f1-abd6f032883e)


## 🧬 QA & Testing

Per [their docs on the `pull_request_target` event](https://github.com/amannn/action-semantic-pull-request#event-triggers), this workflow won't run until it's merged into our default branch so there's no way to test it until then.
