### PR TITLE
chore: add warning to rdme openapi upload for unexpected slugs

### DIFF
--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -54,9 +54,12 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 {
   "error": [Error: Please provide a valid file extension that matches the extension on the file you provided. Must be \`.json\`, \`.yaml\`, or \`.yml\`.],
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-",
+  "stdout": "",
 }
 `;
 
@@ -64,9 +67,12 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 {
   "error": [Error: Please provide a valid file extension that matches the extension on the file you provided. Must be \`.json\`, \`.yaml\`, or \`.yml\`.],
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-",
+  "stdout": "",
 }
 `;
 
@@ -77,11 +83,14 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
     "uri": "/versions/1.0.0/apis/custom-slug.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
+  "stdout": "🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
 ",
 }
 `;
@@ -93,11 +102,14 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
     "uri": "/versions/1.0.0/apis/custom-slug.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
+  "stdout": "🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
 ",
 }
 `;
@@ -109,11 +121,14 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
     "uri": "/versions/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
+  "stdout": "🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
 ",
 }
 `;
@@ -122,10 +137,13 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 {
   "error": [Error: Sorry, this upload timed out. Please try again later.],
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-",
+  "stdout": "",
 }
 `;
 
@@ -133,10 +151,13 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 {
   "error": [Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-",
+  "stdout": "",
 }
 `;
 
@@ -144,11 +165,14 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 {
   "error": [Error: Your API definition upload failed with an unexpected error. Please get in touch with us at support@readme.io.],
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ✖ Creating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion...
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-",
+  "stdout": "",
 }
 `;
 
@@ -159,11 +183,14 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
     "uri": "/versions/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion... done!
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
+  "stdout": "🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
 ",
 }
 `;
@@ -175,11 +202,14 @@ exports[`rdme openapi upload > given that the API definition is a local file > g
     "uri": "/versions/stable/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
+  "stdout": "🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
 ",
 }
 `;
@@ -191,11 +221,14 @@ exports[`rdme openapi upload > given that the API definition is a local file > g
     "uri": "/versions/1.2.3/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
+  "stdout": "🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
 ",
 }
 `;
@@ -207,11 +240,14 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
     "uri": "/versions/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
+  "stdout": "🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
 ",
 }
 `;
@@ -220,11 +256,14 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
 {
   "error": [Error: Your API definition upload failed with an unexpected error. Please get in touch with us at support@readme.io.],
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ✖ Creating your API definition to ReadMe...
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-",
+  "stdout": "",
 }
 `;
 
@@ -235,11 +274,14 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
     "uri": "/versions/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
+  "stdout": "🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
 ",
 }
 `;

--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -55,7 +55,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
   "error": [Error: Please provide a valid file extension that matches the extension on the file you provided. Must be \`.json\`, \`.yaml\`, or \`.yml\`.],
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 ",
 }
 `;
@@ -65,7 +65,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
   "error": [Error: Please provide a valid file extension that matches the extension on the file you provided. Must be \`.json\`, \`.yaml\`, or \`.yml\`.],
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 ",
 }
 `;
@@ -80,7 +80,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
 ",
 }
@@ -96,7 +96,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
 ",
 }
@@ -112,7 +112,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
 ",
 }
@@ -124,7 +124,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
 - Creating your API definition to ReadMe...
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 ",
 }
 `;
@@ -135,7 +135,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
 - Creating your API definition to ReadMe...
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 ",
 }
 `;
@@ -147,7 +147,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 - Creating your API definition to ReadMe...
 ✖ Creating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion...
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 ",
 }
 `;
@@ -162,7 +162,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion... done!
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
 ",
 }
@@ -178,7 +178,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > g
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
 ",
 }
@@ -194,7 +194,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > g
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
 ",
 }
@@ -210,7 +210,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
 ",
 }
@@ -223,7 +223,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
 - Creating your API definition to ReadMe...
 ✖ Creating your API definition to ReadMe...
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 ",
 }
 `;
@@ -238,7 +238,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",
-  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
 🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
 ",
 }

--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -55,7 +55,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
   "error": [Error: Please provide a valid file extension that matches the extension on the file you provided. Must be \`.json\`, \`.yaml\`, or \`.yml\`.],
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 ",
 }
 `;
@@ -65,7 +65,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
   "error": [Error: Please provide a valid file extension that matches the extension on the file you provided. Must be \`.json\`, \`.yaml\`, or \`.yml\`.],
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 ",
 }
 `;
@@ -80,7 +80,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
 ",
 }
@@ -96,7 +96,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
 ",
 }
@@ -112,7 +112,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
 ",
 }
