### PR TITLE
fix: hide `ExperimentalWarning`

### DIFF
--- a/bin/rdme.js
+++ b/bin/rdme.js
@@ -1,3 +1,5 @@
-#!/usr/bin/env node
+#!/usr/bin/env NODE_OPTIONS=--no-warnings node
+// ^ we need this env variable above to hide the ExperimentalWarnings
+// source: https://github.com/nodejs/node/issues/10802#issuecomment-573376999
 // eslint-disable-next-line import/extensions
 import '../dist/src/cli.js';


### PR DESCRIPTION
## 🧰 Changes

As I feared, the current version in `next` yields this whenever you run an `rdme` CLI command:

<img width="852" alt="CleanShot 2023-09-14 at 18 06 07@2x" src="https://github.com/readmeio/rdme/assets/8854718/2e267262-1bb3-4672-8c32-8b4952155739">

This was surprisingly not straightforward (it was _**buried**_ in the comments: https://github.com/nodejs/node/issues/10802#issuecomment-573376999) and I don't love this solution, but I confirmed that adding a `NODE_OPTIONS` env variable to the entry shebang should fix this.

## 🧬 QA & Testing

I `npm link`'d locally and confirmed the warning goes away:

<img width="309" alt="CleanShot 2023-09-14 at 18 09 24@2x" src="https://github.com/readmeio/rdme/assets/8854718/a8fb6b25-32dc-4ffb-b98c-8c8d869526fb">

