### PR TITLE
fix(npm): tweak npm lifecycle scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "vitest": "^2.0.5"
   },
   "scripts": {
-    "build": "tsc && oclif manifest && oclif readme --readme-path documentation/commands.md --no-aliases",
+    "build": "tsc",
     "build:gha": "npm run build && rollup --config",
     "build:gha:prod": "npm run build:gha -- --environment PRODUCTION_BUILD",
     "lint": "alex . && knip && npm run lint:ts && npm run prettier && npm run schemas:check",
@@ -121,7 +121,8 @@
     "prettier": "prettier --check .",
     "schemas:check": "./bin/json-schema-store.js",
     "schemas:write": "./bin/json-schema-store.js --update",
-    "test": "vitest run --coverage"
+    "test": "vitest run --coverage",
+    "version": "oclif manifest && oclif readme --readme-path documentation/commands.md --no-aliases"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
## 🧰 Changes

Noticed a tiny issue where the `documentation/commands.md` file is displaying an outdated version. I'm not entirely tracking why (esp b/c the `oclif.manifest.json` file seems to have the correct version in the npm release?) but I believe that using the `version` npm lifecycle script will ensure that the file is bumped with the `npm` version that's being bumped **_to_**, rather than the one **_prior_** to bumping.

Further reading:

- https://semantic-release.gitbook.io/semantic-release/support/faq#how-can-i-use-a-npm-build-script-that-requires-the-package.jsons-version
- https://github.com/semantic-release/npm
- https://github.com/semantic-release/git
- https://docs.npmjs.com/cli/v10/commands/npm-version


## 🧬 QA & Testing

we'll have to just release this and see 🤷🏽