@@ -124,7 +124,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
 - Creating your API definition to ReadMe...
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 ",
 }
 `;
@@ -135,7 +135,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
 - Creating your API definition to ReadMe...
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 ",
 }
 `;
@@ -147,7 +147,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 - Creating your API definition to ReadMe...
 ✖ Creating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion...
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 ",
 }
 `;
@@ -162,7 +162,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion... done!
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
 ",
 }
@@ -178,7 +178,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > g
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
 ",
 }
@@ -194,7 +194,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > g
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
 ",
 }
@@ -210,7 +210,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
 ",
 }
@@ -223,7 +223,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
 - Creating your API definition to ReadMe...
 ✖ Creating your API definition to ReadMe...
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 ",
 }
 `;
@@ -238,7 +238,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",
-  "stdout": "The slug of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+  "stdout": "The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
 🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
 ",
 }

--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -1,0 +1,245 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`rdme openapi upload > flag error handling > should throw if an error if both \`--version\` and \`--useSpecVersion\` flags are passed 1`] = `
+{
+  "error": [Error: The following error occurred:
+  --version=1.0.0 cannot also be provided when using --useSpecVersion
+See more help with --help],
+  "stderr": "",
+  "stdout": "",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a URL > should create a new API definition in ReadMe 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/versions/1.0.0/apis/openapi.json",
+  },
+  "stderr": "- Validating the API definition located at https://example.com/openapi.json...
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... done!
+",
+  "stdout": "🚀 Your API definition (openapi.json) was successfully created in ReadMe!
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a URL > should handle issues fetching from the URL 1`] = `
+{
+  "error": [Error: Unknown file detected.],
+  "stderr": "- Validating the API definition located at https://example.com/openapi.json...
+✖ Validating the API definition located at https://example.com/openapi.json...
+",
+  "stdout": "",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a URL > should update an existing API definition in ReadMe 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/versions/1.0.0/apis/openapi.json",
+  },
+  "stderr": "- Validating the API definition located at https://example.com/openapi.json...
+- Updating your API definition to ReadMe...
+✔ Updating your API definition to ReadMe... done!
+",
+  "stdout": "🚀 Your API definition (openapi.json) was successfully updated in ReadMe!
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > and the \`--slug\` flag is passed > should handle a slug with a valid but mismatching file extension 1`] = `
+{
+  "error": [Error: Please provide a valid file extension that matches the extension on the file you provided. Must be \`.json\`, \`.yaml\`, or \`.yml\`.],
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > and the \`--slug\` flag is passed > should handle a slug with an invalid file extension 1`] = `
+{
+  "error": [Error: Please provide a valid file extension that matches the extension on the file you provided. Must be \`.json\`, \`.yaml\`, or \`.yml\`.],
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > and the \`--slug\` flag is passed > should use the provided slug (includes file extension) as the filename 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/versions/1.0.0/apis/custom-slug.json",
+  },
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... done!
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > and the \`--slug\` flag is passed > should use the provided slug (no file extension) as the filename 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/versions/1.0.0/apis/custom-slug.json",
+  },
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... done!
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > and the command is being run in a CI environment > should overwrite an existing API definition without asking for confirmation 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/versions/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
+  },
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Updating your API definition to ReadMe...
+✔ Updating your API definition to ReadMe... done!
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > and the upload status initially is a pending state > should poll the API and handle timeouts 1`] = `
+{
+  "error": [Error: Sorry, this upload timed out. Please try again later.],
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Creating your API definition to ReadMe...
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > and the upload status initially is a pending state > should poll the API once and handle a failure state with a 4xx 1`] = `
+{
+  "error": [Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Creating your API definition to ReadMe...
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > and the upload status initially is a pending state > should poll the API once and handle an unexpected state with a 2xx 1`] = `
+{
+  "error": [Error: Your API definition upload failed with an unexpected error. Please get in touch with us at support@readme.io.],
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Creating your API definition to ReadMe...
+✖ Creating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion...
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > and the upload status initially is a pending state > should poll the API until the upload is complete 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/versions/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
+  },
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion... done!
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > given that the \`--version\` flag is not set > should default to the \`stable\` version 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/versions/stable/apis/__tests____fixtures__petstore-simple-weird-version.json",
+  },
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... done!
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > given that the \`--version\` flag is not set > should use the version from the spec file if --\`useSpecVersion\` is passed 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/versions/1.2.3/apis/__tests____fixtures__petstore-simple-weird-version.json",
+  },
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... done!
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > should create a new API definition in ReadMe 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/versions/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
+  },
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... done!
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > should handle upload failures 1`] = `
+{
+  "error": [Error: Your API definition upload failed with an unexpected error. Please get in touch with us at support@readme.io.],
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Creating your API definition to ReadMe...
+✖ Creating your API definition to ReadMe...
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > should update an existing API definition in ReadMe 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/versions/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
+  },
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Updating your API definition to ReadMe...
+✔ Updating your API definition to ReadMe... done!
+",
+  "stdout": "The file name of your API Definition will be updated to __tests____fixtures__petstore-simple-weird-version.json to match ReadMe's slug requirements.
+🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
+",
+}
+`;

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -25,7 +25,7 @@ describe('rdme openapi upload', () => {
   describe('flag error handling', () => {
     it('should throw if an error if both `--version` and `--useSpecVersion` flags are passed', async () => {
       const result = await run(['--useSpecVersion', '--version', version, filename, '--key', key]);
-      expect(result.error.message).toContain('--version=1.0.0 cannot also be provided when using --useSpecVersion');
+      expect(result).toMatchSnapshot();
     });
   });
 
@@ -45,7 +45,7 @@ describe('rdme openapi upload', () => {
         });
 
       const result = await run(['--version', version, filename, '--key', key]);
-      expect(result.stdout).toContain('was successfully created in ReadMe!');
+      expect(result).toMatchSnapshot();
 
       mock.done();
     });
