### PR TITLE
docs: remove a few redundant flag descriptions

### DIFF
--- a/documentation/commands/categories.md
+++ b/documentation/commands/categories.md
@@ -38,8 +38,8 @@ FLAG DESCRIPTIONS
 
   --version=<value>  ReadMe project version
 
-    Your ReadMe project version. If running command in a CI environment and this option is not passed, the main project
-    version will be used. See our docs for more information: https://docs.readme.com/main/docs/versions
+    If running command in a CI environment and this option is not passed, the main project version will be used. See our
+    docs for more information: https://docs.readme.com/main/docs/versions
 ```
 
 ## `rdme categories create TITLE`
@@ -87,6 +87,6 @@ FLAG DESCRIPTIONS
 
   --version=<value>  ReadMe project version
 
-    Your ReadMe project version. If running command in a CI environment and this option is not passed, the main project
-    version will be used. See our docs for more information: https://docs.readme.com/main/docs/versions
+    If running command in a CI environment and this option is not passed, the main project version will be used. See our
+    docs for more information: https://docs.readme.com/main/docs/versions
 ```

--- a/documentation/commands/docs.md
+++ b/documentation/commands/docs.md
@@ -56,8 +56,8 @@ FLAG DESCRIPTIONS
 
   --version=<value>  ReadMe project version
 
-    Your ReadMe project version. If running command in a CI environment and this option is not passed, the main project
-    version will be used. See our docs for more information: https://docs.readme.com/main/docs/versions
+    If running command in a CI environment and this option is not passed, the main project version will be used. See our
+    docs for more information: https://docs.readme.com/main/docs/versions
 ```
 
 ## `rdme docs prune FOLDER`
@@ -105,6 +105,6 @@ FLAG DESCRIPTIONS
 
   --version=<value>  ReadMe project version
 
-    Your ReadMe project version. If running command in a CI environment and this option is not passed, the main project
-    version will be used. See our docs for more information: https://docs.readme.com/main/docs/versions
+    If running command in a CI environment and this option is not passed, the main project version will be used. See our
+    docs for more information: https://docs.readme.com/main/docs/versions
 ```

--- a/documentation/commands/openapi.md
+++ b/documentation/commands/openapi.md
@@ -108,13 +108,12 @@ FLAG DESCRIPTIONS
 
   --update  Bypasses the create/update prompt and automatically updates an existing API definition in ReadMe.
 
-    Bypasses the create/update prompt and automatically updates an existing API definition in ReadMe. Note that this
-    flag only works if there's only one API definition associated with the current version.
+    Note that this flag only works if there's only one API definition associated with the current version.
 
   --version=<value>  ReadMe project version
 
-    Your ReadMe project version. If running command in a CI environment and this option is not passed, the main project
-    version will be used. See our docs for more information: https://docs.readme.com/main/docs/versions
+    If running command in a CI environment and this option is not passed, the main project version will be used. See our
+    docs for more information: https://docs.readme.com/main/docs/versions
 ```
 
 ## `rdme openapi convert [SPEC]`

--- a/src/commands/openapi/index.ts
+++ b/src/commands/openapi/index.ts
@@ -58,7 +58,7 @@ export default class OpenAPICommand extends BaseCommand<typeof OpenAPICommand> {
     }),
     update: Flags.boolean({
       description:
-        "Bypasses the create/update prompt and automatically updates an existing API definition in ReadMe. Note that this flag only works if there's only one API definition associated with the current version.",
+        "Note that this flag only works if there's only one API definition associated with the current version.",
       summary: 'Bypasses the create/update prompt and automatically updates an existing API definition in ReadMe.',
     }),
   };

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -27,7 +27,7 @@ export const titleFlag = Flags.string({
  */
 export const versionFlag = Flags.string({
   description:
-    'Your ReadMe project version. If running command in a CI environment and this option is not passed, the main project version will be used. See our docs for more information: https://docs.readme.com/main/docs/versions',
+    'If running command in a CI environment and this option is not passed, the main project version will be used. See our docs for more information: https://docs.readme.com/main/docs/versions',
   summary: 'ReadMe project version',
 });
 


### PR DESCRIPTION
## 🧰 Changes

i realized that the `summary` and `description` fields are shown right next to each other so we can remove some of the duplication.