### PR TITLE
docs: v9 doc touch-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ With `rdme`, you can manage your API definition (we support [OpenAPI](https://sp
 Not using ReadMe for your docs? No worries. `rdme` has a variety of tools to help you identify issues with your API definition — no ReadMe account required.
 
 > [!WARNING]
-> Heads up: our [new ReadMe Refactored experience](https://docs.readme.com/main/docs/welcome-to-readme-refactored) doesn’t yet support `rdme`. If your project is using the new ReadMe Refactored experience, we recommend [enabling bi-directional syncing via Git](https://docs.readme.com/main/docs/bi-directional-sync) for an even better editing experience for the technical and non-technical users on your team!
+> Heads up: if you're using the [new ReadMe Refactored experience](https://docs.readme.com/main/docs/welcome-to-readme-refactored), you'll want to use `rdme@10` instead. Head over to [our migration guide](https://github.com/readmeio/rdme/tree/v10/documentation/migration-guide.md) for more information.
 
 # Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ With `rdme`, you can manage your API definition (we support [OpenAPI](https://sp
 Not using ReadMe for your docs? No worries. `rdme` has a variety of tools to help you identify issues with your API definition — no ReadMe account required.
 
 > [!WARNING]
-> Heads up: if you're using the [new ReadMe Refactored experience](https://docs.readme.com/main/docs/welcome-to-readme-refactored), you'll want to use `rdme@10` instead. Head over to [our migration guide](https://github.com/readmeio/rdme/tree/v10/documentation/migration-guide.md) for more information.
+> If you're using the [new ReadMe Refactored experience](https://docs.readme.com/main/docs/welcome-to-readme-refactored), you'll want to use `rdme@10` instead. Head over to [our migration guide](https://github.com/readmeio/rdme/blob/next/documentation/migration-guide.md) for more information.
 
 # Table of Contents
 

--- a/documentation/migration-guide.md
+++ b/documentation/migration-guide.md
@@ -28,10 +28,8 @@ npx markdown-toc documentation/migration-guide.md --maxdepth 2 --bullets="-" -i
 ## Migrating to `rdme@10`
 
 <!-- prettier-ignore-start -->
-> [!WARNING]
-> `rdme@10` has not been released yet, so this section is still under construction.
->
-> [Please verify that you're looking at the latest docs for v9](https://github.com/readmeio/rdme/tree/v9/documentation/migration-guide.md). If you're using ReadMe Refactored, stay tuned!
+> [!NOTE]
+> If you're using ReadMe Refactored, you'll want to use `rdme@10` or later. The `v10` migration guide can be found [here](https://github.com/readmeio/rdme/tree/v10/documentation/migration-guide.md).
 <!-- prettier-ignore-end -->
 
 ## Migrating to `rdme@9`


### PR DESCRIPTION
## 🧰 Changes

doc updates that we should push to the `v9` channel right before we release `v10`! see https://github.com/readmeio/rdme/pull/1113 for the sequencing of all of this.