@@ -67,7 +67,7 @@ describe('rdme openapi upload', () => {
         });
 
       const result = await run(['--version', version, filename, '--key', key]);
-      expect(result.stdout).toContain('was successfully updated in ReadMe!');
+      expect(result).toMatchSnapshot();
 
       mock.done();
     });
@@ -87,9 +87,7 @@ describe('rdme openapi upload', () => {
         });
 
       const result = await run(['--version', version, filename, '--key', key]);
-      expect(result.error.message).toBe(
-        'Your API definition upload failed with an unexpected error. Please get in touch with us at support@readme.io.',
-      );
+      expect(result).toMatchSnapshot();
 
       mock.done();
     });
@@ -112,9 +110,7 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--version', version, filename, '--key', key, '--slug', customSlug]);
-        expect(result.stdout).toContain(
-          `Your API definition (${customSlugWithExtension}) was successfully created in ReadMe!`,
-        );
+        expect(result).toMatchSnapshot();
 
         mock.done();
       });
@@ -133,7 +129,7 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--version', version, filename, '--key', key, '--slug', customSlug]);
-        expect(result.stdout).toContain(`Your API definition (${customSlug}) was successfully created in ReadMe!`);
+        expect(result).toMatchSnapshot();
 
         mock.done();
       });
@@ -142,18 +138,14 @@ describe('rdme openapi upload', () => {
         const customSlug = 'custom-slug.yikes';
 
         const result = await run(['--version', version, filename, '--key', key, '--slug', customSlug]);
-        expect(result.error.message).toBe(
-          'Please provide a valid file extension that matches the extension on the file you provided. Must be `.json`, `.yaml`, or `.yml`.',
-        );
+        expect(result).toMatchSnapshot();
       });
 
       it('should handle a slug with a valid but mismatching file extension', async () => {
         const customSlug = 'custom-slug.yml';
 
         const result = await run(['--version', version, filename, '--key', key, '--slug', customSlug]);
-        expect(result.error.message).toBe(
-          'Please provide a valid file extension that matches the extension on the file you provided. Must be `.json`, `.yaml`, or `.yml`.',
-        );
+        expect(result).toMatchSnapshot();
       });
     });
 
@@ -188,8 +180,7 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--version', version, filename, '--key', key]);
-        expect(result.stdout).toContain('was successfully created in ReadMe!');
-
+        expect(result).toMatchSnapshot();
         mock.done();
       });
 
@@ -216,8 +207,7 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--version', version, filename, '--key', key]);
-        expect(result.error.message).toBe('Sorry, this upload timed out. Please try again later.');
-
+        expect(result).toMatchSnapshot();
         mock.done();
       });
 
@@ -238,10 +228,7 @@ describe('rdme openapi upload', () => {
           .reply(400);
 
         const result = await run(['--version', version, filename, '--key', key]);
-        expect(result.error.message).toBe(
-          'The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.',
-        );
-
+        expect(result).toMatchSnapshot();
         mock.done();
       });
 
@@ -267,12 +254,7 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--version', version, filename, '--key', key]);
-        expect(result.error).toStrictEqual(
-          new Error(
-            'Your API definition upload failed with an unexpected error. Please get in touch with us at support@readme.io.',
-          ),
-        );
-
+        expect(result).toMatchSnapshot();
         mock.done();
       });
     });
@@ -297,8 +279,7 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--version', version, filename, '--key', key]);
-        expect(result.stdout).toContain('was successfully updated in ReadMe!');
-
+        expect(result).toMatchSnapshot();
         mock.done();
       });
     });
