### PR TITLE
fix(openapi): add spinner catch statement

### DIFF
--- a/src/lib/prepareOas.ts
+++ b/src/lib/prepareOas.ts
@@ -174,13 +174,20 @@ export default async function prepareOas(
   // And though `.validate()` will run `.load()` itself running `.load()` here will not have any
   // performance implications as `oas-normalizes` caches the result of `.load()` the first time you
   // run it.
-  const { specType, definitionVersion } = await oas.load().then(async schema => {
-    const type = getAPIDefinitionType(schema);
-    return {
-      specType: capitalizeSpecType(type),
-      definitionVersion: await oas.version(),
-    };
-  });
+  const { specType, definitionVersion } = await oas
+    .load()
+    .then(async schema => {
+      const type = getAPIDefinitionType(schema);
+      return {
+        specType: capitalizeSpecType(type),
+        definitionVersion: await oas.version(),
+      };
+    })
+    .catch((err: Error) => {
+      spinner.fail();
+      debug(`raw oas load error object: ${JSON.stringify(err)}`);
+      throw err;
+    });
 
   // If we were supplied a Postman collection this will **always** convert it to OpenAPI 3.0.
   let api: OpenAPI.Document = await oas.validate({ convertToLatest: opts.convertToLatest }).catch((err: Error) => {


### PR DESCRIPTION
## 🧰 Changes

Noticed an un-handled spinner when running an `openapi:validate` command:

![CleanShot 2024-01-09 at 14 52 57@2x](https://github.com/readmeio/rdme/assets/8854718/62a5444d-5608-42d4-8823-111def7cbd15)


## 🧬 QA & Testing

Do tests still pass?
