### PR TITLE
fix: use newest import attributes syntax

### DIFF
--- a/__tests__/cmds/openapi/index.test.ts
+++ b/__tests__/cmds/openapi/index.test.ts
@@ -11,7 +11,7 @@ import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vite
 import OpenAPICommand from '../../../src/cmds/openapi/index.js';
 import APIError from '../../../src/lib/apiError.js';
 import config from '../../../src/lib/config.js';
-import petstoreWeird from '../../__fixtures__/petstore-simple-weird-version.json' assert { type: 'json' };
+import petstoreWeird from '../../__fixtures__/petstore-simple-weird-version.json' with { type: 'json' };
 import getAPIMock, { getAPIMockWithVersionHeader } from '../../helpers/get-api-mock.js';
 import { after, before } from '../../helpers/get-gha-setup.js';
 import { after as afterGHAEnv, before as beforeGHAEnv } from '../../helpers/setup-gha-env.js';

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import prompts from 'prompts';
 import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 
-import pkg from '../package.json' assert { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 import cli from '../src/index.js';
 import conf from '../src/lib/configstore.js';
 

--- a/__tests__/lib/analyzeOas.test.ts
+++ b/__tests__/lib/analyzeOas.test.ts
@@ -1,6 +1,6 @@
 import type { OASDocument } from 'oas/types';
 
-import petstore from '@readme/oas-examples/3.0/json/petstore.json' assert { type: 'json' };
+import petstore from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
 import { describe, it, expect } from 'vitest';
 
 import analyzeOas, { getSupportedFeatures } from '../../src/lib/analyzeOas.js';

--- a/__tests__/lib/fetch.test.ts
+++ b/__tests__/lib/fetch.test.ts
@@ -2,7 +2,7 @@
 import { Headers } from 'node-fetch';
 import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 
-import pkg from '../../package.json' assert { type: 'json' };
+import pkg from '../../package.json' with { type: 'json' };
 import readmeAPIFetch, { cleanHeaders, handleRes } from '../../src/lib/readmeAPIFetch.js';
 import getAPIMock from '../helpers/get-api-mock.js';
 import { after, before } from '../helpers/setup-gha-env.js';

--- a/__tests__/lib/getPkgVersion.test.ts
+++ b/__tests__/lib/getPkgVersion.test.ts
@@ -2,7 +2,7 @@ import nock from 'nock';
 import semver from 'semver';
 import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 
-import pkg from '../../package.json' assert { type: 'json' };
+import pkg from '../../package.json' with { type: 'json' };
 import { getNodeVersion, getPkgVersion } from '../../src/lib/getPkgVersion.js';
 
 describe('#getNodeVersion()', () => {

--- a/__tests__/single-threaded/lib/createGHA.test.ts
+++ b/__tests__/single-threaded/lib/createGHA.test.ts
@@ -19,7 +19,7 @@ import createGHA, { getConfigStoreKey, getGHAFileName, getGitData, git } from '.
 import { getMajorPkgVersion } from '../../../src/lib/getPkgVersion.js';
 import { after, before } from '../../helpers/get-gha-setup.js';
 import getGitRemoteMock from '../../helpers/get-git-mock.js';
-import ghaWorkflowSchema from '../../helpers/github-workflow-schema.json' assert { type: 'json' };
+import ghaWorkflowSchema from '../../helpers/github-workflow-schema.json' with { type: 'json' };
 
 const testWorkingDir = process.cwd();
 

--- a/bin/set-action-image.js
+++ b/bin/set-action-image.js
@@ -5,7 +5,7 @@ import fs from 'node:fs/promises';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import jsYaml from 'js-yaml';
 
-import pkg from '../package.json' assert { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 
 /**
  * Updates our `action.yml` file so it properly points to

--- a/bin/set-major-version-tag.js
+++ b/bin/set-major-version-tag.js
@@ -5,7 +5,7 @@ import util from 'node:util';
 
 import { parse } from 'semver';
 
-import pkg from '../package.json' assert { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 
 const execFile = util.promisify(unpromisifiedExecFile);
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "author": "ReadMe <support@readme.io> (https://readme.com)",
   "engines": {
-    "node": ">=18"
+    "node": ">=18.20.0"
   },
   "bin": {
     "rdme": "bin/rdme.js"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "author": "ReadMe <support@readme.io> (https://readme.com)",
   "engines": {
-    "node": ">=18.20.0"
+    "node": "^18.20.0 || >=20.10.0"
   },
   "bin": {
     "rdme": "bin/rdme.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import * as core from '@actions/core';
 import chalk from 'chalk';
 import updateNotifier from 'update-notifier';
 
-import pkg from '../package.json' assert { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 
 import { isGHA } from './lib/isCI.js';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import chalk from 'chalk';
 import cliArgs from 'command-line-args';
 import parseArgsStringToArgv from 'string-argv';
 
-import pkg from '../package.json' assert { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 
 import * as commands from './lib/commands.js';
 import config from './lib/config.js';

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,4 @@
-import pkg from '../../package.json' assert { type: 'json' };
+import pkg from '../../package.json' with { type: 'json' };
 
 const config = {
   cli: pkg.name,

--- a/src/lib/configstore.ts
+++ b/src/lib/configstore.ts
@@ -1,6 +1,6 @@
 import Configstore from 'configstore';
 
-import pkg from '../../package.json' assert { type: 'json' };
+import pkg from '../../package.json' with { type: 'json' };
 
 const configstore = new Configstore(
   /**

--- a/src/lib/getPkgVersion.ts
+++ b/src/lib/getPkgVersion.ts
@@ -18,13 +18,13 @@ type npmDistTag = 'latest';
  *
  * @example 14
  */
-export function getNodeVersion() {
+export function getNodeVersion(): string {
   const { node } = pkg.engines;
   const parsedVersion = semver.minVersion(node);
   if (!parsedVersion) {
     throw new Error('`version` value in package.json is invalid');
   }
-  return parsedVersion.major;
+  return parsedVersion.version;
 }
 
 /**

--- a/src/lib/getPkgVersion.ts
+++ b/src/lib/getPkgVersion.ts
@@ -2,7 +2,7 @@
 import fetch from 'node-fetch';
 import semver from 'semver';
 
-import pkg from '../../package.json' assert { type: 'json' };
+import pkg from '../../package.json' with { type: 'json' };
 
 import { error } from './logger.js';
 

--- a/src/lib/readmeAPIFetch.ts
+++ b/src/lib/readmeAPIFetch.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import mime from 'mime-types';
 import nodeFetch, { Headers } from 'node-fetch'; // eslint-disable-line no-restricted-imports
 
-import pkg from '../../package.json' assert { type: 'json' };
+import pkg from '../../package.json' with { type: 'json' };
 
 import APIError from './apiError.js';
 import config from './config.js';


### PR DESCRIPTION
## 🧰 Changes

TC39 updated their import _assertions_ to be import _attributes_ and it's a bit of a mess now that we're running tests against Node v22.

Here's what importing JSON in ESM used to look like:

```js
import { x } from "./mod" assert { type: "json" }
```

now it looks like this:

```js
import { x } from "./mod" with { type: "json" };
```

Support for this new `with` keyword was added in [Node v18.20.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#added-support-for-import-attributes) and [Node v20.10.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#2023-11-22-version-20100-iron-lts-targos) (and is supported on all v21 and v22 channels), but importantly the older `assert` keyword is **_not_** supported in Node v22, so unfortunately our `package.json#engines.node` field is going to look a little ridiculous for the time being.

Details: https://github.com/tc39/proposal-import-attributes?tab=readme-ov-file#history

## 🧬 QA & Testing

Do tests pass?