@@ -319,8 +300,7 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run([filename, '--key', key]);
-        expect(result.stdout).toContain('was successfully created in ReadMe!');
-
+        expect(result).toMatchSnapshot();
         mock.done();
       });
 
@@ -340,8 +320,7 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--useSpecVersion', filename, '--key', key]);
-        expect(result.stdout).toContain('was successfully created in ReadMe!');
-
+        expect(result).toMatchSnapshot();
         mock.done();
       });
     });
@@ -363,8 +342,7 @@ describe('rdme openapi upload', () => {
         });
 
       const result = await run(['--version', version, fileUrl, '--key', key]);
-      expect(result.stdout).toContain('was successfully created in ReadMe!');
-
+      expect(result).toMatchSnapshot();
       fileMock.done();
       mock.done();
     });
@@ -386,8 +364,7 @@ describe('rdme openapi upload', () => {
         });
 
       const result = await run(['--version', version, fileUrl, '--key', key]);
-      expect(result.stdout).toContain('was successfully updated in ReadMe!');
-
+      expect(result).toMatchSnapshot();
       fileMock.done();
       mock.done();
     });
@@ -396,8 +373,7 @@ describe('rdme openapi upload', () => {
       const fileMock = nock('https://example.com').get('/openapi.json').reply(400, {});
 
       const result = await run(['--version', version, fileUrl, '--key', key]);
-      expect(result.error.message).toBe('Unknown file detected.');
-
+      expect(result).toMatchSnapshot();
       fileMock.done();
     });
   });

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -110,7 +110,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     let filename = specFileTypeIsUrl ? nodePath.basename(specPath) : slugify.default(specPath);
 
     if (!specFileTypeIsUrl && filename !== specPath) {
-      this.log(`The slug of your API Definition will be updated to ${filename} to match ReadMe's slug requirements.`);
+      this.log(`The slug of your API Definition will be set to ${filename} in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.`);
     }
 
     if (this.flags.slug) {

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -105,7 +105,13 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
 
     const version = this.flags.useSpecVersion ? specVersion : this.flags.version;
 
-    let filename = specFileType === 'url' ? nodePath.basename(specPath) : slugify.default(specPath);
+    const specFileTypeIsUrl = specFileType === 'url';
+
+    let filename = specFileTypeIsUrl ? nodePath.basename(specPath) : slugify.default(specPath);
+
+    if (!specFileTypeIsUrl && filename !== specPath) {
+      this.log(`The file name of your API Definition will be updated to ${filename} to match ReadMe's slug requirements.`);
+    }
 
     if (this.flags.slug) {
       const fileExtension = nodePath.extname(filename);

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -110,7 +110,9 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     let filename = specFileTypeIsUrl ? nodePath.basename(specPath) : slugify.default(specPath);
 
     if (!specFileTypeIsUrl && filename !== specPath) {
-      this.log(`The slug of your API Definition will be set to ${filename} in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.`);
+      this.log(
+        `The slug of your API Definition will be set to ${filename} in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.`,
+      );
     }
 
     if (this.flags.slug) {

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -110,7 +110,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     let filename = specFileTypeIsUrl ? nodePath.basename(specPath) : slugify.default(specPath);
 
     if (!specFileTypeIsUrl && filename !== specPath) {
-      this.log(
+      this.warn(
         `The slug of your API Definition will be set to ${filename} in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.`,
       );
     }

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -110,7 +110,9 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     let filename = specFileTypeIsUrl ? nodePath.basename(specPath) : slugify.default(specPath);
 
     if (!specFileTypeIsUrl && filename !== specPath) {
-      this.log(`The file name of your API Definition will be updated to ${filename} to match ReadMe's slug requirements.`);
+      this.log(
+        `The file name of your API Definition will be updated to ${filename} to match ReadMe's slug requirements.`,
+      );
     }
 
     if (this.flags.slug) {

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -110,9 +110,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     let filename = specFileTypeIsUrl ? nodePath.basename(specPath) : slugify.default(specPath);
 
     if (!specFileTypeIsUrl && filename !== specPath) {
-      this.log(
-        `The file name of your API Definition will be updated to ${filename} to match ReadMe's slug requirements.`,
-      );
+      this.log(`The slug of your API Definition will be updated to ${filename} to match ReadMe's slug requirements.`);
     }
 
     if (this.flags.slug) {


### PR DESCRIPTION
| 🚥 Resolves RM-11894 |
| :------------------- |

## 🧰 Changes

Adding in a warning to alert users that the slug for the spec they're uploading will be updated

## 🧬 QA & Testing

Updated the tests to use snapshots instead of match `result.stdout` or `result.error` to be more comprehensive.
