### PR TITLE
fix(openapi): type fixes in `prepareOas`

### DIFF
--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -101,7 +101,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
   async run() {
     const { spec } = this.args;
 
-    const { preparedSpec, specFileType, specPath, specVersion } = await prepareOas(spec, 'openapi');
+    const { preparedSpec, specFileType, specPath, specVersion } = await prepareOas(spec, 'openapi upload');
 
     const version = this.flags.useSpecVersion ? specVersion : this.flags.version;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,3 +35,13 @@ export const COMMANDS = {
 
   whoami: WhoAmICommand,
 };
+
+/**
+ * A type-safe way to get the command IDs in the CLI for a specific topic.
+ *
+ * @example type OpenAPIAction = CommandIdForTopic<'openapi'>;
+ */
+export type CommandIdForTopic<
+  T extends 'openapi',
+  U extends keyof typeof COMMANDS = keyof typeof COMMANDS,
+> = U extends `${T}:${infer Suffix}` ? `${Suffix}` : never;

--- a/src/lib/prepareOas.ts
+++ b/src/lib/prepareOas.ts
@@ -1,3 +1,4 @@
+import type { CommandIdForTopic } from '../index.js';
 import type { OpenAPI } from 'openapi-types';
 
 import chalk from 'chalk';
@@ -36,7 +37,7 @@ function truthy<T>(value: T): value is Truthy<T> {
   return !!value;
 }
 
-type OpenAPIAction = 'convert' | 'inspect' | 'reduce' | 'upload' | 'validate';
+type OpenAPIAction = CommandIdForTopic<'openapi'>;
 
 const capitalizeSpecType = (type: string) =>
   type === 'openapi' ? 'OpenAPI' : type.charAt(0).toUpperCase() + type.slice(1);


### PR DESCRIPTION
## 🧰 Changes

when reviewing https://github.com/readmeio/rdme/pull/1126, i noticed a few small bugs in our `prepareOas` helper function. this PR makes a few typesafety improvements so we shouldn't run into this issue again(?)

~~one outstanding question that i'd like to figure out prior to merge, see https://github.com/readmeio/rdme/issues/1142~~ (**edit**: going to continue bundling and handle this issue in a follow-up PR)

## 🧬 QA & Testing

do tests + types pass?