### PR TITLE
chore: backport v9 changes back to v10

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,7 +4,7 @@ branches:
   - name: next
     prerelease: true
   - name: v9
-    channel: 9.x
+    range: 9.x
 
 plugins:
   - '@semantic-release/commit-analyzer'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 * **openapi:** type fixes in `prepareOas` ([#1141](https://github.com/readmeio/rdme/issues/1141)) ([fc55d28](https://github.com/readmeio/rdme/commit/fc55d285658e7918bc697398d7c2b10e8a39cacc))
 
+# [9.1.0](https://github.com/readmeio/rdme/compare/v9.0.5...v9.1.0) (2025-01-06)
+
+
+### Features
+
+* **v9:** backport openapi tooling etc. from v10 ([#1145](https://github.com/readmeio/rdme/issues/1145)) ([14828db](https://github.com/readmeio/rdme/commit/14828db4aa8d29c2509198ed2be53b91e9ce3fdb))
+
 # [10.1.0-next.2](https://github.com/readmeio/rdme/compare/v10.1.0-next.1...v10.1.0-next.2) (2025-01-06)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,13 +101,13 @@ When writing command logic, avoid using `console` statements (and correspondingl
 
 <summary><b>Updated Guidance</b></summary>
 
-When writing command logic, avoid using `console` statements. As modeled by [the `openapi upload` command](./src/commands/openapi/upload.ts), we use [`oclif`'s command methods](https://oclif.io/docs/commands/#command-methods) for writing to the console. This allows us to seamlessly integrate [`oclif`'s support for JSON output](https://oclif.io/docs/json/).
+When writing command logic, avoid using `console` statements. As modeled by [the `openapi upload` command](https://github.com/readmeio/rdme/blob/1e199064b0418b11b56ce08bad3d96ff2bead10c/src/commands/openapi/upload.ts) (only available in `v10` and above), we use [`oclif`'s command methods](https://oclif.io/docs/commands/#command-methods) for writing to the console. This allows us to seamlessly integrate [`oclif`'s support for JSON output](https://oclif.io/docs/json/).
 
 [The `@oclif/test` helper](https://github.com/oclif/test) automatically mocks any writes to `stdout` or `stderr`. This is great for properly asserting `rdme` outputs, but can be a bit confusing to develop with at first if you rely on `console.log` as part of your debugging since those statements won't get written to the console the way you'd expect.
 
 If you rely on `console.log` (or something similar) during development, you can do the following to view your output:
 
-1. Make sure you're using the `runCommand` helper in [this file](./__tests__/helpers/oclif.ts) and **not** `runCommandAndReturnResult`. See [this test file](./__tests__/commands/openapi/upload.test.ts) for an example.
+1. Make sure you're using the `runCommand` helper in [this file](https://github.com/readmeio/rdme/blob/1e199064b0418b11b56ce08bad3d96ff2bead10c/__tests__/helpers/oclif.ts) and **not** `runCommandAndReturnResult`. See [this test file](https://github.com/readmeio/rdme/blob/1e199064b0418b11b56ce08bad3d96ff2bead10c/__tests__/commands/openapi/upload.test.ts) for an example.
 
 2. Add a statement like this in your test:
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To set this up, check out [1Password's documentation on the ReadMe shell plugin]
 
 ```sh
 export HTTPS_PROXY=https://proxy.example.com:5678
-rdme openapi upload
+rdme login
 ```
 
 # GitHub Actions Configuration


### PR DESCRIPTION
## 🧰 Changes

takes the following changes from `v9` and reapplies them into `next` so the branches are in sync:

- [x] https://github.com/readmeio/rdme/pull/1145
- [x] https://github.com/readmeio/rdme/commit/1cb1c4da74d79e25a9e4b95417d89892866f632c
- [x] https://github.com/readmeio/rdme/commit/44779e26d840212f9793fd3f457218e1c1107719

very curious if there's a better way to do this lol

## 🧬 QA & Testing

do tests pass?
