### PR TITLE
fix: bring back #1117 without breaking everything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,6 @@ jobs:
           rdme: openapi "oas-examples-repo/3.1/json/petstore.json" --key "${{ secrets.RDME_TEST_PROJECT_API_KEY }}" --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}
 
       - name: Run `openapi` command with weird arg syntax
-        uses: readmeio/rdme@next
-        if: ${{ github.ref }} == 'refs/heads/next'
+        uses: readmeio/rdme@${{ github.sha }}
         with:
           rdme: openapi validate "oas-examples-repo/3.1/json/petstore.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,8 @@ jobs:
         with:
           rdme: openapi "oas-examples-repo/3.1/json/petstore.json" --key "${{ secrets.RDME_TEST_PROJECT_API_KEY }}" --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}
 
+      # this is a test to ensure that the rdme github action can run properly
+      # the way that our users invoke it
       - name: E2E run of `openapi validate` on `next` branch
         uses: readmeio/rdme@next
         if: ${{ github.ref }} == 'refs/heads/next'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
           rdme: openapi "oas-examples-repo/3.1/json/petstore.json" --key "${{ secrets.RDME_TEST_PROJECT_API_KEY }}" --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}
 
       - name: Run `openapi` command with weird arg syntax
-        uses: readmeio/rdme@${{ github.sha }}
+        uses: readmeio/rdme@next
+        if: ${{ github.ref }} == 'refs/heads/next'
         with:
           rdme: openapi validate "oas-examples-repo/3.1/json/petstore.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,8 @@ jobs:
         with:
           rdme: openapi "oas-examples-repo/3.1/json/petstore.json" --key "${{ secrets.RDME_TEST_PROJECT_API_KEY }}" --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}
 
-      - name: Run `openapi` command with weird arg syntax
+      - name: E2E run of `openapi validate` on `next` branch
         uses: readmeio/rdme@next
         if: ${{ github.ref }} == 'refs/heads/next'
         with:
-          rdme: openapi validate "oas-examples-repo/3.1/json/petstore.json"
+          rdme: openapi validate oas-examples-repo/3.1/json/petstore.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,9 @@ jobs:
         uses: ./rdme-repo/
         with:
           rdme: openapi "oas-examples-repo/3.1/json/petstore.json" --key "${{ secrets.RDME_TEST_PROJECT_API_KEY }}" --id=${{ secrets.RDME_TEST_PROJECT_API_SETTING }}
+
+      - name: Run `openapi` command with weird arg syntax
+        uses: readmeio/rdme@next
+        if: ${{ github.ref }} == 'refs/heads/next'
+        with:
+          rdme: openapi validate "oas-examples-repo/3.1/json/petstore.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,20 @@ jobs:
         with:
           github_token: ${{ secrets.RELEASE_GH_TOKEN }}
           branch: next
+
+  # quick assertion to validate that rdme CLI can be installed and run on ubuntu
+  postrelease:
+    name: Post-release checks
+    needs: release
+    runs-on: ubuntu-latest
+    if: ${{ github.ref }} == 'refs/heads/next'
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install `rdme` from npm
+        run: npm install -g rdme@next
+      - name: Print rdme CLI version
+        run: rdme --version
+        timeout-minutes: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,19 +49,11 @@ jobs:
           github_token: ${{ secrets.RELEASE_GH_TOKEN }}
           branch: next
 
-  # quick assertion to validate that rdme CLI can be installed and run on ubuntu
-  postrelease:
-    name: Post-release checks
-    needs: release
-    runs-on: ubuntu-latest
-    if: ${{ github.ref }} == 'refs/heads/next'
-    steps:
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
+      # quick assertion to validate that rdme CLI can be installed and run on ubuntu
       - name: Install `rdme` from npm
+        if: ${{ github.ref }} == 'refs/heads/next'
         run: npm install -g rdme@next
       - name: Print rdme CLI version
+        if: ${{ github.ref }} == 'refs/heads/next'
         run: rdme --version
         timeout-minutes: 1

--- a/__tests__/commands/logout.test.ts
+++ b/__tests__/commands/logout.test.ts
@@ -1,6 +1,6 @@
 import { describe, afterEach, beforeAll, it, expect } from 'vitest';
 
-import pkg from '../../package.json';
+import pkg from '../../package.json' with { type: 'json' };
 import Command from '../../src/commands/logout.js';
 import configStore from '../../src/lib/configstore.js';
 import { runCommandAndReturnResult } from '../helpers/oclif.js';

