### PR TITLE
feat(versions): flag parity with API, copy fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ If you wish to automate the process of creating a new project version, and not h
 For example, the following command contains all the flags to bypass the CLI prompts:
 
 ```sh
-rdme versions:create <version> --fork={version-fork} --main={true|false} --beta={true|false} --deprecated={true|false} --isPublic={true|false}
+rdme versions:create <version> --fork={version-fork} --main={true|false} --beta={true|false} --deprecated={true|false} --hidden={true|false}
 ```
 
 See `rdme versions:create --help` for a full list of flags.

--- a/__tests__/cmds/versions/create.test.ts
+++ b/__tests__/cmds/versions/create.test.ts
@@ -48,7 +48,7 @@ describe('rdme versions:create', () => {
   });
 
   it('should create a specific version', async () => {
-    prompts.inject([version, false, true, true]);
+    prompts.inject([version, false, true, true, false]);
     const newVersion = '1.0.1';
 
     const mockRequest = getAPIMock()
@@ -60,7 +60,8 @@ describe('rdme versions:create', () => {
         is_stable: false,
         is_beta: true,
         from: '1.0.0',
-        is_hidden: false,
+        is_hidden: true,
+        is_deprecated: false,
       })
       .basicAuth({ user: key })
       .reply(201, { version: newVersion });
@@ -96,7 +97,7 @@ describe('rdme versions:create', () => {
         deprecated: 'false',
         main: 'false',
         codename: 'test',
-        isPublic: 'true',
+        hidden: 'false',
       }),
     ).resolves.toBe(`Version ${newVersion} created successfully.`);
 
@@ -123,7 +124,7 @@ describe('rdme versions:create', () => {
         fork: version,
         beta: 'false',
         main: 'true',
-        isPublic: 'false',
+        hidden: 'true',
         deprecated: 'true',
       }),
     ).resolves.toBe(`Version ${newVersion} created successfully.`);
@@ -174,7 +175,7 @@ describe('rdme versions:create', () => {
       ).rejects.toStrictEqual(new Error("Invalid option passed for 'deprecated'. Must be 'true' or 'false'."));
     });
 
