### PR TITLE
fix(autocomplete): bad alias

### DIFF
--- a/src/commands/docs/prune.ts
+++ b/src/commands/docs/prune.ts
@@ -26,7 +26,8 @@ export default class DocsPruneCommand extends BaseCommand<typeof DocsPruneComman
     message: `\`rdme ${this.id}\` is deprecated and will be removed in v10. For more information, please visit our migration guide: https://github.com/readmeio/rdme/tree/v9/documentation/migration-guide.md`,
   };
 
-  static aliases = ['guides prune'];
+  // this needs to be separated by a colon in order for autocomplete to work properly
+  static aliases = ['guides:prune'];
 
   static description = 'Delete any docs from ReadMe if their slugs are not found in the target folder.';
 


### PR DESCRIPTION
## 🧰 Changes

autocompletions were broken, seemingly due to the `guides prune` alias:

![CleanShot 2024-12-10 at 16 22 42@2x](https://github.com/user-attachments/assets/5ecc8b35-895c-4150-9553-821e3e7ba7cf)

thankfully the fix is harmless and shouldn't result in any actual end user changes.