--- a/__tests__/commands/open.test.ts
+++ b/__tests__/commands/open.test.ts
@@ -3,7 +3,7 @@ import type { Version } from '../../src/commands/versions/index.js';
 import chalk from 'chalk';
 import { describe, afterEach, beforeAll, it, expect } from 'vitest';
 
-import pkg from '../../package.json';
+import pkg from '../../package.json' with { type: 'json' };
 import Command from '../../src/commands/open.js';
 import configStore from '../../src/lib/configstore.js';
 import { getAPIv1Mock } from '../helpers/get-api-mock.js';

--- a/__tests__/commands/whoami.test.ts
+++ b/__tests__/commands/whoami.test.ts
@@ -1,6 +1,6 @@
 import { describe, afterEach, it, expect, beforeAll } from 'vitest';
 
-import pkg from '../../package.json';
+import pkg from '../../package.json' with { type: 'json' };
 import Command from '../../src/commands/whoami.js';
 import configStore from '../../src/lib/configstore.js';
 import { runCommandAndReturnResult } from '../helpers/oclif.js';

--- a/__tests__/helpers/get-gha-setup.ts
+++ b/__tests__/helpers/get-gha-setup.ts
@@ -6,7 +6,7 @@ import { vi } from 'vitest';
 
 import configstore from '../../src/lib/configstore.js';
 import { git } from '../../src/lib/createGHA/index.js';
-import * as getPkgVersion from '../../src/lib/getPkgVersion.js';
+import * as getPkgVersion from '../../src/lib/getPkg.js';
 
 import getGitRemoteMock from './get-git-mock.js';
 

