### PR TITLE
feat: sort when syncing by parent

### DIFF
--- a/__tests__/__fixtures__/docs/docs-with-parent-ids/child.md
+++ b/__tests__/__fixtures__/docs/docs-with-parent-ids/child.md
@@ -1,0 +1,6 @@
+---
+title: Child
+parentDocSlug: parent
+---
+
+# Child Body

--- a/__tests__/__fixtures__/docs/docs-with-parent-ids/friend.md
+++ b/__tests__/__fixtures__/docs/docs-with-parent-ids/friend.md
@@ -1,0 +1,5 @@
+---
+title: Friend
+---
+
+# Friend Body

--- a/__tests__/__fixtures__/docs/docs-with-parent-ids/parent.md
+++ b/__tests__/__fixtures__/docs/docs-with-parent-ids/parent.md
@@ -1,0 +1,5 @@
+---
+title: Parent
+---
+
+# Parent Body

--- a/__tests__/__fixtures__/docs/docs-with-parent-ids/with-parent-doc.md
+++ b/__tests__/__fixtures__/docs/docs-with-parent-ids/with-parent-doc.md
@@ -1,0 +1,6 @@
+---
+title: With Parent Doc
+parentDoc: 1234
+---
+
+# With Parent Doc Body

--- a/__tests__/__fixtures__/docs/multiple-docs-cycle/child.md
+++ b/__tests__/__fixtures__/docs/multiple-docs-cycle/child.md
@@ -1,0 +1,6 @@
+---
+title: Child
+parentDocSlug: parent
+---
+
+# Child Body

--- a/__tests__/__fixtures__/docs/multiple-docs-cycle/grandparent.md
+++ b/__tests__/__fixtures__/docs/multiple-docs-cycle/grandparent.md
@@ -1,0 +1,6 @@
+---
+title: Grandparent
+parentDocSlug: child
+---
+
+# Grandparent Body

--- a/__tests__/__fixtures__/docs/multiple-docs-cycle/parent.md
+++ b/__tests__/__fixtures__/docs/multiple-docs-cycle/parent.md
@@ -1,0 +1,6 @@
+---
+title: Parent
+parentDocSlug: grandparent
+---
+
+# Parent Body

--- a/__tests__/__fixtures__/docs/multiple-docs-no-parents/child.md
+++ b/__tests__/__fixtures__/docs/multiple-docs-no-parents/child.md
@@ -1,0 +1,6 @@
+---
+title: Child
+parentDocSlug: parent
+---
+
+# Child Body

--- a/__tests__/__fixtures__/docs/multiple-docs-no-parents/friend.md
+++ b/__tests__/__fixtures__/docs/multiple-docs-no-parents/friend.md
@@ -1,0 +1,5 @@
+---
+title: Friend
+---
+
+# Friend Body

--- a/__tests__/__fixtures__/docs/multiple-docs/child.md
+++ b/__tests__/__fixtures__/docs/multiple-docs/child.md
@@ -1,0 +1,6 @@
+---
+title: Child
+parentDocSlug: parent
+---
+
+# Child Body

--- a/__tests__/__fixtures__/docs/multiple-docs/friend.md
+++ b/__tests__/__fixtures__/docs/multiple-docs/friend.md
@@ -1,0 +1,5 @@
+---
+title: Friend
+---
+
+# Friend Body

--- a/__tests__/__fixtures__/docs/multiple-docs/grandparent.md
+++ b/__tests__/__fixtures__/docs/multiple-docs/grandparent.md
@@ -1,0 +1,5 @@
+---
+title: Grandparent
+---
+
+# Grandparent Body

--- a/__tests__/__fixtures__/docs/multiple-docs/parent.md
+++ b/__tests__/__fixtures__/docs/multiple-docs/parent.md
@@ -1,0 +1,6 @@
+---
+title: Parent
+parentDocSlug: grandparent
+---
+
+# Parent Body

--- a/__tests__/cmds/docs/multiple.test.ts
+++ b/__tests__/cmds/docs/multiple.test.ts
@@ -3,11 +3,10 @@ import path from 'node:path';
 
 import frontMatter from 'gray-matter';
 import nock from 'nock';
