### PR TITLE
feat: add `@oclif/plugin-not-found`, other cleanups

### DIFF
--- a/__tests__/commands/changelogs/index.test.ts
+++ b/__tests__/commands/changelogs/index.test.ts
@@ -276,7 +276,7 @@ describe('rdme changelogs', () => {
         message: `Error uploading ${chalk.underline(`${fullDirectory}/${slug}.md`)}:\n\n${errorObject.message}`,
       };
 
-      await expect(run([`./${fullDirectory}`, '--key', key])).rejects.toThrow(new APIError(formattedErrorObject));
+      await expect(run([`./${fullDirectory}`, '--key', key])).rejects.toStrictEqual(new APIError(formattedErrorObject));
 
       getMocks.done();
       postMocks.done();

--- a/__tests__/commands/changelogs/single.test.ts
+++ b/__tests__/commands/changelogs/single.test.ts
@@ -122,7 +122,7 @@ describe('rdme changelogs (single)', () => {
         message: `Error uploading ${chalk.underline(`${filePath}`)}:\n\n${errorObject.message}`,
       };
 
-      await expect(run([filePath, '--key', key])).rejects.toThrow(new APIError(formattedErrorObject));
+      await expect(run([filePath, '--key', key])).rejects.toStrictEqual(new APIError(formattedErrorObject));
 
       getMock.done();
     });

--- a/__tests__/commands/custompages/index.test.ts
+++ b/__tests__/commands/custompages/index.test.ts
@@ -308,7 +308,7 @@ describe('rdme custompages', () => {
         message: `Error uploading ${chalk.underline(`${fullDirectory}/${slug}.md`)}:\n\n${errorObject.message}`,
       };
 
-      await expect(run([`./${fullDirectory}`, '--key', key])).rejects.toThrow(new APIError(formattedErrorObject));
+      await expect(run([`./${fullDirectory}`, '--key', key])).rejects.toStrictEqual(new APIError(formattedErrorObject));
 
       getMocks.done();
       postMocks.done();

--- a/__tests__/commands/custompages/single.test.ts
+++ b/__tests__/commands/custompages/single.test.ts
@@ -151,7 +151,7 @@ describe('rdme custompages (single)', () => {
         message: `Error uploading ${chalk.underline(`${filePath}`)}:\n\n${errorObject.message}`,
       };
 
-      await expect(run([filePath, '--key', key])).rejects.toThrow(new APIError(formattedErrorObject));
+      await expect(run([filePath, '--key', key])).rejects.toStrictEqual(new APIError(formattedErrorObject));
 
       getMock.done();
     });

--- a/__tests__/commands/docs/__snapshots__/multiple.test.ts.snap
+++ b/__tests__/commands/docs/__snapshots__/multiple.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`rdme docs (multiple) > should return an error message when it encounters a cycle 1`] = `[Error: Cyclic dependency, node was:{"content":"\\n# Parent Body\\n","data":{"title":"Parent","parentDocSlug":"grandparent"},"filePath":"__tests__/__fixtures__/docs/multiple-docs-cycle/parent.md","hash":"0fc832371f8e240047bfc14bc8be9e37d50c8bb8","slug":"parent"}]`;

--- a/__tests__/commands/docs/index.test.ts
+++ b/__tests__/commands/docs/index.test.ts
@@ -342,7 +342,7 @@ describe('rdme docs', () => {
         message: `Error uploading ${chalk.underline(`${fullDirectory}/${slug}.md`)}:\n\n${errorObject.message}`,
       };
 
-      await expect(run([`./${fullDirectory}`, '--key', key, '--version', version])).rejects.toThrow(
+      await expect(run([`./${fullDirectory}`, '--key', key, '--version', version])).rejects.toStrictEqual(
         new APIError(formattedErrorObject),
       );
 

--- a/__tests__/commands/docs/multiple.test.ts
+++ b/__tests__/commands/docs/multiple.test.ts
@@ -162,7 +162,7 @@ describe('rdme docs (multiple)', () => {
 
     const promise = run([`./__tests__/${fixturesBaseDir}/${dir}`, '--key', key, '--version', version]);
 
-    await expect(promise).rejects.toThrow('Cyclic dependency');
+    await expect(promise).rejects.toMatchSnapshot();
     versionMock.done();
   });
 });

