### PR TITLE
feat!: remove `validate`, deprecate/hide `open`

### DIFF
--- a/__tests__/commands/openapi/validate.test.ts
+++ b/__tests__/commands/openapi/validate.test.ts
@@ -211,12 +211,4 @@ describe('rdme openapi:validate', () => {
       );
     });
   });
-
-  describe('rdme validate alias', () => {
-    it('should should `rdme openapi:validate`', async () => {
-      return expect(
-        (await oclifRunCommand(['validate', require.resolve('@readme/oas-examples/3.0/json/petstore.json')])).result,
-      ).toContain(chalk.green('petstore.json is a valid OpenAPI API definition!'));
-    });
-  });
 });

--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -403,9 +403,6 @@ FLAGS
 
 DESCRIPTION
   Validate your OpenAPI/Swagger definition.
-
-ALIASES
-  $ rdme validate
 ```
 
 ## `rdme versions`

--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -35,7 +35,6 @@ USAGE
 * [`rdme help [COMMAND]`](#rdme-help-command)
 * [`rdme login`](#rdme-login)
 * [`rdme logout`](#rdme-logout)
-* [`rdme open`](#rdme-open)
 * [`rdme openapi [SPEC]`](#rdme-openapi-spec)
 * [`rdme openapi:convert [SPEC]`](#rdme-openapiconvert-spec)
 * [`rdme openapi:inspect [SPEC]`](#rdme-openapiinspect-spec)
@@ -260,21 +259,6 @@ USAGE
 
 DESCRIPTION
   Logs the currently authenticated user out of ReadMe.
-```
-
-## `rdme open`
-
-Open your current ReadMe project in the browser.
-
-```
-USAGE
-  $ rdme open [--dash]
-
-FLAGS
-  --dash  Opens your current ReadMe project dashboard.
-
-DESCRIPTION
-  Open your current ReadMe project in the browser.
 ```
 
 ## `rdme openapi [SPEC]`

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -194,7 +194,7 @@ We recommend using the [quick start](#quick-start) to get started with GitHub Ac
 The command syntax in GitHub Actions is functionally equivalent to the CLI. For example, take the following CLI command:
 
 ```sh
-rdme validate [url-or-local-path-to-file]
+rdme openapi:validate [url-or-local-path-to-file]
 ```
 
 To execute this command via GitHub Actions, the step would look like this:
@@ -202,7 +202,7 @@ To execute this command via GitHub Actions, the step would look like this:
 ```yml
 - uses: readmeio/rdme@RDME_VERSION
   with:
-    rdme: validate [url-or-local-path-to-file]
+    rdme: openapi:validate [url-or-local-path-to-file]
 ```
 
 The following section has links to full GitHub Actions workflow file examples.

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -15,6 +15,14 @@ export default class OpenCommand extends BaseCommand<typeof OpenCommand> {
     mock: Flags.boolean({ description: '[hidden] used for mocking.', hidden: true }),
   };
 
+  static hidden = true;
+
+  static state = 'deprecated';
+
+  static deprecationOptions = {
+    message: '`rdme open` is deprecated and will be removed in a future release.',
+  };
+
   async run() {
     const { dash, mock } = this.flags;
     const { apiKey, project } = getCurrentConfig();

--- a/src/commands/openapi/validate.ts
+++ b/src/commands/openapi/validate.ts
@@ -11,10 +11,6 @@ export default class OpenAPIValidateCommand extends BaseCommand<typeof OpenAPIVa
   // needed for unit tests, even though we also specify this in src/index.ts
   static id = 'openapi:validate';
 
-  static aliases = ['validate'];
-
-  static deprecateAliases = true;
-
   static args = {
     spec: Args.string({ description: 'A file/URL to your API definition' }),
   };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,6 @@
 const config = {
   host: 'https://dash.readme.com',
-  hub: 'https://{project}.readme.io', // this is only used for the `open` command
+  hub: 'https://{project}.readme.io', // this is only used for the `rdme open` command
 } as const;
 
 export default config;


### PR DESCRIPTION
## 🧰 Changes

(writing these below as such so they get picked up by `semantic-release`)

BREAKING CHANGE: `rdme validate` has been removed, use `rdme openapi:validate` instead.

BREAKING CHANGE: `rdme open` is now deprecated

also updates our docs accordingly