-import { describe, beforeAll, afterAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
+import { describe, beforeAll, afterAll, afterEach, it, expect, vi } from 'vitest';
 
 import DocsCommand from '../../../src/cmds/docs/index.js';
 import getAPIMock, { getAPIMockWithVersionHeader } from '../../helpers/get-api-mock.js';
-import { gitDefaultMocks } from '../../helpers/get-git-mock.js';
 import hashFileContents from '../../helpers/hash-file-contents.js';
 
 const docs = new DocsCommand();
@@ -21,10 +20,6 @@ const version = '1.0.0';
 describe('rdme docs (multiple)', () => {
   beforeAll(() => {
     nock.disableNetConnect();
-  });
-
-  beforeEach(() => {
-    gitDefaultMocks();
   });
 
   afterEach(() => {

--- a/__tests__/cmds/docs/multiple.test.ts
+++ b/__tests__/cmds/docs/multiple.test.ts
@@ -77,18 +77,99 @@ describe('rdme docs (multiple)', () => {
     versionMock.done();
   });
 
+  it('should upload docs with parent doc ids first', async () => {
+    const dir = 'docs-with-parent-ids';
+    const slugs = ['child', 'friend', 'with-parent-doc', 'parent'];
+    let id = 1234;
+
+    const mocks = slugs.flatMap(slug => {
+      const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/${dir}/${slug}.md`)));
+      const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/${dir}/${slug}.md`)));
+
+      return [
+        getAPIMockWithVersionHeader(version)
+          .get(`/api/v1/docs/${slug}`)
+          .basicAuth({ user: key })
+          .reply(404, {
+            error: 'DOC_NOTFOUND',
+            message: `The doc with the slug '${slug}' couldn't be found`,
+            suggestion: '...a suggestion to resolve the issue...',
+            help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+          }),
+        getAPIMockWithVersionHeader(version)
+          .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
+          .basicAuth({ user: key })
+          // eslint-disable-next-line no-plusplus
+          .reply(201, { slug, _id: id++, body: doc.content, ...doc.data, lastUpdatedHash: hash }),
+      ];
+    });
+
+    const versionMock = getAPIMock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
+
+    const promise = docs.run({ filePath: `./__tests__/${fixturesBaseDir}/${dir}`, key, version });
+
+    await expect(promise).resolves.toStrictEqual(
+      [
+        `🌱 successfully created 'with-parent-doc' (ID: 1236) with contents from __tests__/${fixturesBaseDir}/${dir}/with-parent-doc.md`,
+        `🌱 successfully created 'friend' (ID: 1235) with contents from __tests__/${fixturesBaseDir}/${dir}/friend.md`,
+        `🌱 successfully created 'parent' (ID: 1237) with contents from __tests__/${fixturesBaseDir}/${dir}/parent.md`,
+        `🌱 successfully created 'child' (ID: 1234) with contents from __tests__/${fixturesBaseDir}/${dir}/child.md`,
+      ].join('\n'),
+    );
+
+    mocks.forEach(mock => mock.done());
+    versionMock.done();
+  });
+
+  it('should upload child docs without the parent', async () => {
+    const dir = 'multiple-docs-no-parents';
+    const slugs = ['child', 'friend'];
+    let id = 1234;
+
+    const mocks = slugs.flatMap(slug => {
+      const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/${dir}/${slug}.md`)));
+      const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/${dir}/${slug}.md`)));
+
+      return [
+        getAPIMockWithVersionHeader(version)
+          .get(`/api/v1/docs/${slug}`)
+          .basicAuth({ user: key })
+          .reply(404, {
+            error: 'DOC_NOTFOUND',
+            message: `The doc with the slug '${slug}' couldn't be found`,
+            suggestion: '...a suggestion to resolve the issue...',
+            help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+          }),
+        getAPIMockWithVersionHeader(version)
+          .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
+          .basicAuth({ user: key })
+          // eslint-disable-next-line no-plusplus
+          .reply(201, { slug, _id: id++, body: doc.content, ...doc.data, lastUpdatedHash: hash }),
+      ];
+    });
+
+    const versionMock = getAPIMock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
+
+    const promise = docs.run({ filePath: `./__tests__/${fixturesBaseDir}/${dir}`, key, version });
+
+    await expect(promise).resolves.toStrictEqual(
+      [
+        `🌱 successfully created 'child' (ID: 1234) with contents from __tests__/${fixturesBaseDir}/${dir}/child.md`,
+        `🌱 successfully created 'friend' (ID: 1235) with contents from __tests__/${fixturesBaseDir}/${dir}/friend.md`,
+      ].join('\n'),
+    );
+
+    mocks.forEach(mock => mock.done());
+    versionMock.done();
+  });
+
   it('should return an error message when it encounters a cycle', async () => {
     const dir = 'multiple-docs-cycle';
     const versionMock = getAPIMock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
 
     const promise = docs.run({ filePath: `./__tests__/${fixturesBaseDir}/${dir}`, key, version });
 
-    await expect(promise).rejects.toStrictEqual(
-      new Error(
-        `Unable to resolve docs parent hierarchy. A cycle was found with: __tests__/${fixturesBaseDir}/${dir}/parent.md`,
-      ),
-    );
-
+    await expect(promise).rejects.toThrow('Cyclic dependency');
     versionMock.done();
   });
 });

