### PR TITLE
chore: another grab bag of changes from #1159

### DIFF
--- a/__tests__/commands/changelogs/index.test.ts
+++ b/__tests__/commands/changelogs/index.test.ts
@@ -3,8 +3,7 @@ import path from 'node:path';
 
 import chalk from 'chalk';
 import grayMatter from 'gray-matter';
-import nock from 'nock';
-import { describe, beforeAll, afterAll, beforeEach, it, expect } from 'vitest';
+import { describe, beforeAll, beforeEach, it, expect } from 'vitest';
 
 import Command from '../../../src/commands/changelogs.js';
 import { APIv1Error } from '../../../src/lib/apiError.js';
@@ -20,11 +19,8 @@ describe('rdme changelogs', () => {
   let run: (args?: string[]) => Promise<string>;
 
   beforeAll(() => {
-    nock.disableNetConnect();
     run = runCommandAndReturnResult(Command);
   });
-
-  afterAll(() => nock.cleanAll());
 
   it('should error if no path provided', () => {
     return expect(run(['--key', key])).rejects.toThrow('Missing 1 required arg:\npath');

--- a/__tests__/commands/changelogs/single.test.ts
+++ b/__tests__/commands/changelogs/single.test.ts
@@ -95,11 +95,11 @@ describe('rdme changelogs (single)', () => {
       getMock.done();
     });
 
-    it('should skip if it does not contain any front matter attributes', async () => {
+    it('should skip if it does not contain any frontmatter attributes', async () => {
       const filePath = `./__tests__/${fixturesBaseDir}/failure-docs/doc-sans-attributes.md`;
 
       await expect(run([filePath, '--key', key])).resolves.toBe(
-        `⏭️  no front matter attributes found for ${filePath}, skipping`,
+        `⏭️  no frontmatter attributes found for ${filePath}, skipping`,
       );
     });
 

--- a/__tests__/commands/changelogs/single.test.ts
+++ b/__tests__/commands/changelogs/single.test.ts
@@ -3,8 +3,7 @@ import path from 'node:path';
 
 import chalk from 'chalk';
 import grayMatter from 'gray-matter';
-import nock from 'nock';
-import { describe, beforeAll, afterAll, beforeEach, it, expect } from 'vitest';
+import { describe, beforeAll, beforeEach, it, expect } from 'vitest';
 
 import Command from '../../../src/commands/changelogs.js';
 import { APIv1Error } from '../../../src/lib/apiError.js';
@@ -20,11 +19,8 @@ describe('rdme changelogs (single)', () => {
   let run: (args?: string[]) => Promise<string>;
 
   beforeAll(() => {
-    nock.disableNetConnect();
     run = runCommandAndReturnResult(Command);
   });
-
-  afterAll(() => nock.cleanAll());
 
   it('should error if no file path provided', () => {
     return expect(run(['--key', key])).rejects.toThrow('Missing 1 required arg:\npath');

--- a/__tests__/commands/login.test.ts
+++ b/__tests__/commands/login.test.ts
@@ -1,6 +1,5 @@
-import nock from 'nock';
 import prompts from 'prompts';
-import { describe, beforeAll, afterAll, afterEach, it, expect } from 'vitest';
+import { describe, beforeAll, afterEach, it, expect } from 'vitest';
 
 import Command from '../../src/commands/login.js';
 import { APIv1Error } from '../../src/lib/apiError.js';
@@ -18,13 +17,10 @@ describe('rdme login', () => {
   let run: (args?: string[]) => Promise<string>;
 
   beforeAll(() => {
-    nock.disableNetConnect();
     run = runCommandAndReturnResult(Command);
   });
 
   afterEach(() => configStore.clear());
-
-  afterAll(() => nock.cleanAll());
 
   it('should error if no project provided', () => {
     prompts.inject([email, password]);

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -19,12 +19,7 @@ describe('rdme openapi upload', () => {
   let run: (args?: string[]) => OclifOutput;
 
   beforeAll(() => {
-    nock.disableNetConnect();
     run = runCommand(Command);
-  });
-
-  afterEach(() => {
-    nock.cleanAll();
   });
 
   describe('flag error handling', () => {

--- a/__tests__/helpers/get-gha-setup.ts
+++ b/__tests__/helpers/get-gha-setup.ts
@@ -10,6 +10,8 @@ import * as getPkgVersion from '../../src/lib/getPkg.js';
 
 import getGitRemoteMock from './get-git-mock.js';
 
+const fsWriteFileSync = fs.writeFileSync;
+
 /**
  * A helper function for setting up tests for our GitHub Action onboarding.
  *
@@ -40,6 +42,7 @@ export function before(
  */
 export function after() {
   configstore.clear();
+  fs.writeFileSync = fsWriteFileSync;
   vi.clearAllMocks();
   vi.unstubAllEnvs();
 }

--- a/__tests__/helpers/global-setup.ts
+++ b/__tests__/helpers/global-setup.ts
@@ -1,0 +1,17 @@
+/**
+ * This file is used to setup and teardown the global environment for Vitest.
+ *
+ * This file is referenced in `vitest.config.ts` under the `globalSetup` key.
+ *
+ * @see {@link https://vitest.dev/config/#setupfiles}
+ */
+import nock from 'nock';
+
+export function setup(): void {
+  nock.disableNetConnect();
+}
+
+export function teardown(): void {
+  nock.cleanAll();
+  nock.enableNetConnect();
+}

--- a/__tests__/lib/fetch.test.ts
+++ b/__tests__/lib/fetch.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
-import nock from 'nock';
-import { describe, beforeEach, afterEach, it, expect, vi, beforeAll, type MockInstance } from 'vitest';
+import { describe, beforeEach, afterEach, it, expect, vi, type MockInstance } from 'vitest';
 
 import pkg from '../../package.json' with { type: 'json' };
 import { cleanAPIv1Headers, handleAPIv1Res, readmeAPIv1Fetch } from '../../src/lib/readmeAPIFetch.js';
@@ -8,12 +7,6 @@ import { getAPIv1Mock } from '../helpers/get-api-mock.js';
 import { after, before } from '../helpers/setup-gha-env.js';
 
 describe('#readmeAPIv1Fetch()', () => {
-  beforeAll(() => {
-    nock.disableNetConnect();
-  });
-
-  afterEach(() => nock.cleanAll());
-
   describe('GitHub Actions environment', () => {
     beforeEach(before);
 

--- a/__tests__/lib/getPkgVersion.test.ts
+++ b/__tests__/lib/getPkgVersion.test.ts
@@ -22,8 +22,6 @@ describe('#getPkgVersion()', () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
-
-    nock.cleanAll();
   });
 
   it('should grab version from package.json by default', () => {

--- a/documentation/commands/changelogs.md
+++ b/documentation/commands/changelogs.md
@@ -17,7 +17,7 @@ ARGUMENTS
   PATH  Path to a local Markdown file or folder of Markdown files.
 
 FLAGS
-  --dryRun       Runs the command without creating/updating any changelogs in ReadMe. Useful for debugging.
+  --dryRun       Runs the command without creating nor updating any changelogs in ReadMe. Useful for debugging.
   --github       Create a new GitHub Actions workflow for this command.
   --key=<value>  (required) ReadMe project API key
 

--- a/documentation/commands/changelogs.md
+++ b/documentation/commands/changelogs.md
@@ -25,8 +25,8 @@ DESCRIPTION
   Upload Markdown files to your ReadMe project as Changelog posts.
 
   Syncs Markdown files to the Changelog section of your ReadMe project. The path can either be a directory or a single
-  Markdown file. The Markdown files will require YAML front matter with certain ReadMe documentation attributes. Check
-  out our docs for more info on setting up your front matter: https://docs.readme.com/main/docs/rdme#markdown-file-setup
+  Markdown file. The Markdown files will require YAML frontmatter with certain ReadMe documentation attributes. Check
+  out our docs for more info on setting up your frontmatter: https://docs.readme.com/main/docs/rdme#markdown-file-setup
 
 EXAMPLES
   Passing in a path to a directory will also upload any Markdown files that are located in subdirectories. The path

--- a/documentation/rdme.md
+++ b/documentation/rdme.md
@@ -52,10 +52,10 @@ To see detailed CLI setup instructions and all available commands, check out [th
 > The following guidance on Markdown file setup is nearly identical for Guides (i.e. the `docs` command), Changelog (i.e. the `changelogs` command), and Custom Pages (i.e. the `custompages` command). There are a couple of small differences:
 >
 > - Guides are tied to project versions and therefore require a `--version` parameter. Changelog and Custom Pages are the same across project versions and therefore do not have a `--version` parameter.
-> - There are slight variations in the YAML front matter attributes for each respective section of your documentation. For example, Changelog has a `type` attribute which you can set to `added`. See [Specifying Other Attributes](#specifying-other-attributes) for more information.
-> - In addition to Markdown, Custom Pages also supports HTML files. If you pass an HTML file into the `custompages` commands, the page will have the `htmlmode` flag set to `true` and it will conversely be set to `false` for Markdown files. You can override this in the YAML front matter.
+> - There are slight variations in the YAML frontmatter attributes for each respective section of your documentation. For example, Changelog has a `type` attribute which you can set to `added`. See [Specifying Other Attributes](#specifying-other-attributes) for more information.
+> - In addition to Markdown, Custom Pages also supports HTML files. If you pass an HTML file into the `custompages` commands, the page will have the `htmlmode` flag set to `true` and it will conversely be set to `false` for Markdown files. You can override this in the YAML frontmatter.
 
-In order to sync Markdown files to your Guides, your Changelog, or your Custom Pages, you'll need to add certain attributes to the top of each page via a [YAML front matter block](https://jekyllrb.com/docs/front-matter/). See below for an example (using the page you're currently reading!):
+In order to sync Markdown files to your Guides, your Changelog, or your Custom Pages, you'll need to add certain attributes to the top of each page via a [YAML frontmatter block](https://jekyllrb.com/docs/front-matter/). See below for an example (using the page you're currently reading!):
 
 ```markdown
 ---
@@ -69,7 +69,7 @@ If you're anything like us...
 
 #### Required Attributes
 
-See below for a table detailing the required YAML front matter attributes:
+See below for a table detailing the required YAML frontmatter attributes:
 
 | Attribute  | Required for `changelogs`? | Required for `custompages`? | Required for `docs`? |
 | :--------- | :------------------------- | :-------------------------- | :------------------- |
@@ -80,11 +80,11 @@ To determine what your `category` value should be, you can use [the `Get all cat
 
 > 📘
 >
-> Any Markdown/HTML files that lack YAML front matter attributes will be skipped.
+> Any Markdown/HTML files that lack YAML frontmatter attributes will be skipped.
 
 #### Specifying Page Slugs
 
-By default, we automatically derive the page's slug via the file name (e.g. the file name `rdme.md` would become `/docs/rdme` in your ReadMe project). Note that our API uses [`slugify`](https://www.npmjs.com/package/slugify) to automatically handle certain characters (e.g. spaces), which may lead to unexpected syncing behavior if your file names don't match your page slugs. If you prefer to keep your page slugs different from your file names, you can manually set the `slug` value in the YAML front matter:
+By default, we automatically derive the page's slug via the file name (e.g. the file name `rdme.md` would become `/docs/rdme` in your ReadMe project). Note that our API uses [`slugify`](https://www.npmjs.com/package/slugify) to automatically handle certain characters (e.g. spaces), which may lead to unexpected syncing behavior if your file names don't match your page slugs. If you prefer to keep your page slugs different from your file names, you can manually set the `slug` value in the YAML frontmatter:
 
 ```markdown
 ---
@@ -97,7 +97,7 @@ slug: an-alternative-page-slug-example
 
 #### Specifying Other Attributes
 
-You can also specify several other page attributes in your YAML front matter, such as `hidden` (a boolean which denotes whether your page is published or unpublished). Any attributes you omit will remain unchanged on `rdme` runs. To view the full list of attributes, check out the `POST` endpoints for respective section of your documentation that you're syncing:
+You can also specify several other page attributes in your YAML frontmatter, such as `hidden` (a boolean which denotes whether your page is published or unpublished). Any attributes you omit will remain unchanged on `rdme` runs. To view the full list of attributes, check out the `POST` endpoints for respective section of your documentation that you're syncing:
 
 - [`Create doc`](https://docs.readme.com/reference/createdoc)
 - [`Create changelog`](https://docs.readme.com/reference/createchangelog)

--- a/package-lock.json
+++ b/package-lock.json
@@ -355,16 +355,16 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront": {
-      "version": "3.734.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.734.0.tgz",
-      "integrity": "sha512-j0R5arpRRBHRBKrnRmwXECCKFNOYdjGAmkpVS27GNuE6hJ2h2CBGJvb+XRzqZiEhna40+VeBn0/39yroMb157g==",
+      "version": "3.738.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.738.0.tgz",
+      "integrity": "sha512-T2bAcJrNpZsPHfh+YJR9yYg8rxRAAWvwYlvJgwtPz0kn3TiNdOwcbgiQkcWuWTKxirshOpn6sWBoRcAarMYVZg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.734.0",
-        "@aws-sdk/credential-provider-node": "3.734.0",
+        "@aws-sdk/credential-provider-node": "3.738.0",
         "@aws-sdk/middleware-host-header": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
         "@aws-sdk/middleware-recursion-detection": "3.734.0",
@@ -409,9 +409,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.735.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.735.0.tgz",
-      "integrity": "sha512-6NcxX06c4tnnu6FTFiyS8shoYLy+8TvIDkYjJ5r9tvbaysOptUKQdolOuh7+Lz95QyaqiznpCsNTxsfywLXcqw==",
+      "version": "3.740.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.740.0.tgz",
+      "integrity": "sha512-X9aQOFJC3TsYwQP3AGcNhfYcFehVEHRKCHtHYOIKv5t1ydSJxpN/v34OrMMKvG1jFWMNkSYiSCVB9ZVo9KUwVA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -419,7 +419,7 @@
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.734.0",
-        "@aws-sdk/credential-provider-node": "3.734.0",
+        "@aws-sdk/credential-provider-node": "3.738.0",
         "@aws-sdk/middleware-bucket-endpoint": "3.734.0",
         "@aws-sdk/middleware-expect-continue": "3.734.0",
         "@aws-sdk/middleware-flexible-checksums": "3.735.0",
@@ -427,11 +427,11 @@
         "@aws-sdk/middleware-location-constraint": "3.734.0",
         "@aws-sdk/middleware-logger": "3.734.0",
         "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-sdk-s3": "3.734.0",
+        "@aws-sdk/middleware-sdk-s3": "3.740.0",
         "@aws-sdk/middleware-ssec": "3.734.0",
         "@aws-sdk/middleware-user-agent": "3.734.0",
         "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/signature-v4-multi-region": "3.734.0",
+        "@aws-sdk/signature-v4-multi-region": "3.740.0",
         "@aws-sdk/types": "3.734.0",
         "@aws-sdk/util-endpoints": "3.734.0",
         "@aws-sdk/util-user-agent-browser": "3.734.0",
@@ -614,9 +614,9 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.734.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.734.0.tgz",
-      "integrity": "sha512-9NOSNbkPVb91JwaXOhyfahkzAwWdMsbWHL6fh5/PHlXYpsDjfIfT23I++toepNF2nODAJNLnOEHGYIxgNgf6jQ==",
+      "version": "3.738.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.738.0.tgz",
+      "integrity": "sha512-3MuREsazwBxghKb2sQQHvie+uuK4dX4/ckFYiSoffzJQd0YHxaGxf8cr4NOSCQCUesWu8D3Y0SzlnHGboVSkpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.734.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.734.0.tgz",
-      "integrity": "sha512-zeZPenDhkP/RXYMFG3exhNOe2Qukg2l2KpIjxq9o66meELiTULoIXjCmgPoWcM8zzrue06SBdTsaJDHfDl2vdA==",
+      "version": "3.740.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.740.0.tgz",
+      "integrity": "sha512-VML9TzNoQdAs5lSPQSEgZiPgMUSz2H7SltaLb9g4tHwKK5xQoTq5WcDd6V1d2aPxSN5Q2Q63aiVUBby6MdUN/Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -944,13 +944,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.734.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.734.0.tgz",
-      "integrity": "sha512-GSRP8UH30RIYkcpPILV4pWrKFjRmmNjtUd41HTKWde5GbjJvNYpxqFXw2aIJHjKTw/js3XEtGSNeTaQMVVt3CQ==",
+      "version": "3.740.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.740.0.tgz",
+      "integrity": "sha512-w+psidN3i+kl51nQEV3V+fKjKUqcEbqUA1GtubruDBvBqrl5El/fU2NF3Lo53y8CfI9wCdf3V7KOEpHIqxHNng==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.734.0",
+        "@aws-sdk/middleware-sdk-s3": "3.740.0",
         "@aws-sdk/types": "3.734.0",
         "@smithy/protocol-http": "^5.0.1",
         "@smithy/signature-v4": "^5.0.1",
@@ -2062,14 +2062,14 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.6.tgz",
-      "integrity": "sha512-PgP35JfmGjHU0LSXOyRew0zHuA9N6OJwOlos1fZ20b7j8ISeAdib3L+n0jIxBtX958UeEpte6xhG/gxJ5iUqMw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.7.tgz",
+      "integrity": "sha512-lyoF4uYdBBTnqeB1gjPdYkiQ++fz/iYKaP9DON1ZGlldkvAEJsjaOBRdbl5UW1pOSslBRd701jxhAG0MlhHd2w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/figures": "^1.0.9",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.5",
+        "@inquirer/figures": "^1.0.10",
+        "@inquirer/type": "^3.0.3",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -2081,13 +2081,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.3.tgz",
-      "integrity": "sha512-fuF9laMmHoOgWapF9h9hv6opA5WvmGFHsTYGCmuFxcghIhEhb3dN0CdQR4BUMqa2H506NCj8cGX4jwMsE4t6dA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.4.tgz",
+      "integrity": "sha512-EsiT7K4beM5fN5Mz6j866EFA9+v9d5o9VUra3hrg8zY4GHmCS8b616FErbdo5eyKoVotBQkHzMIeeKYsKDStDw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2"
+        "@inquirer/core": "^10.1.5",
+        "@inquirer/type": "^3.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -2097,18 +2097,17 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.4.tgz",
-      "integrity": "sha512-5y4/PUJVnRb4bwWY67KLdebWOhOc7xj5IP2J80oWXa64mVag24rwQ1VAdnj7/eDY/odhguW0zQ1Mp1pj6fO/2w==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.5.tgz",
+      "integrity": "sha512-/vyCWhET0ktav/mUeBqJRYTwmjFPIKPRYb3COAw7qORULgipGSUO2vL32lQKki3UxDKJ8BvuEbokaoyCA6YlWw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.9",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/figures": "^1.0.10",
+        "@inquirer/type": "^3.0.3",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^6.2.0",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -2131,13 +2130,13 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.3.tgz",
-      "integrity": "sha512-S9KnIOJuTZpb9upeRSBBhoDZv7aSV3pG9TECrBj0f+ZsFwccz886hzKBrChGrXMJwd4NKY+pOA9Vy72uqnd6Eg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.4.tgz",
+      "integrity": "sha512-S8b6+K9PLzxiFGGc02m4syhEu5JsH0BukzRsuZ+tpjJ5aDsDX1WfNfOil2fmsO36Y1RMcpJGxlfQ1yh4WfU28Q==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.5",
+        "@inquirer/type": "^3.0.3",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -2148,13 +2147,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.6.tgz",
-      "integrity": "sha512-TRTfi1mv1GeIZGyi9PQmvAaH65ZlG4/FACq6wSzs7Vvf1z5dnNWsAAXBjWMHt76l+1hUY8teIqJFrWBk5N6gsg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.7.tgz",
+      "integrity": "sha512-PsUQ5t7r+DPjW0VVEHzssOTBM2UPHnvBNse7hzuki7f6ekRL94drjjfBLrGEDe7cgj3pguufy/cuFwMeWUWHXw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.5",
+        "@inquirer/type": "^3.0.3",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -2165,22 +2164,22 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.9.tgz",
-      "integrity": "sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.10.tgz",
+      "integrity": "sha512-Ey6176gZmeqZuY/W/nZiUyvmb1/qInjcpiZjXWi6nON+nxJpD1bxtSoBxNliGISae32n6OwbY+TSXPZ1CfS4bw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.3.tgz",
-      "integrity": "sha512-zeo++6f7hxaEe7OjtMzdGZPHiawsfmCZxWB9X1NpmYgbeoyerIbWemvlBxxl+sQIlHC0WuSAG19ibMq3gbhaqQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.4.tgz",
+      "integrity": "sha512-CKKF8otRBdIaVnRxkFLs00VNA9HWlEh3x4SqUfC3A8819TeOZpTYG/p+4Nqu3hh97G+A0lxkOZNYE7KISgU8BA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2"
+        "@inquirer/core": "^10.1.5",
+        "@inquirer/type": "^3.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -2190,13 +2189,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.6.tgz",
-      "integrity": "sha512-xO07lftUHk1rs1gR0KbqB+LJPhkUNkyzV/KhH+937hdkMazmAYHLm1OIrNKpPelppeV1FgWrgFDjdUD8mM+XUg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.7.tgz",
+      "integrity": "sha512-uU2nmXGC0kD8+BLgwZqcgBD1jcw2XFww2GmtP6b4504DkOp+fFAhydt7JzRR1TAI2dmj175p4SZB0lxVssNreA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2"
+        "@inquirer/core": "^10.1.5",
+        "@inquirer/type": "^3.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -2206,13 +2205,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.6.tgz",
-      "integrity": "sha512-QLF0HmMpHZPPMp10WGXh6F+ZPvzWE7LX6rNoccdktv/Rov0B+0f+eyXkAcgqy5cH9V+WSpbLxu2lo3ysEVK91w==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.7.tgz",
+      "integrity": "sha512-DFpqWLx+C5GV5zeFWuxwDYaeYnTWYphO07pQ2VnP403RIqRIpwBG0ATWf7pF+3IDbaXEtWatCJWxyDrJ+rkj2A==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.5",
+        "@inquirer/type": "^3.0.3",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -2223,21 +2222,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.2.3.tgz",
-      "integrity": "sha512-hzfnm3uOoDySDXfDNOm9usOuYIaQvTgKp/13l1uJoe6UNY+Zpcn2RYt0jXz3yA+yemGHvDOxVzqWl3S5sQq53Q==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.2.4.tgz",
+      "integrity": "sha512-Zn2XZL2VZl76pllUjeDnS6Poz2Oiv9kmAZdSZw1oFya985+/JXZ3GZ2JUWDokAPDhvuhkv9qz0Z7z/U80G8ztA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.0.6",
-        "@inquirer/confirm": "^5.1.3",
-        "@inquirer/editor": "^4.2.3",
-        "@inquirer/expand": "^4.0.6",
-        "@inquirer/input": "^4.1.3",
-        "@inquirer/number": "^3.0.6",
-        "@inquirer/password": "^4.0.6",
-        "@inquirer/rawlist": "^4.0.6",
-        "@inquirer/search": "^3.0.6",
-        "@inquirer/select": "^4.0.6"
+        "@inquirer/checkbox": "^4.0.7",
+        "@inquirer/confirm": "^5.1.4",
+        "@inquirer/editor": "^4.2.4",
+        "@inquirer/expand": "^4.0.7",
+        "@inquirer/input": "^4.1.4",
+        "@inquirer/number": "^3.0.7",
+        "@inquirer/password": "^4.0.7",
+        "@inquirer/rawlist": "^4.0.7",
+        "@inquirer/search": "^3.0.7",
+        "@inquirer/select": "^4.0.7"
       },
       "engines": {
         "node": ">=18"
@@ -2247,13 +2246,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.6.tgz",
-      "integrity": "sha512-QoE4s1SsIPx27FO4L1b1mUjVcoHm1pWE/oCmm4z/Hl+V1Aw5IXl8FYYzGmfXaBT0l/sWr49XmNSiq7kg3Kd/Lg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.7.tgz",
+      "integrity": "sha512-ZeBca+JCCtEIwQMvhuROT6rgFQWWvAImdQmIIP3XoyDFjrp2E0gZlEn65sWIoR6pP2EatYK96pvx0887OATWQQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.5",
+        "@inquirer/type": "^3.0.3",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -2264,14 +2263,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.6.tgz",
-      "integrity": "sha512-eFZ2hiAq0bZcFPuFFBmZEtXU1EarHLigE+ENCtpO+37NHCl4+Yokq1P/d09kUblObaikwfo97w+0FtG/EXl5Ng==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.7.tgz",
+      "integrity": "sha512-Krq925SDoLh9AWSNee8mbSIysgyWtcPnSAp5YtPBGCQ+OCO+5KGC8FwLpyxl8wZ2YAov/8Tp21stTRK/fw5SGg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/figures": "^1.0.9",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.5",
+        "@inquirer/figures": "^1.0.10",
+        "@inquirer/type": "^3.0.3",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -2282,14 +2281,14 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.6.tgz",
-      "integrity": "sha512-yANzIiNZ8fhMm4NORm+a74+KFYHmf7BZphSOBovIzYPVLquseTGEkU5l2UTnBOf5k0VLmTgPighNDLE9QtbViQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.7.tgz",
+      "integrity": "sha512-ejGBMDSD+Iqk60u5t0Zf2UQhGlJWDM78Ep70XpNufIfc+f4VOTeybYKXu9pDjz87FkRzLiVsGpQG2SzuGlhaJw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/figures": "^1.0.9",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.5",
+        "@inquirer/figures": "^1.0.10",
+        "@inquirer/type": "^3.0.3",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -2301,9 +2300,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.2.tgz",
-      "integrity": "sha512-ZhQ4TvhwHZF+lGhQ2O/rsjo80XoZR5/5qhOY3t6FJuX5XBg5Be8YzYTvaUGJnc12AUGI2nr4QSUE4PhKSigx7g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.3.tgz",
+      "integrity": "sha512-I4VIHFxUuY1bshGbXZTxCmhwaaEst9s/lll3ekok+o1Z26/ZUKdx8y1b7lsoG6rtsBDwEGfiBJ2SfirjoISLpg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2528,9 +2527,9 @@
       "license": "MIT"
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.37.5",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.5.tgz",
-      "integrity": "sha512-AAwRb5vXFcY4L+FvZ7LZusDuZ0vEe0Zm8ohn1FM6/X7A3bj4mqmkAcGRWuvC2JwSygNwHAAmMnAI73vPHeqsHA==",
+      "version": "0.37.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.6.tgz",
+      "integrity": "sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2840,51 +2839,23 @@
       }
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-2.0.0.tgz",
-      "integrity": "sha512-RquGi4rLHJNBIdlp+28x3a0T1m3NTbDMkAIAxE+u0pVEF2cBGSyfwbNT77lRWqKveOod0ua3MW5S+czTR3cExw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-2.1.2.tgz",
+      "integrity": "sha512-nfAs1+wzO9SWwji/7mbhXo2vJZ6PLMSpv7XNrFrwufhdwRPc07GNBwcEsiL6qq8VnI+A2lMEkcj7xCEK1nOrNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
         "@babel/runtime": "^7.22.5",
         "@humanwhocodes/momoa": "^2.0.3",
-        "chalk": "^4.1.2",
         "jsonpointer": "^5.0.0",
-        "leven": "^3.1.0"
+        "leven": "^3.1.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "ajv": "4.11.8 - 8"
-      }
-    },
-    "node_modules/@readme/better-ajv-errors/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@readme/better-ajv-errors/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@readme/eslint-config": {
@@ -4394,9 +4365,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
-      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.0.tgz",
+      "integrity": "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -5851,9 +5822,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001695",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
-      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
+      "version": "1.0.30001696",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
+      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
       "dev": true,
       "funding": [
         {
@@ -6956,9 +6927,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.88",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.88.tgz",
-      "integrity": "sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==",
+      "version": "1.5.90",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.90.tgz",
+      "integrity": "sha512-C3PN4aydfW91Natdyd449Kw+BzhLmof6tzy5W1pFC5SpQxVXT+oyiyOG9AgYYSN9OdA/ik3YkCrpwqI8ug5Tug==",
       "dev": true,
       "license": "ISC"
     },
@@ -8894,9 +8865,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
-      "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
+      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -13745,9 +13716,9 @@
       }
     },
     "node_modules/oclif": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/oclif/-/oclif-4.17.20.tgz",
-      "integrity": "sha512-8zhZ8M2Of5oB3zLLZAr6rVEozCeXMYGJpnj/iTyefZSX9O9frimGqnpUgHnKhl3GAJS5UnPgJ9s3yLzv5IMudA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/oclif/-/oclif-4.17.21.tgz",
+      "integrity": "sha512-ix0H1xSWrk12jxALgub+6Eo9uvV+t42EQVeapDmPCUw78QVivOxmnpTws5ZU2DDbviLGDDIZrWGywfK8OS87rQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15764,9 +15735,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/src/commands/changelogs.ts
+++ b/src/commands/changelogs.ts
@@ -37,7 +37,7 @@ export default class ChangelogsCommand extends BaseCommand<typeof ChangelogsComm
     github: githubFlag,
     key: keyFlag,
     dryRun: Flags.boolean({
-      description: 'Runs the command without creating/updating any changelogs in ReadMe. Useful for debugging.',
+      description: 'Runs the command without creating nor updating any changelogs in ReadMe. Useful for debugging.',
     }),
   };
 

--- a/src/commands/changelogs.ts
+++ b/src/commands/changelogs.ts
@@ -14,7 +14,7 @@ export default class ChangelogsCommand extends BaseCommand<typeof ChangelogsComm
   static summary = 'Upload Markdown files to your ReadMe project as Changelog posts.';
 
   static description =
-    'Syncs Markdown files to the Changelog section of your ReadMe project. The path can either be a directory or a single Markdown file. The Markdown files will require YAML front matter with certain ReadMe documentation attributes. Check out our docs for more info on setting up your front matter: https://docs.readme.com/main/docs/rdme#markdown-file-setup';
+    'Syncs Markdown files to the Changelog section of your ReadMe project. The path can either be a directory or a single Markdown file. The Markdown files will require YAML frontmatter with certain ReadMe documentation attributes. Check out our docs for more info on setting up your frontmatter: https://docs.readme.com/main/docs/rdme#markdown-file-setup';
 
   static args = {
     path: Args.string({ description: 'Path to a local Markdown file or folder of Markdown files.', required: true }),

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -89,7 +89,7 @@ export default abstract class BaseCommand<T extends typeof OclifCommand> extends
   protected async _run<U>(): Promise<U> {
     // eslint-disable-next-line no-underscore-dangle
     const result: U = await super._run();
-    if (isGHA() && result) {
+    if (isGHA() && !isTest() && result) {
       core.setOutput('rdme', result);
     }
     return result;

--- a/src/lib/readDoc.ts
+++ b/src/lib/readDoc.ts
@@ -8,11 +8,11 @@ import grayMatter from 'gray-matter';
 
 export interface PageMetadata<T = Record<string, unknown>> {
   /**
-   * The contents of the Markdown file below the YAML front matter
+   * The contents of the Markdown file below the YAML frontmatter
    */
   content: string;
   /**
-   * A JSON object representation of the the YAML front matter
+   * A JSON object representation of the the YAML frontmatter
    */
   data: T;
   /**
@@ -20,13 +20,13 @@ export interface PageMetadata<T = Record<string, unknown>> {
    */
   filePath: string;
   /**
-   * A hash of the file contents (including the front matter)
+   * A hash of the file contents (including the frontmatter)
    *
    * @deprecated this is no longer used in our API.
    */
   hash: string;
   /**
-   * The page slug from front matter (and falls back to the filename without the extension)
+   * The page slug from frontmatter (and falls back to the filename without the extension)
    */
   slug: string;
 }
@@ -49,7 +49,7 @@ export default function readPage(
   // (so far we've seen this issue crop up in tests)
   const matter = grayMatter(rawFileContents, {});
   const { content, data } = matter;
-  this.debug(`front matter for ${filePath}: ${JSON.stringify(matter)}`);
+  this.debug(`frontmatter for ${filePath}: ${JSON.stringify(matter)}`);
 
   // Stripping the subdirectories and markdown extension from the filename and lowercasing to get the default slug.
   const slug = matter.data.slug || path.basename(filePath).replace(path.extname(filePath), '').toLowerCase();

--- a/src/lib/syncDocsPath.legacy.ts
+++ b/src/lib/syncDocsPath.legacy.ts
@@ -32,10 +32,10 @@ async function pushDoc(
   const { content, data, filePath, hash, slug } = fileData;
 
   // TODO: ideally we should offer a zero-configuration approach that doesn't
-  // require YAML front matter, but that will have to be a breaking change
+  // require YAML frontmatter, but that will have to be a breaking change
   if (!Object.keys(data).length) {
-    this.debug(`No front matter attributes found for ${filePath}, not syncing`);
-    return `⏭️  no front matter attributes found for ${filePath}, skipping`;
+    this.debug(`No frontmatter attributes found for ${filePath}, not syncing`);
+    return `⏭️  no frontmatter attributes found for ${filePath}, skipping`;
   }
 
   const payload: {

--- a/src/lib/syncDocsPath.legacy.ts
+++ b/src/lib/syncDocsPath.legacy.ts
@@ -122,6 +122,13 @@ const byParentDoc = (left: PageMetadata, right: PageMetadata) => {
   return (right.data.parentDoc ? 1 : 0) - (left.data.parentDoc ? 1 : 0);
 };
 
+/**
+ * Sorts files based on their parentDoc attribute. If a file has a parentDoc attribute,
+ * it will be sorted after the file it references.
+ *
+ * @see {@link https://github.com/readmeio/rdme/pull/973}
+ * @returns An array of sorted PageMetadata objects
+ */
 function sortFiles(this: ChangelogsCommand, filePaths: string[]): PageMetadata[] {
   const files = filePaths.map(file => readPage.call(this, file)).sort(byParentDoc);
   const filesBySlug = files.reduce<Record<string, PageMetadata>>((bySlug, obj) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,5 +32,6 @@ export default defineConfig({
       '**/__snapshots__/**',
       ...configDefaults.exclude,
     ],
+    globalSetup: '__tests__/helpers/global-setup.ts',
   },
 });


### PR DESCRIPTION
## 🧰 Changes

chunks out a lot of PR feedback and random changes from #1159:

- [x] renames all "front matter" to "frontmatter"
- [x] better `nock` and `fs` setup/teardown
- [x] cherry-picking over https://github.com/readmeio/rdme/pull/1159/commits/c871520494f2ab576a49a72f9ed8828a1f8120d4
- [x] various cleanups
- [x] bumps deps:

before:

```Package                    Current   Wanted   Latest  Location                                Depended by
@readme/better-ajv-errors    2.0.0    2.1.2    2.1.2  node_modules/@readme/better-ajv-errors  rdme
eslint                      8.57.1   8.57.1   9.19.0  node_modules/eslint                     rdme
oclif                      4.17.20  4.17.21  4.17.21  node_modules/oclif                      rdme
semver                       7.6.3    7.7.0    7.7.0  node_modules/semver                     rdme
undici                      5.28.5   5.28.5    7.3.0  node_modules/undici                     rdme
```

after:

```
Package  Current  Wanted  Latest  Location             Depended by
eslint    8.57.1  8.57.1  9.19.0  node_modules/eslint  rdme
undici    5.28.5  5.28.5   7.3.0  node_modules/undici  rdme
```

## 🧬 QA & Testing

do tests still pass?