-    it('should throw if non-boolean `isPublic` flag is passed', () => {
+    it('should throw if non-boolean `hidden` flag is passed', () => {
       const newVersion = '1.0.1';
 
       return expect(
@@ -183,9 +184,9 @@ describe('rdme versions:create', () => {
           version: newVersion,
           fork: version,
           // @ts-expect-error deliberately passing a bad value here
-          isPublic: 'test',
+          hidden: 'test',
         }),
-      ).rejects.toStrictEqual(new Error("Invalid option passed for 'isPublic'. Must be 'true' or 'false'."));
+      ).rejects.toStrictEqual(new Error("Invalid option passed for 'hidden'. Must be 'true' or 'false'."));
     });
 
     it('should throw if non-boolean `main` flag is passed', () => {

--- a/__tests__/lib/prompts.test.ts
+++ b/__tests__/lib/prompts.test.ts
@@ -97,7 +97,7 @@ describe('prompt test bed', () => {
         newVersion: '1.2.1',
         is_stable: false,
         is_beta: true,
-        is_public: true,
+        is_hidden: true,
         is_deprecated: false,
       });
     });

--- a/src/cmds/versions/update.ts
+++ b/src/cmds/versions/update.ts
@@ -40,7 +40,7 @@ export default class UpdateVersionCommand extends Command {
   async run(opts: AuthenticatedCommandOptions<Options>) {
     await super.run(opts);
 
-    const { key, version, newVersion, codename, main, beta, isPublic, deprecated } = opts;
+    const { key, version, newVersion, codename, main, beta, hidden, deprecated } = opts;
 
     const selectedVersion = await getProjectVersion(version, key);
 
@@ -56,7 +56,7 @@ export default class UpdateVersionCommand extends Command {
     prompts.override({
       is_beta: castStringOptToBool(beta, 'beta'),
       is_deprecated: castStringOptToBool(deprecated, 'deprecated'),
-      is_public: castStringOptToBool(isPublic, 'isPublic'),
+      is_hidden: castStringOptToBool(hidden, 'hidden'),
       is_stable: castStringOptToBool(main, 'main'),
       newVersion,
     });
@@ -65,12 +65,11 @@ export default class UpdateVersionCommand extends Command {
 
     const body: Version = {
       codename,
-      // fall back to current version if user didn't enter one
+      // fallback to existing version if user was prompted to rename the version but didn't enter anything
       version: promptResponse.newVersion || version,
       is_beta: promptResponse.is_beta,
       is_deprecated: promptResponse.is_deprecated,
-      // if the "is public" question was never asked, we should omit that from the payload
-      is_hidden: typeof promptResponse.is_public === 'undefined' ? undefined : !promptResponse.is_public,
+      is_hidden: promptResponse.is_hidden,
       is_stable: promptResponse.is_stable,
     };
 

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -189,24 +189,23 @@ export default class Command {
       {
         name: 'main',
         type: String,
-        description:
-          "Should this version be the primary (default) version for your project? (Must be 'true' or 'false')",
+        description: "Should this be the main version for your project? (Must be 'true' or 'false')",
       },
       {
         name: 'beta',
         type: String,
-        description: "Is this version in beta? (Must be 'true' or 'false')",
+        description: "Should this version be in beta? (Must be 'true' or 'false')",
       },
       {
         name: 'deprecated',
         type: String,
-        description: "Would you like to deprecate this version? (Must be 'true' or 'false')",
+        description:
+          "Should this version be deprecated? The main version cannot be deprecated. (Must be 'true' or 'false')",
       },
       {
-        name: 'isPublic',
+        name: 'hidden',
         type: String,
-        description:
-          "Would you like to make this version public? Any primary version must be public. (Must be 'true' or 'false')",
+        description: "Should this version be hidden? The main version cannot be hidden. (Must be 'true' or 'false')",
       },
     ];
   }

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -139,14 +139,14 @@ export function versionPrompt(
   /** list of versions, used for prompt about which version to fork */
   versionList: Version[],
   /** existing version if we're performing an update */
-  isUpdate?: {
+  existingVersion?: {
     is_stable: boolean;
   },
 ): PromptObject[] {
   return [
     {
       // only runs for versions:create command
-      type: isUpdate ? null : 'select',
+      type: existingVersion ? null : 'select',
       name: 'from',
       message: 'Which version would you like to fork from?',
       choices: versionList.map(v => {
@@ -158,7 +158,7 @@ export function versionPrompt(
     },
     {
       // only runs for versions:update command
-      type: !isUpdate ? null : 'text',
+      type: !existingVersion ? null : 'text',
       name: 'newVersion',
       message: 'What should the version be renamed to?',
       hint: '1.0.0',
@@ -169,11 +169,11 @@ export function versionPrompt(
       },
     },
     {
-      // if the existing version being updated is already the main version,
-      // we can't switch that so we skip this question
-      type: isUpdate?.is_stable ? null : 'confirm',
+      // if the user is already updating the main version
+      // we skip this question since it must remain the main version
+      type: existingVersion?.is_stable ? null : 'confirm',
       name: 'is_stable',
-      message: 'Would you like to make this version the main version for this project?',
+      message: 'Should this be the main version for your project?',
     },
     {
       type: 'confirm',
@@ -186,8 +186,8 @@ export function versionPrompt(
         // it can't also be hidden.
         return values.is_stable ? null : 'confirm';
       },
-      name: 'is_public',
-      message: 'Would you like to make this version public?',
+      name: 'is_hidden',
+      message: 'Should this version be hidden?',
     },
     {
       type: (prev, values) => {
@@ -196,7 +196,7 @@ export function versionPrompt(
         return values.is_stable ? null : 'confirm';
       },
       name: 'is_deprecated',
-      message: 'Would you like to deprecate this version?',
+      message: 'Should this version be deprecated?',
     },
   ];
 }


### PR DESCRIPTION
## 🧰 Changes

This PR updates our `versions:create` and `versions:update` commands to bring parity with our CLI flags and [our API flags](https://docs.readme.com/main/reference/createversion). The only flag that needed to be updated was `isPublic`, which has been renamed to `hidden`. This PR is a breaking change since the flag needs to be renamed and flipped..

This PR also cleans up our copy related to these commands and cleans up a bunch of tests and comments.

## 🧬 QA & Testing

Does the copy look good and do tests pass?