--- a/__tests__/commands/docs/prune.test.ts
+++ b/__tests__/commands/docs/prune.test.ts
@@ -30,8 +30,8 @@ describe('rdme docs:prune', () => {
   it('should error if the argument is not a folder', async () => {
     const versionMock = getAPIMock().get(`/api/v1/version/${version}`).basicAuth({ user: key }).reply(200, { version });
 
-    await expect(run(['--key', key, '--version', version, 'not-a-folder'])).rejects.toThrow(
-      "ENOENT: no such file or directory, scandir 'not-a-folder'",
+    await expect(run(['--key', key, '--version', version, 'not-a-folder'])).rejects.toStrictEqual(
+      new Error("ENOENT: no such file or directory, scandir 'not-a-folder'"),
     );
 
     versionMock.done();

--- a/__tests__/commands/docs/single.test.ts
+++ b/__tests__/commands/docs/single.test.ts
@@ -163,7 +163,7 @@ describe('rdme docs (single)', () => {
         message: `Error uploading ${chalk.underline(`${filePath}`)}:\n\n${errorObject.message}`,
       };
 
-      await expect(run([filePath, '--key', key, '--version', version])).rejects.toThrow(
+      await expect(run([filePath, '--key', key, '--version', version])).rejects.toStrictEqual(
         new APIError(formattedErrorObject),
       );
 

--- a/__tests__/commands/login.test.ts
+++ b/__tests__/commands/login.test.ts
@@ -105,7 +105,7 @@ describe('rdme login', () => {
 
     const mock = getAPIMock().post('/api/v1/login', { email, password, project }).reply(401, errorResponse);
 
-    await expect(run()).rejects.toThrow(new APIError(errorResponse));
+    await expect(run()).rejects.toStrictEqual(new APIError(errorResponse));
     mock.done();
   });
 
@@ -147,7 +147,7 @@ describe('rdme login', () => {
       .post('/api/v1/login', { email, password, project: projectThatIsNotYours })
       .reply(404, errorResponse);
 
-    await expect(run()).rejects.toThrow(new APIError(errorResponse));
+    await expect(run()).rejects.toStrictEqual(new APIError(errorResponse));
     mock.done();
   });
 });

--- a/__tests__/commands/openapi/__snapshots__/index.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/index.test.ts.snap
@@ -287,6 +287,8 @@ jobs:
 "
 `;
 
+exports[`rdme openapi > error handling > should throw an error if an invalid OpenAPI 3.0 definition is supplied 1`] = `[MissingPointerError: Token "Error" does not exist.]`;
+
 exports[`rdme openapi > error handling > should throw an error if an invalid OpenAPI 3.1 definition is supplied 1`] = `
 [SyntaxError: OpenAPI schema validation failed.
 

--- a/__tests__/commands/openapi/__snapshots__/validate.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/validate.test.ts.snap
@@ -172,6 +172,8 @@ ADDITIONAL PROPERTY must NOT have additional properties
   29 |         "summary": "Finds Pets by status",]
 `;
 
+exports[`rdme openapi:validate > error handling > should throw an error if an invalid OpenAPI 3.0 definition is supplied 1`] = `[MissingPointerError: Token "Error" does not exist.]`;
+
 exports[`rdme openapi:validate > error handling > should throw an error if an invalid OpenAPI 3.1 definition is supplied 1`] = `
 [SyntaxError: OpenAPI schema validation failed.
 

--- a/__tests__/commands/openapi/index.test.ts
+++ b/__tests__/commands/openapi/index.test.ts
@@ -762,7 +762,7 @@ describe('rdme openapi', () => {
           '--version',
           invalidVersion,
         ]),
-      ).rejects.toThrow(new APIError(errorObject));
+      ).rejects.toStrictEqual(new APIError(errorObject));
 
       return mock.done();
     });
@@ -824,7 +824,7 @@ describe('rdme openapi', () => {
 
       await expect(
         run([require.resolve('@readme/oas-examples/3.1/json/petstore.json'), '--key', 'key']),
-      ).rejects.toThrow(new APIError(errorObject));
+      ).rejects.toStrictEqual(new APIError(errorObject));
 
       return mock.done();
     });
@@ -874,7 +874,7 @@ describe('rdme openapi', () => {
 
       await expect(
         run(['./__tests__/__fixtures__/swagger-with-invalid-extensions.json', '--key', key, '--version', version]),
-      ).rejects.toThrow(new APIError(errorObject));
+      ).rejects.toStrictEqual(new APIError(errorObject));
 
       mockWithHeader.done();
       return mock.done();
@@ -909,7 +909,7 @@ describe('rdme openapi', () => {
           '--version',
           version,
         ]),
-      ).rejects.toThrow(new APIError(errorObject));
+      ).rejects.toStrictEqual(new APIError(errorObject));
 
       putMock.done();
       return mock.done();
