### PR TITLE
feat: use `actions/checkout@v4` everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - 20
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install deps
         run: npm ci
@@ -52,12 +52,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GitHub Action
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: rdme-repo
 
       - name: Checkout external repo containing OpenAPI file
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: oas-examples-repo
           repository: readmeio/oas-examples

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install and build rdme deps
         run: npm ci && npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_GH_TOKEN }}

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GitHub Action
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # This is a simple example that runs our `validate` command on a local file.
       - name: Run `openapi:validate` command

--- a/__tests__/cmds/docs/__snapshots__/index.test.ts.snap
+++ b/__tests__/cmds/docs/__snapshots__/index.test.ts.snap
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`docs\` command 🚀
         uses: readmeio/rdme@v7
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`docs\` command 🚀
         uses: readmeio/rdme@v7
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`docs\` command 🚀
         uses: readmeio/rdme@v7

--- a/__tests__/cmds/openapi/__snapshots__/index.test.ts.snap
+++ b/__tests__/cmds/openapi/__snapshots__/index.test.ts.snap
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi\` command 🚀
         uses: readmeio/rdme@v7
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi\` command 🚀
         uses: readmeio/rdme@v7
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi\` command 🚀
         uses: readmeio/rdme@v7
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi\` command 🚀
         uses: readmeio/rdme@v7
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi\` command 🚀
         uses: readmeio/rdme@v7
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi\` command 🚀
         uses: readmeio/rdme@v7

--- a/__tests__/cmds/openapi/__snapshots__/validate.test.ts.snap
+++ b/__tests__/cmds/openapi/__snapshots__/validate.test.ts.snap
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi:validate\` command 🚀
         uses: readmeio/rdme@v7
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi:validate\` command 🚀
         uses: readmeio/rdme@v7
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi:validate\` command 🚀
         uses: readmeio/rdme@v7

--- a/__tests__/lib/__snapshots__/createGHA.test.ts.snap
+++ b/__tests__/lib/__snapshots__/createGHA.test.ts.snap
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`changelogs\` command 🚀
         uses: readmeio/rdme@v7
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`changelogs\` command 🚀
         uses: readmeio/rdme@v7
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`changelogs\` command 🚀
         uses: readmeio/rdme@v7
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`changelogs\` command 🚀
         uses: readmeio/rdme@v7
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`custompages\` command 🚀
         uses: readmeio/rdme@v7
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`custompages\` command 🚀
         uses: readmeio/rdme@v7
@@ -278,7 +278,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`custompages\` command 🚀
         uses: readmeio/rdme@v7
@@ -319,7 +319,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`custompages\` command 🚀
         uses: readmeio/rdme@v7
@@ -360,7 +360,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`docs\` command 🚀
         uses: readmeio/rdme@v7
@@ -401,7 +401,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`docs\` command 🚀
         uses: readmeio/rdme@v7
@@ -442,7 +442,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`docs\` command 🚀
         uses: readmeio/rdme@v7
@@ -483,7 +483,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`docs\` command 🚀
         uses: readmeio/rdme@v7
@@ -524,7 +524,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi\` command 🚀
         uses: readmeio/rdme@v7
@@ -565,7 +565,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi\` command 🚀
         uses: readmeio/rdme@v7
@@ -602,7 +602,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi:validate\` command 🚀
         uses: readmeio/rdme@v7
@@ -639,7 +639,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi:validate\` command 🚀
         uses: readmeio/rdme@v7

--- a/__tests__/single-threaded/lib/__snapshots__/createGHA.test.ts.snap
+++ b/__tests__/single-threaded/lib/__snapshots__/createGHA.test.ts.snap
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`changelogs\` command 🚀
         uses: readmeio/rdme@v7
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`changelogs\` command 🚀
         uses: readmeio/rdme@v7
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`changelogs\` command 🚀
         uses: readmeio/rdme@v7
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`changelogs\` command 🚀
         uses: readmeio/rdme@v7
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`custompages\` command 🚀
         uses: readmeio/rdme@v7
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`custompages\` command 🚀
         uses: readmeio/rdme@v7
@@ -278,7 +278,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`custompages\` command 🚀
         uses: readmeio/rdme@v7
@@ -319,7 +319,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`custompages\` command 🚀
         uses: readmeio/rdme@v7
@@ -360,7 +360,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`docs\` command 🚀
         uses: readmeio/rdme@v7
@@ -401,7 +401,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`docs\` command 🚀
         uses: readmeio/rdme@v7
@@ -442,7 +442,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`docs\` command 🚀
         uses: readmeio/rdme@v7
@@ -483,7 +483,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`docs\` command 🚀
         uses: readmeio/rdme@v7
@@ -524,7 +524,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi\` command 🚀
         uses: readmeio/rdme@v7
@@ -565,7 +565,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi\` command 🚀
         uses: readmeio/rdme@v7
@@ -602,7 +602,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi:validate\` command 🚀
         uses: readmeio/rdme@v7
@@ -639,7 +639,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi:validate\` command 🚀
         uses: readmeio/rdme@v7

--- a/__tests__/single-threaded/openapi/__snapshots__/index.test.ts.snap
+++ b/__tests__/single-threaded/openapi/__snapshots__/index.test.ts.snap
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi\` command 🚀
         uses: readmeio/rdme@v7

--- a/__tests__/single-threaded/openapi/__snapshots__/validate.test.ts.snap
+++ b/__tests__/single-threaded/openapi/__snapshots__/validate.test.ts.snap
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`openapi:validate\` command 🚀
         uses: readmeio/rdme@v7

--- a/documentation/github-actions-docs-example.md
+++ b/documentation/github-actions-docs-example.md
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Run GitHub Action to sync docs in `documentation` directory
       - name: GitHub Action

--- a/documentation/github-actions-openapi-example.md
+++ b/documentation/github-actions-openapi-example.md
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Run GitHub Action to sync OpenAPI file at ./path-to-file.json
       - name: GitHub Action

--- a/documentation/legacy-github-action.md
+++ b/documentation/legacy-github-action.md
@@ -74,7 +74,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: readmeio/github-readme-sync@v2
         with:
           readme-oas-key: 'unique-key-from-dashboard'

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -179,7 +179,7 @@ We recommend using the [quick start](#quick-start) to get started with GitHub Ac
 
 ```yml
 # Required in order for the GitHub Action to access your repo's contents
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 
 # Runs the `rdme` command on your repo's contents
 - uses: readmeio/rdme@RDME_VERSION

--- a/src/lib/createGHA/baseFile.ts
+++ b/src/lib/createGHA/baseFile.ts
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run \`{{command}}\` command 🚀
         uses: readmeio/rdme@{{rdmeVersion}}


### PR DESCRIPTION
## 🧰 Changes

Did a quick find-and-replace to update our GitHub workflow files and our GitHub Actions onboarding workflow generation to use [`actions/checkout@v4`](https://github.com/actions/checkout/releases/tag/v4.0.0)

## 🧬 QA & Testing

If our tests pass, we should be good to go since we're actually using `actions/checkout@v4` against the real `rdme` GitHub Action.