--- a/__tests__/cmds/docs/multiple.test.ts
+++ b/__tests__/cmds/docs/multiple.test.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import frontMatter from 'gray-matter';
+import nock from 'nock';
+import { describe, beforeAll, afterAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
+
+import DocsCommand from '../../../src/cmds/docs/index.js';
+import getAPIMock, { getAPIMockWithVersionHeader } from '../../helpers/get-api-mock.js';
+import { gitDefaultMocks } from '../../helpers/get-git-mock.js';
+import hashFileContents from '../../helpers/hash-file-contents.js';
+
+const docs = new DocsCommand();
+
+const fixturesBaseDir = '__fixtures__/docs';
+const fullFixturesDir = `${__dirname}./../../${fixturesBaseDir}`;
+
+const key = 'API_KEY';
+const version = '1.0.0';
+
+describe('rdme docs (multiple)', () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+
+  beforeEach(() => {
+    gitDefaultMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => nock.cleanAll());
+
+  it('should upload parent docs first', async () => {
+    const dir = 'multiple-docs';
+    const slugs = ['grandparent', 'parent', 'child', 'friend'];
+    let id = 1234;
+
+    const mocks = slugs.flatMap(slug => {
+      const doc = frontMatter(fs.readFileSync(path.join(fullFixturesDir, `/${dir}/${slug}.md`)));
+      const hash = hashFileContents(fs.readFileSync(path.join(fullFixturesDir, `/${dir}/${slug}.md`)));
+
+      return [
+        getAPIMockWithVersionHeader(version)
+          .get(`/api/v1/docs/${slug}`)
+          .basicAuth({ user: key })
+          .reply(404, {
+            error: 'DOC_NOTFOUND',
+            message: `The doc with the slug '${slug}' couldn't be found`,
+            suggestion: '...a suggestion to resolve the issue...',
+            help: 'If you need help, email support@readme.io and mention log "fake-metrics-uuid".',
+          }),
+        getAPIMockWithVersionHeader(version)
+          .post('/api/v1/docs', { slug, body: doc.content, ...doc.data, lastUpdatedHash: hash })
+          .basicAuth({ user: key })
+          // eslint-disable-next-line no-plusplus
+          .reply(201, { slug, _id: id++, body: doc.content, ...doc.data, lastUpdatedHash: hash }),
+      ];
+    });
+
+    const versionMock = getAPIMock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
+
+    const promise = docs.run({ filePath: `./__tests__/${fixturesBaseDir}/${dir}`, key, version });
+
+    await expect(promise).resolves.toStrictEqual(
+      [
+        `🌱 successfully created 'friend' (ID: 1237) with contents from __tests__/${fixturesBaseDir}/${dir}/friend.md`,
+        `🌱 successfully created 'grandparent' (ID: 1234) with contents from __tests__/${fixturesBaseDir}/${dir}/grandparent.md`,
+        `🌱 successfully created 'parent' (ID: 1235) with contents from __tests__/${fixturesBaseDir}/${dir}/parent.md`,
+        `🌱 successfully created 'child' (ID: 1236) with contents from __tests__/${fixturesBaseDir}/${dir}/child.md`,
+      ].join('\n'),
+    );
+
+    mocks.forEach(mock => mock.done());
+    versionMock.done();
+  });
+
+  it('should return an error message when it encounters a cycle', async () => {
+    const dir = 'multiple-docs-cycle';
+    const versionMock = getAPIMock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
+
+    const promise = docs.run({ filePath: `./__tests__/${fixturesBaseDir}/${dir}`, key, version });
+
+    await expect(promise).rejects.toStrictEqual(
+      new Error(
+        `Unable to resolve docs parent hierarchy. A cycle was found with: __tests__/${fixturesBaseDir}/${dir}/parent.md`,
+      ),
+    );
+
+    versionMock.done();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "string-argv": "^0.3.1",
         "table": "^6.8.1",
         "tmp-promise": "^3.0.2",
+        "toposort": "^2.0.2",
         "update-notifier": "^7.0.0",
         "validator": "^13.7.0"
       },
@@ -15828,6 +15829,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@types/pluralize": "^0.0.33",
         "@types/prompts": "^2.4.2",
         "@types/semver": "^7.3.12",
+        "@types/toposort": "^2.0.7",
         "@types/update-notifier": "^6.0.5",
         "@types/validator": "^13.7.6",
         "@vitest/coverage-v8": "^1.1.0",
@@ -2852,6 +2853,12 @@
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
       "integrity": "sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==",
+      "dev": true
+    },
+    "node_modules/@types/toposort": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/toposort/-/toposort-2.0.7.tgz",
+      "integrity": "sha512-sQNk65vbC36+UixCkcky+dCr7MlflHcVILg1FVGqlUntsLFv9xd9ToWIVko/gTuin+cVe16t+2YubEFkhnSuPQ==",
       "dev": true
     },
     "node_modules/@types/unist": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@types/pluralize": "^0.0.33",
     "@types/prompts": "^2.4.2",
     "@types/semver": "^7.3.12",
+    "@types/toposort": "^2.0.7",
     "@types/update-notifier": "^6.0.5",
     "@types/validator": "^13.7.6",
     "@vitest/coverage-v8": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "string-argv": "^0.3.1",
     "table": "^6.8.1",
     "tmp-promise": "^3.0.2",
+    "toposort": "^2.0.2",
     "update-notifier": "^7.0.0",
     "validator": "^13.7.0"
   },

--- a/src/lib/readDoc.ts
+++ b/src/lib/readDoc.ts
@@ -6,11 +6,13 @@ import grayMatter from 'gray-matter';
 
 import { debug } from './logger.js';
 
-interface ReadDocMetadata {
+export interface ReadDocMetadata {
   /** The contents of the file below the YAML front matter */
   content: string;
   /** A JSON object with the YAML front matter */
   data: Record<string, unknown>;
+  /** The original filePath */
+  filePath: string;
   /**
    * A hash of the file contents (including the front matter)
    */
@@ -22,19 +24,19 @@ interface ReadDocMetadata {
 /**
  * Returns the content, matter and slug of the specified Markdown or HTML file
  *
- * @param {String} filepath path to the HTML/Markdown file
+ * @param {String} filePath path to the HTML/Markdown file
  *  (file extension must end in `.html`, `.md`., or `.markdown`)
  */
-export default function readDoc(filepath: string): ReadDocMetadata {
-  debug(`reading file ${filepath}`);
-  const rawFileContents = fs.readFileSync(filepath, 'utf8');
+export default function readDoc(filePath: string): ReadDocMetadata {
+  debug(`reading file ${filePath}`);
+  const rawFileContents = fs.readFileSync(filePath, 'utf8');
   const matter = grayMatter(rawFileContents);
   const { content, data } = matter;
-  debug(`front matter for ${filepath}: ${JSON.stringify(matter)}`);
+  debug(`front matter for ${filePath}: ${JSON.stringify(matter)}`);
 
   // Stripping the subdirectories and markdown extension from the filename and lowercasing to get the default slug.
-  const slug = matter.data.slug || path.basename(filepath).replace(path.extname(filepath), '').toLowerCase();
+  const slug = matter.data.slug || path.basename(filePath).replace(path.extname(filePath), '').toLowerCase();
 
   const hash = crypto.createHash('sha1').update(rawFileContents).digest('hex');
-  return { content, data, hash, slug };
+  return { content, data, filePath, hash, slug };
 }

--- a/src/lib/syncDocsPath.ts
+++ b/src/lib/syncDocsPath.ts
@@ -150,7 +150,7 @@ function sortFiles(files: string[], { allowedFileExtensions }: { allowedFileExte
       {},
     );
 
-  const dependencies = Object.values(filesBySlug).reduce(
+  const dependencies = Object.values(filesBySlug).reduce<[string, string][]>(
     (edges, obj) => {
       if (obj.parentDocSlug) {
         edges.push([filesBySlug[obj.parentDocSlug].filePath, filesBySlug[obj.slug].filePath]);
@@ -158,7 +158,7 @@ function sortFiles(files: string[], { allowedFileExtensions }: { allowedFileExte
 
       return edges;
     },
-    [] as [string, string][],
+    [],
   );
 
   return toposort.array(files, dependencies);

--- a/src/lib/syncDocsPath.ts
+++ b/src/lib/syncDocsPath.ts
@@ -141,13 +141,13 @@ function sortFiles(files: string[], { allowedFileExtensions }: { allowedFileExte
 
       return { filePath, slug, parentDocSlug };
     })
-    .reduce(
+    .reduce<Record<string, { filePath: string; parentDocSlug: string; slug: string }>>(
       (bySlug, obj) => {
         // eslint-disable-next-line no-param-reassign
         bySlug[obj.slug] = obj;
         return bySlug;
       },
-      {} as Record<string, { filePath: string; parentDocSlug: string; slug: string }>,
+      {},
     );
 
   const dependencies = Object.values(filesBySlug).reduce(


### PR DESCRIPTION
| 🚥 Resolves RM-8336 |
| :------------------ |

## 🧰 Changes

When syncing docs, it sorts them by their parents!

Users reported issues where if a parent document was in a directory, it could error out because it would get synced after one of its children.

## 🧬 QA & Testing

Not sure :grimacing:.
