### PR TITLE
chore: cleaning up some type imports

### DIFF
--- a/__tests__/commands/openapi/reduce.test.ts
+++ b/__tests__/commands/openapi/reduce.test.ts
@@ -1,9 +1,11 @@
 /* eslint-disable no-console */
+import type { MockInstance } from 'vitest';
+
 import fs from 'node:fs';
 
 import chalk from 'chalk';
 import prompts from 'prompts';
-import { describe, beforeAll, beforeEach, afterEach, it, expect, vi, type MockInstance } from 'vitest';
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 
 import Command from '../../../src/commands/openapi/reduce.js';
 import { runCommandAndReturnResult } from '../../helpers/oclif.js';

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -1,3 +1,5 @@
+import type { OclifOutput } from '../../helpers/oclif.js';
+
 import nock from 'nock';
 import prompts from 'prompts';
 import slugify from 'slugify';
@@ -6,7 +8,7 @@ import { describe, beforeAll, beforeEach, afterEach, it, expect } from 'vitest';
 import Command from '../../../src/commands/openapi/upload.js';
 import petstore from '../../__fixtures__/petstore-simple-weird-version.json' with { type: 'json' };
 import { getAPIv2Mock, getAPIv2MockForGHA } from '../../helpers/get-api-mock.js';
-import { runCommand, type OclifOutput } from '../../helpers/oclif.js';
+import { runCommand } from '../../helpers/oclif.js';
 import { after, before } from '../../helpers/setup-gha-env.js';
 
 const key = 'rdme_123';

--- a/__tests__/commands/openapi/validate.test.ts
+++ b/__tests__/commands/openapi/validate.test.ts
@@ -1,10 +1,11 @@
 /* eslint-disable no-console */
+import type { MockInstance } from 'vitest';
 
 import fs from 'node:fs';
 
 import chalk from 'chalk';
 import prompts from 'prompts';
-import { describe, beforeAll, beforeEach, afterEach, it, expect, vi, type MockInstance } from 'vitest';
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 
 import Command from '../../../src/commands/openapi/validate.js';
 import { after, before } from '../../helpers/get-gha-setup.js';

--- a/__tests__/lib/createGHA.test.ts
+++ b/__tests__/lib/createGHA.test.ts
@@ -2,11 +2,12 @@
 /* eslint-disable no-console */
 import type { Command, Config } from '@oclif/core';
 import type { Response } from 'simple-git';
+import type { MockInstance } from 'vitest';
 
 import fs from 'node:fs';
 
 import prompts from 'prompts';
-import { describe, beforeEach, afterEach, it, expect, vi, type MockInstance, beforeAll } from 'vitest';
+import { describe, beforeEach, afterEach, it, expect, vi, beforeAll } from 'vitest';
 
 import configstore from '../../src/lib/configstore.js';
 import { getConfigStoreKey, getGHAFileName, git } from '../../src/lib/createGHA/index.js';

--- a/__tests__/lib/fetch.test.ts
+++ b/__tests__/lib/fetch.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
+import type { MockInstance } from 'vitest';
+
 import nock from 'nock';
-import { describe, beforeEach, afterEach, it, expect, vi, beforeAll, type MockInstance } from 'vitest';
+import { describe, beforeEach, afterEach, it, expect, vi, beforeAll } from 'vitest';
 
 import pkg from '../../package.json' with { type: 'json' };
 import { cleanAPIv1Headers, handleAPIv1Res, readmeAPIv1Fetch } from '../../src/lib/readmeAPIFetch.js';

--- a/__tests__/lib/getPkgVersion.test.ts
+++ b/__tests__/lib/getPkgVersion.test.ts
@@ -1,6 +1,8 @@
+import type { MockInstance } from 'vitest';
+
 import nock from 'nock';
 import semver from 'semver';
-import { describe, beforeEach, afterEach, it, expect, vi, type MockInstance } from 'vitest';
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 
 import pkg from '../../package.json' with { type: 'json' };
 import { getNodeVersion, getPkgVersion, getPkgVersionFromNPM } from '../../src/lib/getPkg.js';

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -1,4 +1,5 @@
 import type { CreateGHAHook, CreateGHAHookOptsInClass } from './hooks/createGHA.js';
+import type { FilePathDetails } from './readmeAPIFetch.js';
 import type { Config, Hook, Interfaces } from '@oclif/core';
 
 import { format } from 'node:util';
@@ -9,7 +10,7 @@ import chalk from 'chalk';
 import debugPkg from 'debug';
 
 import { isGHA, isTest } from './isCI.js';
-import { handleAPIv2Res, readmeAPIv2Fetch, type FilePathDetails } from './readmeAPIFetch.js';
+import { handleAPIv2Res, readmeAPIv2Fetch } from './readmeAPIFetch.js';
 
 type Flags<T extends typeof OclifCommand> = Interfaces.InferredFlags<(typeof BaseCommand)['baseFlags'] & T['flags']>;
 type Args<T extends typeof OclifCommand> = Interfaces.InferredArgs<T['args']>;

--- a/src/lib/hooks/prerun.ts
+++ b/src/lib/hooks/prerun.ts
@@ -1,4 +1,6 @@
-import { Flags, type Hook } from '@oclif/core';
+import type { Hook } from '@oclif/core';
+
+import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
 import configstore from '../configstore.js';

--- a/src/lib/readmeAPIFetch.ts
+++ b/src/lib/readmeAPIFetch.ts
@@ -1,3 +1,4 @@
+import type { APIv2ErrorResponse } from './apiError.js';
 import type { SpecFileType } from './prepareOas.js';
 import type { Command } from '@oclif/core';
 
@@ -6,7 +7,7 @@ import path from 'node:path';
 import mime from 'mime-types';
 import { ProxyAgent } from 'undici';
 
-import { APIv1Error, APIv2Error, type APIv2ErrorResponse } from './apiError.js';
+import { APIv1Error, APIv2Error } from './apiError.js';
 import config from './config.js';
 import { git } from './createGHA/index.js';
 import { getPkgVersion } from './getPkg.js';


### PR DESCRIPTION
## 🧰 Changes

This just cleans up some `import type { typeName} from ...` imports so that they're imported that way instead of as `import { type typeName }` from ...`. We generally use `import type` everywhere already there's just some stragglers that sometimes get through the other way via VSCode.