### PR TITLE
chore(deps-dev): upgrading our eslint standards

### DIFF
--- a/__tests__/.eslintrc
+++ b/__tests__/.eslintrc
@@ -6,7 +6,5 @@
     "unicorn/prefer-module": "off",
 
     "@vitest/require-mock-type-parameters": "off",
-    "@vitest/padding-around-expect-groups": "off",
-    "@vitest/padding-around-all": "off",
   }
 }

--- a/__tests__/.eslintrc
+++ b/__tests__/.eslintrc
@@ -3,6 +3,10 @@
   "rules": {
     // vitest currently allows for __dirname, require, etc.
     // see https://github.com/vitest-dev/vitest/issues/2841
-    "unicorn/prefer-module": "off"
+    "unicorn/prefer-module": "off",
+
+    "@vitest/require-mock-type-parameters": "off",
+    "@vitest/padding-around-expect-groups": "off",
+    "@vitest/padding-around-all": "off",
   }
 }

--- a/__tests__/bin.test.ts
+++ b/__tests__/bin.test.ts
@@ -9,6 +9,7 @@ describe('bin', () => {
     await new Promise(resolve => {
       exec(`node ${__dirname}/../bin/run.js`, (error, stdout) => {
         expect(stdout).toContain("ReadMe's official CLI and GitHub Action");
+
         resolve(true);
       });
     });

--- a/__tests__/commands/docs/upload.test.ts
+++ b/__tests__/commands/docs/upload.test.ts
@@ -45,6 +45,7 @@ describe('rdme docs upload', () => {
         .reply(201, {});
 
       const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key]);
+
       expect(result).toMatchSnapshot();
       expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -64,6 +65,7 @@ describe('rdme docs upload', () => {
         .reply(201, {});
 
       const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key, '--version', '1.2.3']);
+
       expect(result).toMatchSnapshot();
       expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -75,6 +77,7 @@ describe('rdme docs upload', () => {
         const mock = getAPIv2Mock({ authorization }).head('/versions/stable/guides/new-doc').reply(404);
 
         const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key, '--dry-run']);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -85,6 +88,7 @@ describe('rdme docs upload', () => {
         const mock = getAPIv2Mock({ authorization }).head('/versions/stable/guides/some-slug').reply(200);
 
         const result = await run(['__tests__/__fixtures__/docs/slug-docs/new-doc-slug.md', '--key', key, '--dry-run']);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -95,6 +99,7 @@ describe('rdme docs upload', () => {
         const mock = getAPIv2Mock({ authorization }).head('/versions/stable/guides/some-slug').reply(500);
 
         const result = await run(['__tests__/__fixtures__/docs/slug-docs/new-doc-slug.md', '--key', key, '--dry-run']);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -116,6 +121,7 @@ describe('rdme docs upload', () => {
           .reply(201, {});
 
         const result = await run(['__tests__/__fixtures__/docs/slug-docs/new-doc-slug.md', '--key', key]);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -134,6 +140,7 @@ describe('rdme docs upload', () => {
           .reply(201, {});
 
         const result = await run(['__tests__/__fixtures__/docs/slug-docs/new-doc-slug.md', '--key', key]);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -157,6 +164,7 @@ describe('rdme docs upload', () => {
         prompts.inject([true]);
 
         const result = await run(['__tests__/__fixtures__/docs/mixed-docs/legacy-category.md', '--key', key]);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).toHaveBeenCalledWith(
           '__tests__/__fixtures__/docs/mixed-docs/legacy-category.md',
@@ -190,6 +198,7 @@ describe('rdme docs upload', () => {
         prompts.inject([true]);
 
         const result = await run(['__tests__/__fixtures__/docs/mixed-docs/legacy-category.md', '--key', key]);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).toHaveBeenCalledWith(
           '__tests__/__fixtures__/docs/mixed-docs/legacy-category.md',
@@ -205,6 +214,7 @@ describe('rdme docs upload', () => {
         prompts.inject([false]);
 
         const result = await run(['__tests__/__fixtures__/docs/mixed-docs/legacy-category.md', '--key', key]);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).not.toHaveBeenCalled();
       });
@@ -227,6 +237,7 @@ describe('rdme docs upload', () => {
           key,
           '--skip-validation',
         ]);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -249,6 +260,7 @@ describe('rdme docs upload', () => {
           .reply(201, {});
 
         const result = await run(['__tests__/__fixtures__/docs/mixed-docs/invalid-attributes.md', '--key', key]);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -278,6 +290,7 @@ describe('rdme docs upload', () => {
           .reply(201, {});
 
         const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key]);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -287,6 +300,7 @@ describe('rdme docs upload', () => {
 
       it('should error out if the file has validation errors', async () => {
         const result = await run(['__tests__/__fixtures__/docs/mixed-docs/legacy-category.md', '--key', key]);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).not.toHaveBeenCalled();
       });
@@ -296,6 +310,7 @@ describe('rdme docs upload', () => {
       const mock = getAPIv2Mock({ authorization }).head('/versions/stable/guides/new-doc').reply(500);
 
       const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key]);
+
       expect(result).toMatchSnapshot();
       expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -304,12 +319,14 @@ describe('rdme docs upload', () => {
 
     it('should error out if the file does not exist', async () => {
       const result = await run(['non-existent-file', '--key', key]);
+
       expect(result).toMatchSnapshot();
       expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
 
     it('should error out if the file has an invalid file extension', async () => {
       const result = await run(['package.json', '--key', key]);
+
       expect(result).toMatchSnapshot();
       expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
@@ -337,6 +354,7 @@ describe('rdme docs upload', () => {
         .reply(201, {});
 
       const result = await run(['__tests__/__fixtures__/docs/existing-docs', '--key', key]);
+
       expect(result).toMatchSnapshot();
       expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -362,6 +380,7 @@ describe('rdme docs upload', () => {
         .reply(201, {});
 
       const result = await run(['__tests__/__fixtures__/docs/existing-docs', '--key', key]);
+
       expect(result).toMatchSnapshot();
       expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -407,6 +426,7 @@ describe('rdme docs upload', () => {
           .reply(201, {});
 
         const result = await run(['__tests__/__fixtures__/docs/multiple-docs', '--key', key]);
+
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).not.toHaveBeenCalled();
 
@@ -416,6 +436,7 @@ describe('rdme docs upload', () => {
 
     it('should error out if the directory does not contain any Markdown files', async () => {
       const result = await run(['__tests__/__fixtures__/ref-oas', '--key', key]);
+
       expect(result).toMatchSnapshot();
     });
 
@@ -459,6 +480,7 @@ describe('rdme docs upload', () => {
       prompts.inject([true]);
 
       const result = await run(['__tests__/__fixtures__/docs/mixed-docs', '--key', key]);
+
       expect(result).toMatchSnapshot();
       expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
 
@@ -479,6 +501,7 @@ describe('rdme docs upload', () => {
       prompts.inject([true]);
 
       const result = await run(['__tests__/__fixtures__/docs/mixed-docs', '--key', key, '--dry-run']);
+
       expect(result).toMatchSnapshot();
       expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
 

--- a/__tests__/commands/login.test.ts
+++ b/__tests__/commands/login.test.ts
@@ -102,6 +102,7 @@ describe('rdme login', () => {
     const mock = getAPIv1Mock().post('/api/v1/login', { email, password, project }).reply(401, errorResponse);
 
     await expect(run()).rejects.toStrictEqual(new APIv1Error(errorResponse));
+
     mock.done();
   });
 
@@ -144,6 +145,7 @@ describe('rdme login', () => {
       .reply(404, errorResponse);
 
     await expect(run()).rejects.toStrictEqual(new APIv1Error(errorResponse));
+
     mock.done();
   });
 });

--- a/__tests__/commands/openapi/inspect.test.ts
+++ b/__tests__/commands/openapi/inspect.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable vitest/no-conditional-expect */
+/* eslint-disable @vitest/no-conditional-expect */
 import assert from 'node:assert';
 
 import { describe, it, expect, beforeAll } from 'vitest';

--- a/__tests__/commands/openapi/inspect.test.ts
+++ b/__tests__/commands/openapi/inspect.test.ts
@@ -69,6 +69,7 @@ describe('rdme openapi inspect', () => {
       const args = [require.resolve(spec)].concat(...feature.map(f => ['--feature', f]));
       if (!shouldSoftError) {
         await expect(run(args)).resolves.toMatchSnapshot();
+
         return;
       }
 

--- a/__tests__/commands/openapi/reduce.test.ts
+++ b/__tests__/commands/openapi/reduce.test.ts
@@ -76,6 +76,7 @@ describe('rdme openapi reduce', () => {
         expect(console.info).toHaveBeenCalledTimes(1);
 
         const output = getCommandOutput();
+
         expect(output).toBe(chalk.yellow(`ℹ️  We found ${spec} and are attempting to reduce it.`));
 
         expect(Object.keys(reducedSpec.paths)).toStrictEqual(['/user']);
@@ -98,6 +99,7 @@ describe('rdme openapi reduce', () => {
         expect(console.info).toHaveBeenCalledTimes(1);
 
         const output = getCommandOutput();
+
         expect(output).toBe(chalk.yellow(`ℹ️  We found ${spec} and are attempting to reduce it.`));
 
         expect(Object.keys(reducedSpec.paths)).toStrictEqual(['/user']);
@@ -147,6 +149,7 @@ describe('rdme openapi reduce', () => {
         expect(console.info).toHaveBeenCalledTimes(1);
 
         const output = getCommandOutput();
+
         expect(output).toBe(chalk.yellow(`ℹ️  We found ${spec} and are attempting to reduce it.`));
 
         expect(fsWriteFileSyncSpy).toHaveBeenCalledWith('output.json', expect.any(String));
@@ -181,6 +184,7 @@ describe('rdme openapi reduce', () => {
         expect(console.info).toHaveBeenCalledTimes(1);
 
         const output = getCommandOutput();
+
         expect(output).toBe(chalk.yellow(`ℹ️  We found ${spec} and are attempting to reduce it.`));
 
         expect(fsWriteFileSyncSpy).toHaveBeenCalledWith('output.json', expect.any(String));

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -27,6 +27,7 @@ describe('rdme openapi upload', () => {
   describe('flag error handling', () => {
     it('should throw if an error if both `--version` and `--useSpecVersion` flags are passed', async () => {
       const result = await run(['--useSpecVersion', '--version', version, filename, '--key', key]);
+
       expect(result).toMatchSnapshot();
     });
   });
@@ -47,6 +48,7 @@ describe('rdme openapi upload', () => {
         });
 
       const result = await run(['--version', version, filename, '--key', key]);
+
       expect(result).toMatchSnapshot();
 
       mock.done();
@@ -67,6 +69,7 @@ describe('rdme openapi upload', () => {
         });
 
       const result = await run(['--version', version, yamlFile, '--key', key]);
+
       expect(result).toMatchSnapshot();
 
       mock.done();
@@ -89,6 +92,7 @@ describe('rdme openapi upload', () => {
         });
 
       const result = await run(['--version', version, filename, '--key', key]);
+
       expect(result).toMatchSnapshot();
 
       mock.done();
@@ -109,6 +113,7 @@ describe('rdme openapi upload', () => {
         });
 
       const result = await run(['--version', version, filename, '--key', key]);
+
       expect(result).toMatchSnapshot();
 
       mock.done();
@@ -132,6 +137,7 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--version', version, filename, '--key', key, '--slug', customSlug]);
+
         expect(result).toMatchSnapshot();
 
         mock.done();
@@ -151,6 +157,7 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--version', version, filename, '--key', key, '--slug', customSlug]);
+
         expect(result).toMatchSnapshot();
 
         mock.done();
@@ -160,6 +167,7 @@ describe('rdme openapi upload', () => {
         const customSlug = 'custom-slug.yikes';
 
         const result = await run(['--version', version, filename, '--key', key, '--slug', customSlug]);
+
         expect(result).toMatchSnapshot();
       });
 
@@ -167,6 +175,7 @@ describe('rdme openapi upload', () => {
         const customSlug = 'custom-slug.yml';
 
         const result = await run(['--version', version, filename, '--key', key, '--slug', customSlug]);
+
         expect(result).toMatchSnapshot();
       });
     });
@@ -202,7 +211,9 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--version', version, filename, '--key', key]);
+
         expect(result).toMatchSnapshot();
+
         mock.done();
       });
 
@@ -229,7 +240,9 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--version', version, filename, '--key', key]);
+
         expect(result).toMatchSnapshot();
+
         mock.done();
       });
 
@@ -250,7 +263,9 @@ describe('rdme openapi upload', () => {
           .reply(400);
 
         const result = await run(['--version', version, filename, '--key', key]);
+
         expect(result).toMatchSnapshot();
+
         mock.done();
       });
 
@@ -276,7 +291,9 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--version', version, filename, '--key', key]);
+
         expect(result).toMatchSnapshot();
+
         mock.done();
       });
     });
@@ -301,7 +318,9 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--version', version, filename, '--key', key]);
+
         expect(result).toMatchSnapshot();
+
         mock.done();
       });
     });
@@ -322,7 +341,9 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run([filename, '--key', key]);
+
         expect(result).toMatchSnapshot();
+
         mock.done();
       });
 
@@ -342,7 +363,9 @@ describe('rdme openapi upload', () => {
           });
 
         const result = await run(['--useSpecVersion', filename, '--key', key]);
+
         expect(result).toMatchSnapshot();
+
         mock.done();
       });
     });
@@ -364,7 +387,9 @@ describe('rdme openapi upload', () => {
         });
 
       const result = await run(['--version', version, fileUrl, '--key', key]);
+
       expect(result).toMatchSnapshot();
+
       fileMock.done();
       mock.done();
     });
@@ -386,7 +411,9 @@ describe('rdme openapi upload', () => {
         });
 
       const result = await run(['--version', version, fileUrl, '--key', key]);
+
       expect(result).toMatchSnapshot();
+
       fileMock.done();
       mock.done();
     });
@@ -395,7 +422,9 @@ describe('rdme openapi upload', () => {
       const fileMock = nock('https://example.com').get('/openapi.json').reply(400, {});
 
       const result = await run(['--version', version, fileUrl, '--key', key]);
+
       expect(result).toMatchSnapshot();
+
       fileMock.done();
     });
   });

--- a/__tests__/commands/openapi/validate.test.ts
+++ b/__tests__/commands/openapi/validate.test.ts
@@ -44,6 +44,7 @@ describe('rdme openapi validate', () => {
     ['OpenAPI 3.1', 'yaml', '3.1'],
   ])('should support validating a %s definition (format: %s)', (_, format, specVersion) => {
     expect(console.info).toHaveBeenCalledTimes(0);
+
     return expect(
       run([require.resolve(`@readme/oas-examples/${specVersion}/${format}/petstore.${format}`)]),
     ).resolves.toContain(
@@ -59,6 +60,7 @@ describe('rdme openapi validate', () => {
     expect(console.info).toHaveBeenCalledTimes(1);
 
     const output = getCommandOutput();
+
     expect(output).toBe(chalk.yellow('ℹ️  We found petstore.json and are attempting to validate it.'));
   });
 
@@ -115,6 +117,7 @@ describe('rdme openapi validate', () => {
     it('should successfully validate prompt and not run GHA onboarding', async () => {
       vi.stubEnv('TEST_RDME_CREATEGHA', 'true');
       const spec = '__tests__/__fixtures__/petstore-simple-weird-version.json';
+
       await expect(run([spec])).resolves.toBe(chalk.green(`${spec} is a valid OpenAPI API definition!`));
     });
 
@@ -146,6 +149,7 @@ describe('rdme openapi validate', () => {
 
     it('should create GHA workflow if user passes in spec via prompts', async () => {
       expect.assertions(6);
+
       const spec = '__tests__/__fixtures__/petstore-simple-weird-version.json';
       const fileName = 'validate-test-file';
       prompts.inject([spec, true, 'validate-test-branch', fileName]);
@@ -155,13 +159,16 @@ describe('rdme openapi validate', () => {
       expect(yamlOutput).toMatchSnapshot();
       expect(fs.writeFileSync).toHaveBeenCalledWith(`.github/workflows/${fileName}.yml`, expect.any(String));
       expect(console.info).toHaveBeenCalledTimes(2);
+
       const output = getCommandOutput();
+
       expect(output).toMatch("Looks like you're running this command in a GitHub Repository!");
       expect(output).toMatch('is a valid OpenAPI API definition!');
     });
 
     it('should create GHA workflow if user passes in spec via opt', async () => {
       expect.assertions(3);
+
       const spec = '__tests__/__fixtures__/petstore-simple-weird-version.json';
       const fileName = 'validate-test-opt-spec-file';
       prompts.inject([true, 'validate-test-opt-spec-branch', fileName]);
@@ -174,6 +181,7 @@ describe('rdme openapi validate', () => {
 
     it('should create GHA workflow if user passes in spec via opt (including workingDirectory)', async () => {
       expect.assertions(3);
+
       const spec = 'petstore.json';
       const fileName = 'validate-test-opt-spec-workdir-file';
       prompts.inject([true, 'validate-test-opt-spec-github-branch', fileName]);
@@ -188,6 +196,7 @@ describe('rdme openapi validate', () => {
 
     it('should create GHA workflow if user passes in spec via opt (github flag enabled)', async () => {
       expect.assertions(3);
+
       const spec = '__tests__/__fixtures__/petstore-simple-weird-version.json';
       const fileName = 'validate-test-opt-spec-github-file';
       prompts.inject(['validate-test-opt-spec-github-branch', fileName]);

--- a/__tests__/lib/createGHA.test.ts
+++ b/__tests__/lib/createGHA.test.ts
@@ -75,22 +75,27 @@ describe('#createGHA', () => {
 
       it('should run GHA creation workflow and generate valid workflow file', async () => {
         expect.assertions(6);
+
         const fileName = `rdme-${cmd}`;
         prompts.inject([true, 'some-branch', fileName]);
 
         const res = await oclifConfig.runHook('createGHA', { command: CurrentCommand, parsedOpts: opts, result: '' });
+
         expect(res.successes[0].result).toMatchSnapshot();
 
         expect(yamlOutput).toBeValidSchema(ghaWorkflowSchema);
         expect(yamlOutput).toMatchSnapshot();
         expect(fs.writeFileSync).toHaveBeenCalledWith(getGHAFileName(fileName), expect.any(String));
         expect(console.info).toHaveBeenCalledTimes(1);
+
         const output = getCommandOutput();
+
         expect(output).toMatch("Looks like you're running this command in a GitHub Repository!");
       });
 
       it('should run GHA creation workflow with `--github` flag and messy file name and generate valid workflow file', async () => {
         expect.assertions(4);
+
         const fileName = `rdme-${cmd} with GitHub flag`;
         prompts.inject(['another-branch', fileName]);
 
@@ -99,6 +104,7 @@ describe('#createGHA', () => {
           parsedOpts: { ...opts, github: true },
           result: '',
         });
+
         expect(res.successes[0].result).toMatchSnapshot();
 
         expect(yamlOutput).toBeValidSchema(ghaWorkflowSchema);
@@ -109,6 +115,7 @@ describe('#createGHA', () => {
       // skipping because these mocks aren't playing nicely with oclif
       it.skip('should create workflow directory if it does not exist', async () => {
         expect.assertions(3);
+
         const repoRoot = '__tests__/__fixtures__';
 
         git.revparse = vi.fn(() => {
@@ -123,6 +130,7 @@ describe('#createGHA', () => {
         });
 
         const res = await oclifConfig.runHook('createGHA', { command: CurrentCommand, parsedOpts: opts, result: '' });
+
         expect(res.successes[0].result).toBe(true);
 
         expect(fs.mkdirSync).toHaveBeenCalledWith('.github/workflows', { recursive: true });
@@ -143,6 +151,7 @@ describe('#createGHA', () => {
 
       it('should set config and exit if user does not want to set up GHA', async () => {
         expect.assertions(2);
+
         prompts.inject([false]);
 
         const repoRoot = process.cwd();
@@ -152,6 +161,7 @@ describe('#createGHA', () => {
         });
 
         const res = await oclifConfig.runHook('createGHA', { command: CurrentCommand, parsedOpts: opts, result: '' });
+
         expect(res.failures[0].error).toStrictEqual(
           new Error(
             'GitHub Actions workflow creation cancelled. If you ever change your mind, you can run this command again with the `--github` flag.',
@@ -225,9 +235,11 @@ describe('#createGHA', () => {
           parsedOpts: opts,
           result: 'success!',
         });
+
         expect(res.successes[0].result).toBe('success!');
         // asserts that git commands aren't run in CI
         expect(git.checkIsRepo).not.toHaveBeenCalled();
+
         delete process.env.TEST_RDME_CI;
       });
 
@@ -238,9 +250,11 @@ describe('#createGHA', () => {
           parsedOpts: opts,
           result: 'success!',
         });
+
         expect(res.successes[0].result).toBe('success!');
         // asserts that git commands aren't run in CI
         expect(git.checkIsRepo).not.toHaveBeenCalled();
+
         delete process.env.TEST_RDME_NPM_SCRIPT;
       });
 

--- a/__tests__/lib/createGHA.test.ts
+++ b/__tests__/lib/createGHA.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable vitest/no-disabled-tests */
+/* eslint-disable @vitest/no-disabled-tests */
 /* eslint-disable no-console */
 import type { Command, Config } from '@oclif/core';
 import type { Response } from 'simple-git';
@@ -123,7 +123,7 @@ describe('#createGHA', () => {
         });
 
         const res = await oclifConfig.runHook('createGHA', { command: CurrentCommand, parsedOpts: opts, result: '' });
-        expect(res.successes[0].result).toBeTruthy();
+        expect(res.successes[0].result).toBe(true);
 
         expect(fs.mkdirSync).toHaveBeenCalledWith('.github/workflows', { recursive: true });
         expect(fs.writeFileSync).toHaveBeenCalledWith(getGHAFileName(fileName), expect.any(String));

--- a/__tests__/lib/fetch.test.ts
+++ b/__tests__/lib/fetch.test.ts
@@ -299,7 +299,7 @@ describe('#readmeAPIv1Fetch()', () => {
 
       await readmeAPIv1Fetch('/api/v1/proxy');
 
-      mock.done();
+      expect(mock.isDone()).toBe(true);
     });
 
     it('should support proxies via https_proxy env variable', async () => {
@@ -311,7 +311,7 @@ describe('#readmeAPIv1Fetch()', () => {
 
       await readmeAPIv1Fetch('/api/v1/proxy');
 
-      mock.done();
+      expect(mock.isDone()).toBe(true);
     });
 
     it('should handle trailing slash in proxy URL', async () => {
@@ -323,7 +323,7 @@ describe('#readmeAPIv1Fetch()', () => {
 
       await readmeAPIv1Fetch('/api/v1/proxy');
 
-      mock.done();
+      expect(mock.isDone()).toBe(true);
     });
   });
 });

--- a/__tests__/lib/fetch.test.ts
+++ b/__tests__/lib/fetch.test.ts
@@ -37,6 +37,7 @@ describe('#readmeAPIv1Fetch()', () => {
       expect(headers['x-github-run-number']).toBe('3');
       expect(headers['x-github-sha']).toBe('ffac537e6cbbf934b08745a378932722df287a53');
       expect(headers['x-rdme-ci']).toBe('GitHub Actions (test)');
+
       mock.done();
     });
 
@@ -63,6 +64,7 @@ describe('#readmeAPIv1Fetch()', () => {
         expect(headers['x-readme-source-url']).toBe(
           'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/openapi.json',
         );
+
         mock.done();
       });
 
@@ -88,6 +90,7 @@ describe('#readmeAPIv1Fetch()', () => {
         expect(headers['x-readme-source-url']).toBe(
           'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/%F0%9F%93%88%20Dashboard%20&%20Metrics/openapi.json',
         );
+
         mock.done();
       });
 
@@ -112,6 +115,7 @@ describe('#readmeAPIv1Fetch()', () => {
         ).then(handleAPIv1Res);
 
         expect(headers['x-readme-source-url']).toBeUndefined();
+
         mock.done();
       });
 
@@ -137,6 +141,7 @@ describe('#readmeAPIv1Fetch()', () => {
         expect(headers['x-readme-source-url']).toBe(
           'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/openapi.json',
         );
+
         mock.done();
       });
 
@@ -161,6 +166,7 @@ describe('#readmeAPIv1Fetch()', () => {
         ).then(handleAPIv1Res);
 
         expect(headers['x-readme-source-url']).toBe(filePath);
+
         mock.done();
       });
     });
@@ -188,6 +194,7 @@ describe('#readmeAPIv1Fetch()', () => {
     expect(headers['x-github-run-id']).toBeUndefined();
     expect(headers['x-github-run-number']).toBeUndefined();
     expect(headers['x-github-sha']).toBeUndefined();
+
     mock.done();
   });
 
@@ -207,6 +214,7 @@ describe('#readmeAPIv1Fetch()', () => {
     expect(headers['x-github-run-id']).toBeUndefined();
     expect(headers['x-github-run-number']).toBeUndefined();
     expect(headers['x-github-sha']).toBeUndefined();
+
     mock.done();
   });
 

--- a/__tests__/lib/getPkgVersion.test.ts
+++ b/__tests__/lib/getPkgVersion.test.ts
@@ -9,6 +9,7 @@ describe('#getNodeVersion()', () => {
   it('should extract version that matches range in package.json', () => {
     const version = getNodeVersion();
     const cleanedVersion = semver.valid(semver.coerce(version));
+
     expect(semver.satisfies(cleanedVersion as string, pkg.engines.node)).toBe(true);
   });
 });

--- a/__tests__/lib/validatePromptInput.test.ts
+++ b/__tests__/lib/validatePromptInput.test.ts
@@ -15,6 +15,7 @@ describe('#validateFilePath', () => {
 
   it('should return error if path already exists', () => {
     expect.assertions(2);
+
     const testPath = 'path-that-already-exists';
 
     fs.existsSync = vi.fn(() => true);
@@ -25,6 +26,7 @@ describe('#validateFilePath', () => {
 
   it("should return true if the path doesn't exist", () => {
     expect.assertions(2);
+
     const testPath = 'path-that-does-not-exist';
 
     fs.existsSync = vi.fn(() => false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@commitlint/cli": "^19.0.3",
         "@commitlint/config-conventional": "^19.0.3",
         "@oclif/test": "^4.1.0",
-        "@readme/eslint-config": "^14.0.0",
+        "@readme/eslint-config": "^14.3.0",
         "@readme/oas-examples": "^5.10.0",
         "@rollup/plugin-commonjs": "^28.0.0",
         "@rollup/plugin-json": "^6.0.0",
@@ -2929,16 +2929,17 @@
       }
     },
     "node_modules/@readme/eslint-config": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-14.1.2.tgz",
-      "integrity": "sha512-KhdKYK9GBxA36YAYx6jNIbs4/n/zxKEnEfs3XvVbEwmtkojlGdF+oWQlnzelZeBgKwh0/Je2cD2haauC7186Pw==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-14.3.0.tgz",
+      "integrity": "sha512-++vSkRcwVgpRma2ZJZJZFv2ImfEE8g67Jw/xVXxVGTn8Doc2tGNsxb3ab6WnUIhJxFcjPW4IJrxRv0Ix2umLKQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
+        "@vitest/eslint-plugin": "^1.1.32-beta.1",
         "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-config-prettier": "^9.1.0",
+        "eslint-config-prettier": "^10.0.1",
         "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.28.1",
@@ -2948,14 +2949,13 @@
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-react": "^7.34.4",
-        "eslint-plugin-react-hooks": "^4.6.0",
-        "eslint-plugin-readme": "^2.0.6",
+        "eslint-plugin-react-hooks": "^5.0.0",
+        "eslint-plugin-readme": "^2.0.8",
         "eslint-plugin-require-extensions": "^0.1.3",
-        "eslint-plugin-testing-library": "^6.0.1",
+        "eslint-plugin-testing-library": "^7.1.1",
         "eslint-plugin-try-catch-failsafe": "^0.1.4",
         "eslint-plugin-typescript-sort-keys": "^3.2.0",
-        "eslint-plugin-unicorn": "^55.0.0",
-        "eslint-plugin-vitest": "^0.5.4",
+        "eslint-plugin-unicorn": "^56.0.1",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0",
         "lodash": "^4.17.21"
       },
@@ -4903,6 +4903,26 @@
         }
       }
     },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.1.32-beta.1",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.1.32-beta.1.tgz",
+      "integrity": "sha512-U0OWYco/g+y+AtyOWBrFYCBUreDG4aFYh+4FiSHB0kI3KXQ5/ytf7UCfPwMfewQjhBYJpfQ0uphKy5x3ItLqVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">= 8.57.0",
+        "typescript": ">= 5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.5.tgz",
@@ -5910,9 +5930,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001696",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
-      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
+      "version": "1.0.30001700",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
+      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
       "dev": true,
       "funding": [
         {
@@ -7015,9 +7035,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.91",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.91.tgz",
-      "integrity": "sha512-sNSHHyq048PFmZY4S90ax61q+gLCs0X0YmcOII9wG9S2XwbVr+h4VW2wWhnbp/Eys3cCwTxVF292W3qPaxIapQ==",
+      "version": "1.5.103",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.103.tgz",
+      "integrity": "sha512-P6+XzIkfndgsrjROJWfSvVEgNHtPgbhVyTkwLjUM2HU/h7pZRORgaTlHqfAikqxKmdJMLW8fftrdGWbd/Ds0FA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7469,13 +7489,13 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
-      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.0.1.tgz",
+      "integrity": "sha512-lZBts941cyJyeaooiKxAtzoPHTN+GbQTJFAIdQbRhA4/8whaAraEh47Whw/ZFfrjNSnlAxqfm9i0XVAEkULjCw==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "eslint-config-prettier": "bin/cli.js"
+        "eslint-config-prettier": "build/bin/cli.js"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
@@ -7935,16 +7955,16 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz",
+      "integrity": "sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
@@ -8013,9 +8033,9 @@
       }
     },
     "node_modules/eslint-plugin-readme": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-readme/-/eslint-plugin-readme-2.0.6.tgz",
-      "integrity": "sha512-BOGxzzTzAoIIccSPR8f1paYNuC+3Pz9LNNXK3zoDW5Wt5QEdTUvef/RXh0gEVp8hH70bkchAR2h8V71w36vkHw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-readme/-/eslint-plugin-readme-2.0.8.tgz",
+      "integrity": "sha512-dYWpmV3ghTeF6Lil82xLI/W9E7pxS5VRfy8/jaX1DphVKglNINh+1hknxTKC+pGzLrWQnVZWb6H4Mvan+RafEQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -8039,149 +8059,21 @@
       }
     },
     "node_modules/eslint-plugin-testing-library": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.5.0.tgz",
-      "integrity": "sha512-Ls5TUfLm5/snocMAOlofSOJxNN0aKqwTlco7CrNtMjkTdQlkpSMaeTCDHCuXfzrI97xcx2rSCNeKeJjtpkNC1w==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.1.1.tgz",
+      "integrity": "sha512-nszC833aZPwB6tik1nMkbFqmtgIXTT0sfJEYs0zMBKMlkQ4to2079yUV96SvmLh00ovSBJI4pgcBC1TiIP8mXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^5.62.0"
+        "@typescript-eslint/scope-manager": "^8.15.0",
+        "@typescript-eslint/utils": "^8.15.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
-        "npm": ">=6"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0",
+        "pnpm": "^9.14.0"
       },
       "peerDependencies": {
-        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/visitor-keys": "5.62.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/types": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/visitor-keys": "5.62.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/utils": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@types/json-schema": "^7.0.9",
-        "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/typescript-estree": "5.62.0",
-        "eslint-scope": "^5.1.1",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
+        "eslint": "^8.57.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-try-catch-failsafe": {
@@ -8215,19 +8107,19 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "55.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-55.0.0.tgz",
-      "integrity": "sha512-n3AKiVpY2/uDcGrS3+QsYDkjPfaOrNrsfQxU9nt5nitd9KuvVXrfAvgCO9DYPSfap+Gqjw9EOrXIsBp5tlHZjA==",
+      "version": "56.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-56.0.1.tgz",
+      "integrity": "sha512-FwVV0Uwf8XPfVnKSGpMg7NtlZh0G0gBarCaFcMUOoqPxXryxdYxTRRv4kH6B9TFCVIrjRXG+emcxIk2ayZilog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.5",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "@eslint-community/eslint-utils": "^4.4.0",
         "ci-info": "^4.0.0",
         "clean-regexp": "^1.0.0",
-        "core-js-compat": "^3.37.0",
-        "esquery": "^1.5.0",
-        "globals": "^15.7.0",
+        "core-js-compat": "^3.38.1",
+        "esquery": "^1.6.0",
+        "globals": "^15.9.0",
         "indent-string": "^4.0.0",
         "is-builtin-module": "^3.2.1",
         "jsesc": "^3.0.2",
@@ -8235,7 +8127,7 @@
         "read-pkg-up": "^7.0.1",
         "regexp-tree": "^0.1.27",
         "regjsparser": "^0.10.0",
-        "semver": "^7.6.1",
+        "semver": "^7.6.3",
         "strip-indent": "^3.0.0"
       },
       "engines": {
@@ -8249,9 +8141,9 @@
       }
     },
     "node_modules/eslint-plugin-unicorn/node_modules/globals": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
-      "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8259,146 +8151,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-vitest": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vitest/-/eslint-plugin-vitest-0.5.4.tgz",
-      "integrity": "sha512-um+odCkccAHU53WdKAw39MY61+1x990uXjSPguUCq3VcEHdqJrOb8OTMrbYlY6f9jAKx7x98kLVlIe3RJeJqoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/utils": "^7.7.1"
-      },
-      "engines": {
-        "node": "^18.0.0 || >= 20.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "vitest": "*"
-      },
-      "peerDependenciesMeta": {
-        "@typescript-eslint/eslint-plugin": {
-          "optional": true
-        },
-        "vitest": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
-      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/types": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
-      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
-      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/utils": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
-      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/typescript-estree": "7.18.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      }
-    },
-    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
-      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-vitest/node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.2.0"
       }
     },
     "node_modules/eslint-plugin-you-dont-need-lodash-underscore": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@commitlint/cli": "^19.0.3",
     "@commitlint/config-conventional": "^19.0.3",
     "@oclif/test": "^4.1.0",
-    "@readme/eslint-config": "^14.0.0",
+    "@readme/eslint-config": "^14.3.0",
     "@readme/oas-examples": "^5.10.0",
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-json": "^6.0.0",


### PR DESCRIPTION
## 🧰 Changes

The owner of `eslint-plugin-vitest` lost their NPM access to it was moved into `@vitest/eslint-plugin` a little over a year ago. This upgrades our `@readme/eslint-config` package to pull that in.