### PR TITLE
feat: support `README_API_KEY` env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,11 @@ For local CLI usage with a single project, you can authenticate `rdme` to your R
 > [!WARNING]
 > For security reasons, we strongly recommend providing a project API key via the `--key` option in automations or CI environments (GitHub Actions, CircleCI, Travis CI, etc.). It's also recommended if you're working with multiple ReadMe projects to avoid accidentally overwriting existing data.
 
-You can also pass in your API key via the `RDME_API_KEY` environmental variable. Here is the order of precedence when passing your API key into `rdme`:
+You can also pass in your API key via environmental variable. Here is the order of precedence when passing your API key into `rdme`:
 
 1. The `--key` option. If that isn't present, we look for...
 1. The `RDME_API_KEY` environmental variable. If that isn't present, we look for...
+1. The `README_API_KEY` environmental variable. If that isn't present, we look for...
 1. The API key value stored in your local configuration file (i.e., the one set via `rdme login`)
 
 `rdme whoami` is also available to you to determine who is logged in, and to what project. You can clear your stored credentials with `rdme logout`.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -155,7 +155,7 @@ describe('cli', () => {
       });
     });
 
-    describe('stored API key via env vars', () => {
+    describe.each(['README_API_KEY', 'RDME_API_KEY'])('stored API key via %s env var', envKey => {
       let consoleInfoSpy;
       const key = '123456-env';
       const getCommandOutput = () => {
@@ -163,7 +163,7 @@ describe('cli', () => {
       };
 
       beforeEach(() => {
-        vi.stubEnv('RDME_API_KEY', key);
+        vi.stubEnv(envKey, key);
         vi.stubEnv('RDME_EMAIL', 'owlbert-env@readme.io');
         vi.stubEnv('RDME_PROJECT', 'project-owlbert-env');
         consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});

--- a/src/lib/getCurrentConfig.ts
+++ b/src/lib/getCurrentConfig.ts
@@ -5,7 +5,7 @@ import configstore from './configstore.js';
  * with env variables taking precedent
  */
 export default function getCurrentConfig(): { apiKey?: string; email?: string; project?: string } {
-  const apiKey = process.env.RDME_API_KEY || configstore.get('apiKey');
+  const apiKey = process.env.RDME_API_KEY || process.env.README_API_KEY || configstore.get('apiKey');
   const email = process.env.RDME_EMAIL || configstore.get('email');
   const project = process.env.RDME_PROJECT || configstore.get('project');
 


### PR DESCRIPTION
| 🚥 Resolves #948 |
| :------------------- |

## 🧰 Changes

Adds the ability to pass in the API key via the `README_API_KEY` environmental variable.

## 🧬 QA & Testing

Do the docs + tests + etc. look good?