--- a/__tests__/lib/createGHA.test.ts
+++ b/__tests__/lib/createGHA.test.ts
@@ -10,7 +10,7 @@ import { describe, beforeEach, afterEach, it, expect, vi, type MockInstance, bef
 
 import configstore from '../../src/lib/configstore.js';
 import { getConfigStoreKey, getGHAFileName, git } from '../../src/lib/createGHA/index.js';
-import { getMajorPkgVersion } from '../../src/lib/getPkgVersion.js';
+import { getMajorPkgVersion } from '../../src/lib/getPkg.js';
 import { after, before } from '../helpers/get-gha-setup.js';
 import getGitRemoteMock from '../helpers/get-git-mock.js';
 import ghaWorkflowSchema from '../helpers/github-workflow-schema.json' with { type: 'json' };

--- a/__tests__/lib/getPkgVersion.test.ts
+++ b/__tests__/lib/getPkgVersion.test.ts
@@ -3,7 +3,7 @@ import semver from 'semver';
 import { describe, beforeEach, afterEach, it, expect, vi, type MockInstance } from 'vitest';
 
 import pkg from '../../package.json' with { type: 'json' };
-import { getNodeVersion, getPkgVersion } from '../../src/lib/getPkgVersion.js';
+import { getNodeVersion, getPkgVersion, getPkgVersionFromNPM } from '../../src/lib/getPkg.js';
 
 describe('#getNodeVersion()', () => {
   it('should extract version that matches range in package.json', () => {
@@ -27,7 +27,7 @@ describe('#getPkgVersion()', () => {
   });
 
   it('should grab version from package.json by default', () => {
-    return expect(getPkgVersion()).resolves.toBe(pkg.version);
+    return expect(getPkgVersion()).toBe(pkg.version);
   });
 
   it('should fetch version from npm registry', async () => {
@@ -35,7 +35,7 @@ describe('#getPkgVersion()', () => {
       .get('/rdme')
       .reply(200, { 'dist-tags': { latest: '1.0' } });
 
-    await expect(getPkgVersion('latest')).resolves.toBe('1.0');
+    await expect(getPkgVersionFromNPM('latest')).resolves.toBe('1.0');
 
     mock.done();
   });
@@ -43,7 +43,7 @@ describe('#getPkgVersion()', () => {
   it('should fallback if npm registry fails', async () => {
     const mock = nock('https://registry.npmjs.com', { encodedQueryParams: true }).get('/rdme').reply(500);
 
-    await expect(getPkgVersion('latest')).resolves.toBe(pkg.version);
+    await expect(getPkgVersionFromNPM('latest')).resolves.toBe(pkg.version);
 
     mock.done();
   });

--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S npx tsx
+#!/usr/bin/env npx tsx
 
 async function main() {
   const { execute } = await import('@oclif/core');

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,6 +1,4 @@
-#!/usr/bin/env -S node --no-warnings=ExperimentalWarning
-// ^ we need this env variable above to hide the ExperimentalWarnings
-// source: https://github.com/nodejs/node/issues/10802#issuecomment-573376999
+#!/usr/bin/env node
 
 import stringArgv from 'string-argv';
 

--- a/bin/set-version-output.js
+++ b/bin/set-version-output.js
@@ -3,7 +3,7 @@
 import * as core from '@actions/core';
 
 // eslint-disable-next-line import/extensions
-import { getNodeVersion, getMajorPkgVersion } from '../dist/lib/getPkgVersion.js';
+import { getNodeVersion, getMajorPkgVersion } from '../dist/lib/getPkg.js';
 
 /**
  * Sets output parameters for GitHub Actions workflow so we can do

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "vitest": "^2.0.5"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && ln package.json dist/package.json",
     "build:docs": "oclif readme --multi --output-dir documentation/commands --no-aliases",
     "build:gha": "npm run build && rollup --config",
     "build:gha:prod": "npm run build:gha -- --environment PRODUCTION_BUILD",

--- a/src/lib/configstore.ts
+++ b/src/lib/configstore.ts
@@ -1,6 +1,6 @@
 import Configstore from 'configstore';
 
-import pkg from '../package.json' with { type: 'json' };
+import { pkg } from './getPkg.js';
 
 const configstore = new Configstore(
   /**

--- a/src/lib/createGHA/index.ts
+++ b/src/lib/createGHA/index.ts
@@ -8,7 +8,7 @@ import prompts from 'prompts';
 import { simpleGit } from 'simple-git';
 
 import configstore from '../configstore.js';
-import { getMajorPkgVersion } from '../getPkgVersion.js';
+import { getMajorPkgVersion } from '../getPkg.js';
 import isCI, { isNpmScript, isTest } from '../isCI.js';
 import { info } from '../logger.js';
 import promptTerminal from '../promptWrapper.js';

--- a/src/lib/getPkg.ts
+++ b/src/lib/getPkg.ts
@@ -20,7 +20,7 @@ type npmDistTag = 'latest';
  * @see {@link https://nodejs.org/docs/latest-v20.x/api/esm.html#import-attributes}
  * @see {@link https://www.stefanjudis.com/snippets/how-to-import-json-files-in-es-modules-node-js/}
  */
-export const pkg = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), { encoding: 'utf-8' }));
+export const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), { encoding: 'utf-8' }));
 
 /**
  * Return the major Node.js version specified in our `package.json` config.

--- a/src/lib/readmeAPIFetch.ts
+++ b/src/lib/readmeAPIFetch.ts
@@ -5,11 +5,10 @@ import path from 'node:path';
 import mime from 'mime-types';
 import { ProxyAgent } from 'undici';
 
-import pkg from '../package.json' with { type: 'json' };
-
 import { APIv1Error } from './apiError.js';
 import config from './config.js';
 import { git } from './createGHA/index.js';
+import { getPkgVersion } from './getPkg.js';
 import isCI, { ciName, isGHA } from './isCI.js';
 import { debug, warn } from './logger.js';
 
@@ -90,7 +89,7 @@ function parseWarningHeader(header: string): WarningHeader[] {
  */
 export function getUserAgent() {
   const gh = isGHA() ? '-github' : '';
-  return `rdme${gh}/${pkg.version}`;
+  return `rdme${gh}/${getPkgVersion()}`;
 }
 
 /**


### PR DESCRIPTION
## 🧰 Changes

we hit a bit of a wild edge case where the github action was only breaking in production builds due to how oclif loads the `package.json` and the only way we caught it was with [this failure](https://github.com/readmeio/rdme/actions/runs/12267183540/job/34226921877).

this PR reverts https://github.com/readmeio/rdme/pull/1119 (which in turn brings back https://github.com/readmeio/rdme/pull/1117) with a slight tweak in https://github.com/readmeio/rdme/pull/1120/commits/f9461b430e2318c00731c4f75d1506cd593d4970 to do the following:
- make our import paths friendlier to github actions
- manually copy over the `package.json` to our `dist/` directory whenever we run `npm run build`. TS was automatically handling this when we were using JSON imports before but now it's not able to pick up on the import so we have to copy it over ourselves.

additionally in https://github.com/readmeio/rdme/pull/1120/commits/669cb4f2854ff775023eeec3895b70998c70f920, i added a little check so we can catch these sorts of things better going forward.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
