### PR TITLE
fix: `openapi:refs` touch ups

### DIFF
--- a/__tests__/commands/openapi/refs.test.ts
+++ b/__tests__/commands/openapi/refs.test.ts
@@ -97,4 +97,14 @@ describe('openapi refs', () => {
       expect(processedOutput).toStrictEqual(expectedOutput);
     });
   });
+
+  describe('error handling', () => {
+    it.each([['json'], ['yaml']])('should fail if given a Swagger 2.0 definition (format: %s)', async format => {
+      const spec = require.resolve(`@readme/oas-examples/2.0/${format}/petstore.${format}`);
+
+      await expect(run([spec])).rejects.toStrictEqual(
+        new Error('Sorry, this ref resolver feature in rdme only supports OpenAPI 3.0+ definitions.'),
+      );
+    });
+  });
 });

--- a/__tests__/commands/openapi/refs.test.ts
+++ b/__tests__/commands/openapi/refs.test.ts
@@ -7,7 +7,7 @@ import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vite
 import Command from '../../../src/commands/openapi/refs.js';
 import { runCommandAndReturnResult } from '../../helpers/oclif.js';
 
-describe('openapi:solving-circularity-recursiveness', () => {
+describe('openapi refs', () => {
   let run: (args?: string[]) => Promise<string>;
 
   beforeAll(() => {

--- a/documentation/commands/openapi.md
+++ b/documentation/commands/openapi.md
@@ -264,7 +264,7 @@ EXAMPLES
 
   If you wish to automate this command, you can pass in CLI arguments to bypass the prompts:
 
-    $ rdme openapi:refs petstore.json -out petstore.openapi.json
+    $ rdme openapi:refs petstore.json --out petstore.openapi.json
 ```
 
 ## `rdme openapi:validate [SPEC]`

--- a/documentation/commands/openapi.md
+++ b/documentation/commands/openapi.md
@@ -245,12 +245,12 @@ FLAGS
 DESCRIPTION
   Resolves circular and recursive references in OpenAPI by replacing them with object schemas.
 
-  This command addresses limitations in ReadMe’s support for circular or recursive references within OpenAPI
-  specifications. It automatically identifies and replaces these references with simplified object schemas, ensuring
-  compatibility for seamless display in the ReadMe platform. As a result, instead of displaying an empty form, as would
-  occur with schemas containing such references, you will receive a flattened representation of the object, showing what
-  the object can potentially contain, including references to itself. Complex circular references may require manual
-  inspection and may not be fully resolved.
+  This command provides a workaround for circular or recursive references within OpenAPI definitions so they can render
+  properly in ReadMe. It automatically identifies and replaces these references with simplified object schemas, ensuring
+  compatibility for seamless display in the ReadMe API Reference. As a result, instead of displaying an empty form, as
+  would occur with schemas containing such references, you will receive a flattened representation of the object,
+  showing what the object can potentially contain, including references to itself. Complex circular references may
+  require manual inspection and may not be fully resolved.
 
 EXAMPLES
   This will resolve circular and recursive references in the OpenAPI definition at the given file or URL:

--- a/src/commands/openapi/refs.ts
+++ b/src/commands/openapi/refs.ts
@@ -312,7 +312,11 @@ export default class OpenAPIRefsCommand extends BaseCommand<typeof OpenAPIRefsCo
       this.debug(`Switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
-    const { preparedSpec, specPath } = await prepareOas(spec, 'openapi:refs', { convertToLatest: true });
+    const { preparedSpec, specPath, specType } = await prepareOas(spec, 'openapi:refs', { convertToLatest: true });
+    if (specType !== 'OpenAPI') {
+      throw new Error('Sorry, this ref resolver feature in rdme only supports OpenAPI 3.0+ definitions.');
+    }
+
     const openApiData = JSON.parse(preparedSpec);
 
     const spinner = ora({ ...oraOptions() });

--- a/src/commands/openapi/refs.ts
+++ b/src/commands/openapi/refs.ts
@@ -317,7 +317,7 @@ export default class OpenAPIRefsCommand extends BaseCommand<typeof OpenAPIRefsCo
       throw new Error('Sorry, this ref resolver feature in rdme only supports OpenAPI 3.0+ definitions.');
     }
 
-    const openApiData = JSON.parse(preparedSpec);
+    const openApiData: OASDocument = JSON.parse(preparedSpec);
 
     const spinner = ora({ ...oraOptions() });
     spinner.start('Identifying and resolving circular/recursive references in your API definition...');

--- a/src/commands/openapi/refs.ts
+++ b/src/commands/openapi/refs.ts
@@ -24,7 +24,7 @@ export default class OpenAPIRefsCommand extends BaseCommand<typeof OpenAPIRefsCo
   static summary = 'Resolves circular and recursive references in OpenAPI by replacing them with object schemas.';
 
   static description =
-    'This command addresses limitations in ReadMe’s support for circular or recursive references within OpenAPI specifications. It automatically identifies and replaces these references with simplified object schemas, ensuring compatibility for seamless display in the ReadMe platform. As a result, instead of displaying an empty form, as would occur with schemas containing such references, you will receive a flattened representation of the object, showing what the object can potentially contain, including references to itself. Complex circular references may require manual inspection and may not be fully resolved.';
+    'This command provides a workaround for circular or recursive references within OpenAPI definitions so they can render properly in ReadMe. It automatically identifies and replaces these references with simplified object schemas, ensuring compatibility for seamless display in the ReadMe API Reference. As a result, instead of displaying an empty form, as would occur with schemas containing such references, you will receive a flattened representation of the object, showing what the object can potentially contain, including references to itself. Complex circular references may require manual inspection and may not be fully resolved.';
 
   static args = {
     spec: Args.string({ description: 'A file/URL to your API definition' }),


### PR DESCRIPTION
## 🧰 Changes

Touched up a few things in https://github.com/readmeio/rdme/pull/1063!

- [x] Documentation copy edits
- [x] Logging touch ups
- [x] Makes sure we're only allowing this to be run against OpenAPI
- [ ] Adds a stricter type in https://github.com/readmeio/rdme/pull/1103/commits/81607ca4a8b7cd2e8f5a56e2ce26c421a2248cf9 that ends up breaking the build — I believe this is a code smell. @olehshh can you look into fixing the type errors here?

## 🧬 QA & Testing

Are my changes sound?
