### PR TITLE
fix(v9): point to correct dist-tag for outdated version notifications

### DIFF
--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,7 +1,15 @@
 #!/usr/bin/env npx tsx
 
 async function main() {
+  /**
+   * This is a v9-specific change to ensure that we're pointing to the
+   * correct npm release channel for version upgrade checks.
+   * Once we deprecate v9, we can remove this line.
+   *
+   * @see {@link https://github.com/oclif/plugin-warn-if-update-available/blob/75634b0cdb6a605b9ecb503576461e60ba9a37b1/README.md?plain=1#L136}
+   */
   process.env.RDME_NEW_VERSION_CHECK_TAG = 'release-v9';
+
   const { execute } = await import('@oclif/core');
   await execute({ development: true, dir: import.meta.url }).then(msg => {
     if (msg && typeof msg === 'string') {

--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env npx tsx
 
 async function main() {
+  process.env.RDME_NEW_VERSION_CHECK_TAG = 'release-v9';
   const { execute } = await import('@oclif/core');
   await execute({ development: true, dir: import.meta.url }).then(msg => {
     if (msg && typeof msg === 'string') {

--- a/bin/run.js
+++ b/bin/run.js
@@ -3,7 +3,15 @@
 import stringArgv from 'string-argv';
 
 async function main() {
+  /**
+   * This is a v9-specific change to ensure that we're pointing to the
+   * correct npm release channel for version upgrade checks.
+   * Once we deprecate v9, we can remove this line.
+   *
+   * @see {@link https://github.com/oclif/plugin-warn-if-update-available/blob/75634b0cdb6a605b9ecb503576461e60ba9a37b1/README.md?plain=1#L136}
+   */
   process.env.RDME_NEW_VERSION_CHECK_TAG = 'release-v9';
+
   const { execute } = await import('@oclif/core');
   const opts = { dir: import.meta.url };
   if (process.env.INPUT_RDME) {

--- a/bin/run.js
+++ b/bin/run.js
@@ -3,6 +3,7 @@
 import stringArgv from 'string-argv';
 
 async function main() {
+  process.env.RDME_NEW_VERSION_CHECK_TAG = 'release-v9';
   const { execute } = await import('@oclif/core');
   const opts = { dir: import.meta.url };
   if (process.env.INPUT_RDME) {


### PR DESCRIPTION
## 🧰 Changes

fixes an issue where users of the `v9` channel are being told to upgrade to `v10` even though we're still maintaining the `v9` channel.

## 🧬 QA & Testing

before:

![CleanShot 2025-02-03 at 08 37 15@2x](https://github.com/user-attachments/assets/1abae2ac-6a70-440e-90a6-372f76e8ed80)

after:

![CleanShot 2025-02-03 at 08 36 58@2x](https://github.com/user-attachments/assets/b9a2d5b2-72d5-4af9-8175-d19f8de1bb95)

