### PR TITLE
chore(temp): see if this action paradigm works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,12 @@ jobs:
       # Instead of testing against the pre-built image, we can build
       # an image from the currently checked-out repo contents by doing a
       # li'l update in the action.yml file to point to the current Dockerfile.
-      - name: Replace Docker image value in action.yml
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: 'image:.*'
-          replace: "image: 'Dockerfile'"
-          include: rdme-repo/action.yml
+      # - name: Replace Docker image value in action.yml
+      #   uses: jacobtomlinson/gha-find-replace@v3
+      #   with:
+      #     find: 'image:.*'
+      #     replace: "image: 'Dockerfile'"
+      #     include: rdme-repo/action.yml
 
       - name: Run `openapi:validate` command
         uses: ./rdme-repo/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,12 +45,12 @@ jobs:
       # Instead of testing against the pre-built image, we can build
       # an image from the currently checked-out repo contents by doing a
       # li'l update in the action.yml file to point to the current Dockerfile.
-      - name: Replace Docker image value in action.yml
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: 'image:.*'
-          replace: "image: 'Dockerfile'"
-          include: action.yml
+      # - name: Replace Docker image value in action.yml
+      #   uses: jacobtomlinson/gha-find-replace@v3
+      #   with:
+      #     find: 'image:.*'
+      #     replace: "image: 'Dockerfile'"
+      #     include: action.yml
 
       # And finally, with our updated documentation,
       # we run the `rdme` GitHub Action to sync the Markdown file

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,5 @@ outputs:
   rdme:
     description: The rdme command result output
 runs:
-  using: docker
-  image: docker://ghcr.io/readmeio/rdme:8.7.0-next.2
-  args:
-    - docker-gha
-    - ${{ inputs.rdme }}
+  using: node20
+  main: rollup-output.cjs

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import { defineConfig } from 'rollup';
 
 export default defineConfig({
   input: 'bin/rdme.js',
-  output: { file: 'dist/rollup-output.cjs', format: 'cjs', inlineDynamicImports: true },
+  output: { file: 'rollup-output.cjs', format: 'cjs', inlineDynamicImports: true },
   plugins: [
     commonjs(),
     json(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,11 +7,9 @@ import { defineConfig } from 'rollup';
 export default defineConfig({
   input: 'bin/rdme.js',
   output: {
-    compact: true,
     file: 'rollup-output.cjs',
     format: 'cjs',
     inlineDynamicImports: true,
-    minifyInternalExports: true,
   },
   plugins: [
     commonjs(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,13 @@ import { defineConfig } from 'rollup';
 
 export default defineConfig({
   input: 'bin/rdme.js',
-  output: { file: 'rollup-output.cjs', format: 'cjs', inlineDynamicImports: true },
+  output: {
+    compact: true,
+    file: 'rollup-output.cjs',
+    format: 'cjs',
+    inlineDynamicImports: true,
+    minifyInternalExports: true,
+  },
   plugins: [
     commonjs(),
     json(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,11 @@ export default function rdme(rawProcessArgv: NodeJS.Process['argv']) {
     debug(`parsing arg string into argv: ${JSON.stringify(processArgv)}`);
   }
 
+  if (process.env.INPUT_RDME) {
+    processArgv = parseArgsStringToArgv(process.env.INPUT_RDME);
+    debug(`parsing arg string for GHA into argv: ${JSON.stringify(processArgv)}`);
+  }
+
   const argv = cliArgs(mainArgs, { partial: true, argv: processArgv });
   const cmd = argv.command || false;
 


### PR DESCRIPTION
We currently build a single executable and publish a Docker image to the GitHub container registry, but now that we're using Rollup to build a single JS file, is it possible to use a JavaScript action instead? This PR is a little proof-of-concept of what that would look like.

For reference: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions