### PR TITLE
fix: executable issue for linux users

### DIFF
--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env -S npx tsx
 
 async function main() {
   const { execute } = await import('@oclif/core');

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings=ExperimentalWarning
+#!/usr/bin/env -S node --no-warnings=ExperimentalWarning
 // ^ we need this env variable above to hide the ExperimentalWarnings
 // source: https://github.com/nodejs/node/issues/10802#issuecomment-573376999
 


### PR DESCRIPTION
## 🧰 Changes

Linux requires the `-S` flag when passing options to `node` command-line in executable files. This was fun to troubleshoot 🥴

## 🧬 QA & Testing

Can Linux users run the CLI again? 😮‍💨