@@ -932,7 +932,7 @@ describe('rdme openapi', () => {
 
       await expect(
         run(['./__tests__/__fixtures__/swagger-with-invalid-extensions.json', '--key', key, '--version', version]),
-      ).rejects.toThrow(new APIError(errorObject));
+      ).rejects.toStrictEqual(new APIError(errorObject));
 
       return mock.done();
     });
@@ -965,7 +965,7 @@ describe('rdme openapi', () => {
 
       await expect(
         run([require.resolve('@readme/oas-examples/2.0/json/petstore.json'), '--key', key, '--version', version]),
-      ).rejects.toThrow(new APIError(errorObject));
+      ).rejects.toStrictEqual(new APIError(errorObject));
 
       mockWithHeader.done();
       return mock.done();

--- a/__tests__/commands/openapi/index.test.ts
+++ b/__tests__/commands/openapi/index.test.ts
@@ -832,7 +832,7 @@ describe('rdme openapi', () => {
     it('should throw an error if an invalid OpenAPI 3.0 definition is supplied', () => {
       return expect(
         run(['./__tests__/__fixtures__/invalid-oas.json', '--key', key, '--id', id, '--version', version]),
-      ).rejects.toThrow('Token "Error" does not exist.');
+      ).rejects.toMatchSnapshot();
     });
 
     it('should throw an error if an invalid OpenAPI 3.1 definition is supplied', () => {

--- a/__tests__/commands/openapi/validate.test.ts
+++ b/__tests__/commands/openapi/validate.test.ts
@@ -83,7 +83,7 @@ describe('rdme openapi:validate', () => {
   describe('error handling', () => {
     it('should throw an error if invalid JSON is supplied', () => {
       return expect(run(['./__tests__/__fixtures__/invalid-json/yikes.json'])).rejects.toStrictEqual(
-        new Error('Unexpected end of JSON input'),
+        new SyntaxError('Unexpected end of JSON input'),
       );
     });
 

--- a/__tests__/commands/openapi/validate.test.ts
+++ b/__tests__/commands/openapi/validate.test.ts
@@ -88,9 +88,7 @@ describe('rdme openapi:validate', () => {
     });
 
     it('should throw an error if an invalid OpenAPI 3.0 definition is supplied', () => {
-      return expect(run(['./__tests__/__fixtures__/invalid-oas.json'])).rejects.toThrow(
-        'Token "Error" does not exist.',
-      );
+      return expect(run(['./__tests__/__fixtures__/invalid-oas.json'])).rejects.toMatchSnapshot();
     });
 
     it('should throw an error if an invalid OpenAPI 3.1 definition is supplied', () => {

--- a/__tests__/commands/versions/create.test.ts
+++ b/__tests__/commands/versions/create.test.ts
@@ -136,7 +136,7 @@ describe('rdme versions:create', () => {
 
     const mockRequest = getAPIMock().post('/api/v1/version').basicAuth({ user: key }).reply(400, errorResponse);
 
-    await expect(run(['--key', key, version, '--fork', '0.0.5'])).rejects.toThrow(new APIError(errorResponse));
+    await expect(run(['--key', key, version, '--fork', '0.0.5'])).rejects.toStrictEqual(new APIError(errorResponse));
     mockRequest.done();
   });
 

--- a/__tests__/commands/versions/delete.test.ts
+++ b/__tests__/commands/versions/delete.test.ts
@@ -49,7 +49,7 @@ describe('rdme versions:delete', () => {
       .basicAuth({ user: key })
       .reply(200, { version });
 
-    await expect(run(['--key', key, version])).rejects.toThrow(new APIError(errorResponse));
+    await expect(run(['--key', key, version])).rejects.toStrictEqual(new APIError(errorResponse));
     mockRequest.done();
   });
 });

--- a/__tests__/commands/versions/update.test.ts
+++ b/__tests__/commands/versions/update.test.ts
@@ -348,7 +348,7 @@ describe('rdme versions:update', () => {
       .basicAuth({ user: key })
       .reply(400, errorResponse);
 
-    await expect(run(['--key', key, version])).rejects.toThrow(new APIError(errorResponse));
+    await expect(run(['--key', key, version])).rejects.toStrictEqual(new APIError(errorResponse));
     mockRequest.done();
   });
 

--- a/__tests__/helpers/setup-oclif-config.ts
+++ b/__tests__/helpers/setup-oclif-config.ts
@@ -31,9 +31,7 @@ export function runCommand<T extends typeof OclifCommand>(Command: T) {
     return captureOutput<string>(() => Command.run(args, oclifConfig), { testNodeEnv: 'rdme-test' }).then(
       ({ error, result }) => {
         if (error) {
-          const e = new Error(error.message);
-          if (error.name) e.name = error.name;
-          throw e;
+          throw error;
         }
         return result;
       },

--- a/knip.ts
+++ b/knip.ts
@@ -4,7 +4,6 @@ const config: KnipConfig = {
   entry: ['src/index.ts', 'src/lib/help.ts', 'bin/*.js'],
   ignore: ['dist-gha/**'],
   ignoreBinaries: ['semantic-release'],
-  ignoreDependencies: ['oclif'],
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@oclif/core": "^4.0.29",
         "@oclif/plugin-autocomplete": "^3.2.6",
         "@oclif/plugin-help": "^6.2.15",
+        "@oclif/plugin-not-found": "^3.2.28",
         "@oclif/plugin-warn-if-update-available": "^3.1.19",
         "chalk": "^5.3.0",
         "ci-info": "^4.0.0",
@@ -1985,7 +1986,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.2.tgz",
       "integrity": "sha512-+gznPl8ip8P8HYHYecDtUtdsh1t2jvb+sWCD72GAiZ9m45RqwrLmReDaqdC0umQfamtFXVRoMVJ2/qINKGm9Tg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",
@@ -2005,7 +2005,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
       "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.8",
@@ -2026,7 +2025,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
       "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2039,14 +2037,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@inquirer/checkbox/node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -2056,7 +2052,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -2069,7 +2064,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2084,7 +2078,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2200,7 +2193,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.1.0.tgz",
       "integrity": "sha512-K1gGWsxEqO23tVdp5MT3H799OZ4ER1za7Dlc8F4um0W7lwSv0KGR/YyrUEyimj0g7dXZd8XknM/5QA2/Uy+TbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",
@@ -2218,7 +2210,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
       "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.8",
@@ -2239,7 +2230,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
       "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2252,14 +2242,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@inquirer/editor/node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -2269,7 +2257,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -2282,7 +2269,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2297,7 +2283,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2312,7 +2297,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.2.tgz",
       "integrity": "sha512-WdgCX1cUtinz+syKyZdJomovULYlKUWZbVYZzhf+ZeeYf4htAQ3jLymoNs3koIAKfZZl3HUBb819ClCBfyznaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",
@@ -2330,7 +2314,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
       "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.8",
@@ -2351,7 +2334,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
       "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2364,14 +2346,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@inquirer/expand/node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -2381,7 +2361,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -2394,7 +2373,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2409,7 +2387,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2424,7 +2401,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
       "integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2448,7 +2424,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.2.tgz",
       "integrity": "sha512-MKQhYofdUNk7eqJtz52KvM1dH6R93OMrqHduXCvuefKrsiMjHiMwjc3NZw5Imm2nqY7gWd9xdhYrtcHMJQZUxA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",
@@ -2465,7 +2440,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
       "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.8",
@@ -2486,7 +2460,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
       "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2499,14 +2472,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@inquirer/number/node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -2516,7 +2487,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -2529,7 +2499,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2544,7 +2513,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2559,7 +2527,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.2.tgz",
       "integrity": "sha512-tQXGSu7IO07gsYlGy3VgXRVsbOWqFBMbqAUrJSc1PDTQQ5Qdm+QVwkP0OC0jnUZ62D19iPgXOMO+tnWG+HhjNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",
@@ -2577,7 +2544,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
       "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.8",
@@ -2598,7 +2564,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
       "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2611,14 +2576,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@inquirer/password/node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -2628,7 +2591,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -2641,7 +2603,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2656,7 +2617,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2671,7 +2631,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.1.0.tgz",
       "integrity": "sha512-5U/XiVRH2pp1X6gpNAjWOglMf38/Ys522ncEHIKT1voRUvSj/DQnR22OVxHnwu5S+rCFaUiPQ57JOtMFQayqYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^4.0.2",
@@ -2696,7 +2655,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.2.tgz",
       "integrity": "sha512-KJLUHOaKnNCYzwVbryj3TNBxyZIrr56fR5N45v6K9IPrbT6B7DcudBMfylkV1A8PUdJE15mybkEQyp2/ZUpxUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",
@@ -2713,7 +2671,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
       "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.8",
@@ -2734,7 +2691,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.0.2.tgz",
       "integrity": "sha512-yCLCraigU085EcdpIVEDgyfGv4vBiE4I+k1qRkc9C5dMjWF42ADMGy1RFU94+eZlz4YlkmFsiyHZy0W1wdhaNg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",
@@ -2751,7 +2707,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.2.tgz",
       "integrity": "sha512-uSWUzaSYAEj0hlzxa1mUB6VqrKaYx0QxGBLZzU4xWFxaSyGaXxsSE4OSOwdU24j0xl8OajgayqFXW0l2bkl2kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",
@@ -2771,7 +2726,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
       "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2784,14 +2738,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@inquirer/prompts/node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -2801,7 +2753,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -2814,7 +2765,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2829,7 +2779,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2844,7 +2793,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.2.tgz",
       "integrity": "sha512-3XGcskMoVF8H0Dl1S5TSZ3rMPPBWXRcM0VeNVsS4ByWeWjSeb0lPqfnBg6N7T0608I1B2bSVnbi2cwCrmOD1Yw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",
@@ -2862,7 +2810,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
       "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.8",
@@ -2883,7 +2830,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
       "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2896,14 +2842,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@inquirer/rawlist/node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -2913,7 +2857,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -2926,7 +2869,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2941,7 +2883,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2956,7 +2897,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.2.tgz",
       "integrity": "sha512-Zv4FC7w4dJ13BOJfKRQCICQfShinGjb1bCEIHxTSnjj2telu3+3RHwHubPG9HyD4aix5s+lyAMEK/wSFD75HLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.0",
@@ -2975,7 +2915,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
       "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.8",
@@ -2996,7 +2935,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
       "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3009,14 +2947,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@inquirer/search/node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -3026,7 +2962,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -3039,7 +2974,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -3054,7 +2988,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -3554,10 +3487,9 @@
       }
     },
     "node_modules/@oclif/plugin-not-found": {
-      "version": "3.2.26",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.26.tgz",
-      "integrity": "sha512-f2kVzS/AQqYelSMEv/2sbVR8cIPpJo/AtFCNsLgmeJrETUExLy0RoOqIfk3DMlZYKBmWImwjLVhvQF13IBVTkg==",
-      "dev": true,
+      "version": "3.2.28",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.28.tgz",
+      "integrity": "sha512-ObkesXE8F4Hj/AzOCQGI39hqDqm+MfaqY5ByG77uhSkMI4dMaDcPjXZSj1Ftn2mkhZiRk70YN3wTCG4HO/8gqw==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.1.0",
@@ -3573,7 +3505,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz",
       "integrity": "sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fastest-levenshtein": "^1.0.7"
@@ -5539,7 +5470,6 @@
       "version": "22.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
       "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.8"
@@ -7297,7 +7227,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/check-error": {
@@ -7402,7 +7331,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -10062,7 +9990,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chardet": "^0.7.0",
@@ -10077,7 +10004,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
@@ -10173,7 +10099,6 @@
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
@@ -11292,7 +11217,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -15201,7 +15125,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16767,7 +16690,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/section-matter": {
@@ -18370,7 +18292,6 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unherit": {
@@ -20128,7 +20049,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
       "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "build:docs": "oclif readme --readme-path documentation/commands.md --no-aliases",
     "build:gha": "npm run build && rollup --config",
     "build:gha:prod": "npm run build:gha -- --environment PRODUCTION_BUILD",
     "lint": "alex . && knip && npm run lint:ts && npm run prettier && npm run schemas:check",
@@ -122,7 +123,7 @@
     "schemas:check": "./bin/json-schema-store.js",
     "schemas:write": "./bin/json-schema-store.js --update",
     "test": "vitest run --coverage",
-    "version": "npm run build:gha:prod && oclif manifest && oclif readme --readme-path documentation/commands.md --no-aliases"
+    "version": "npm run build:gha:prod && oclif manifest && npm run build:docs"
   },
   "commitlint": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@oclif/core": "^4.0.29",
     "@oclif/plugin-autocomplete": "^3.2.6",
     "@oclif/plugin-help": "^6.2.15",
+    "@oclif/plugin-not-found": "^3.2.28",
     "@oclif/plugin-warn-if-update-available": "^3.1.19",
     "chalk": "^5.3.0",
     "ci-info": "^4.0.0",
@@ -170,6 +171,7 @@
     "plugins": [
       "@oclif/plugin-autocomplete",
       "@oclif/plugin-help",
+      "@oclif/plugin-not-found",
       "@oclif/plugin-warn-if-update-available"
     ],
     "topics": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
       ...configDefaults.exclude,
     ],
     globalSetup: ['./__tests__/setup.js'],
+    onConsoleLog(log: string, type: 'stderr' | 'stdout'): boolean | void {
+      // hides `rdme open` deprecation warning
+      return !(log.includes('`rdme open` is deprecated and will be removed in a future release') && type === 'stderr');
+    },
     setupFiles: ['./__tests__/helpers/vitest.matchers.ts'],
   },
 });


### PR DESCRIPTION
## 🧰 Changes

- [x] introduces [`@oclif/plugin-not-found`](https://github.com/oclif/plugin-not-found/tree/main) into the mix
- [x] shuffles around our `npm` scripts a tiny bit
- [x] stronger test assertions
- [x] various lint/test output cleanups