### PR TITLE
feat(openapi/upload): add `--confirm-overwrite` flag

### DIFF
--- a/documentation/legacy/rdme.md
+++ b/documentation/legacy/rdme.md
@@ -161,7 +161,7 @@ This will run through the `openapi` command, ask you a few quick questions, and 
 >
 > Here are the relevant files on GitHub:
 >
-> - [The Markdown source file for the page you're reading](https://github.com/readmeio/rdme/blob/main/documentation/rdme.md) 📜
+> - [The Markdown source file for the page you're reading](https://github.com/readmeio/rdme/blob/main/documentation/legacy/rdme.md) 📜
 > - [The GitHub Actions workflow file that syncs the Markdown to docs.readme.com](https://github.com/readmeio/rdme/blob/main/.github/workflows/docs.yml) 🔄
 > - And finally... [the workflow run results](https://github.com/readmeio/rdme/actions/workflows/docs.yml) ✅
 

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -29,9 +29,9 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
 
   static flags = {
     key: keyFlag,
-    overwrite: Flags.boolean({
+    'confirm-overwrite': Flags.boolean({
       description:
-        'If set, the overwrite prompt will be skipped. This flag can be a useful in automated environments where prompts cannot be responded to.',
+        'If set, file overwrites will be made without a confirmation prompt. This flag can be a useful in automated environments where prompts cannot be responded to.',
       hidden: true,
     }),
     slug: Flags.string({
@@ -142,7 +142,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     if (method === 'PUT') {
       // bypass the prompt if we're in a CI environment
       prompts.override({
-        confirm: isCI() ? true : this.flags.overwrite,
+        confirm: isCI() || this.flags['confirm-overwrite'] ? true : undefined,
       });
 
       const { confirm } = await promptTerminal({

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -29,6 +29,11 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
 
   static flags = {
     key: keyFlag,
+    overwrite: Flags.boolean({
+      description:
+        'If set, the overwrite prompt will be skipped. This flag can be a useful in automated environments where prompts cannot be responded to.',
+      hidden: true,
+    }),
     slug: Flags.string({
       summary: 'Override the slug (i.e., the unique identifier) for your API definition.',
       description: [
@@ -137,7 +142,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     if (method === 'PUT') {
       // bypass the prompt if we're in a CI environment
       prompts.override({
-        confirm: isCI() ? true : undefined,
+        confirm: isCI() ? true : this.flags.overwrite,
       });
 
       const { confirm } = await promptTerminal({


### PR DESCRIPTION
| 🚥 Resolves https://github.com/readmeio/rdme/issues/1167 |
| :------------------- |

## 🧰 Changes

If an automated system runs `openapi upload` on a pre-existing file, then an overwrite prompt is shown. There is no way to skip this prompt which can lock up automated systems.

This PR adds a flag to skip the prompt.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.

**Case 1 - confirm existing behavior**
- Upload a new API spec to readme using `openapi upload {spec} --key={key} --slug={slug}`
- Try uploading the API spec again to trigger the overwrite prompt

**Case 2 - test new behavior**
- Upload a new API spec to readme using `openapi upload {spec} --key={key} --slug={slug}`
- Try uploading the API spec again using `openapi upload {spec} --key={key} --slug={slug} --overwrite` to skip the overwrite prompt