### PR TITLE
test(openapi/validate): rewrite tests to be more comprehensive

### DIFF
--- a/__tests__/commands/openapi/__snapshots__/validate.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/validate.test.ts.snap
@@ -1,13 +1,37 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`rdme openapi validate > CI tests > should fail if user attempts to pass \`--github\` flag in CI environment 1`] = `
+[Error: Parsing --github 
+	The \`--github\` flag is only for usage in non-CI environments.
+See more help with --help]
+`;
+
+exports[`rdme openapi validate > CI tests > should successfully validate prompt and not run GHA onboarding 1`] = `
+{
+  "result": "__tests__/__fixtures__/petstore-simple-weird-version.json is a valid OpenAPI API definition!",
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+",
+  "stdout": "",
+}
+`;
+
 exports[`rdme openapi validate > GHA onboarding E2E tests > should create GHA workflow if user passes in spec via opt (github flag enabled) 1`] = `
-"
+{
+  "result": "
 Your GitHub Actions workflow file has been created! ✨
 
 Almost done! Push your newly created file (.github/workflows/validate-test-opt-spec-github-file.yml) to GitHub and you're all set 🚀
 
 🦉 If you have any more questions, feel free to drop us a line! support@readme.io
-"
+",
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+",
+  "stdout": "__tests__/__fixtures__/petstore-simple-weird-version.json is a valid OpenAPI API definition!
+
+🚀 Let's get you set up with GitHub Actions! 🚀
+
+",
+}
 `;
 
 exports[`rdme openapi validate > GHA onboarding E2E tests > should create GHA workflow if user passes in spec via opt (github flag enabled) 2`] = `
@@ -38,13 +62,26 @@ jobs:
 `;
 
 exports[`rdme openapi validate > GHA onboarding E2E tests > should create GHA workflow if user passes in spec via opt (including workingDirectory) 1`] = `
-"
+{
+  "result": "
 Your GitHub Actions workflow file has been created! ✨
 
 Almost done! Push your newly created file (.github/workflows/validate-test-opt-spec-workdir-file.yml) to GitHub and you're all set 🚀
 
 🦉 If you have any more questions, feel free to drop us a line! support@readme.io
-"
+",
+  "stderr": "- Validating the API definition located at petstore.json...
+",
+  "stdout": "petstore.json is a valid OpenAPI API definition!
+
+🐙 Looks like you're running this command in a GitHub Repository! 🐙
+
+🚀 With a few quick clicks, you can run this \`openapi validate\` command via GitHub Actions (https://github.com/features/actions)
+
+✨ This means it will run automagically with every push to a branch of your choice!
+
+",
+}
 `;
 
 exports[`rdme openapi validate > GHA onboarding E2E tests > should create GHA workflow if user passes in spec via opt (including workingDirectory) 2`] = `
@@ -75,13 +112,26 @@ jobs:
 `;
 
 exports[`rdme openapi validate > GHA onboarding E2E tests > should create GHA workflow if user passes in spec via opt 1`] = `
-"
+{
+  "result": "
 Your GitHub Actions workflow file has been created! ✨
 
 Almost done! Push your newly created file (.github/workflows/validate-test-opt-spec-file.yml) to GitHub and you're all set 🚀
 
 🦉 If you have any more questions, feel free to drop us a line! support@readme.io
-"
+",
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+",
+  "stdout": "__tests__/__fixtures__/petstore-simple-weird-version.json is a valid OpenAPI API definition!
+
+🐙 Looks like you're running this command in a GitHub Repository! 🐙
+
+🚀 With a few quick clicks, you can run this \`openapi validate\` command via GitHub Actions (https://github.com/features/actions)
+
+✨ This means it will run automagically with every push to a branch of your choice!
+
+",
+}
 `;
 
 exports[`rdme openapi validate > GHA onboarding E2E tests > should create GHA workflow if user passes in spec via opt 2`] = `
@@ -112,13 +162,27 @@ jobs:
 `;
 
 exports[`rdme openapi validate > GHA onboarding E2E tests > should create GHA workflow if user passes in spec via prompts 1`] = `
-"
+{
+  "result": "
 Your GitHub Actions workflow file has been created! ✨
 
 Almost done! Push your newly created file (.github/workflows/validate-test-file.yml) to GitHub and you're all set 🚀
 
 🦉 If you have any more questions, feel free to drop us a line! support@readme.io
-"
+",
+  "stderr": "- Looking for API definitions...
+- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+",
+  "stdout": "__tests__/__fixtures__/petstore-simple-weird-version.json is a valid OpenAPI API definition!
+
+🐙 Looks like you're running this command in a GitHub Repository! 🐙
+
+🚀 With a few quick clicks, you can run this \`openapi validate\` command via GitHub Actions (https://github.com/features/actions)
+
+✨ This means it will run automagically with every push to a branch of your choice!
+
+",
+}
 `;
 
 exports[`rdme openapi validate > GHA onboarding E2E tests > should create GHA workflow if user passes in spec via prompts 2`] = `
@@ -148,8 +212,27 @@ jobs:
 "
 `;
 
+exports[`rdme openapi validate > GHA onboarding E2E tests > should reject if user says no to creating GHA workflow 1`] = `
+{
+  "error": [Error: GitHub Actions workflow creation cancelled. If you ever change your mind, you can run this command again with the \`--github\` flag.],
+  "stderr": "- Looking for API definitions...
+- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+",
+  "stdout": "__tests__/__fixtures__/petstore-simple-weird-version.json is a valid OpenAPI API definition!
+
+🐙 Looks like you're running this command in a GitHub Repository! 🐙
+
+🚀 With a few quick clicks, you can run this \`openapi validate\` command via GitHub Actions (https://github.com/features/actions)
+
+✨ This means it will run automagically with every push to a branch of your choice!
+
+",
+}
+`;
+
 exports[`rdme openapi validate > error handling > should throw an error if an invalid API definition has many errors 1`] = `
-[SyntaxError: OpenAPI schema validation failed.
+{
+  "error": [SyntaxError: OpenAPI schema validation failed.
 
 REQUIRED must have required property 'url'
 
@@ -169,13 +252,27 @@ ADDITIONAL PROPERTY must NOT have additional properties
      |         ^^^^^^^ tagss is not expected to be here!
   27 |           "pet"
   28 |         ],
-  29 |         "summary": "Finds Pets by status",]
+  29 |         "summary": "Finds Pets by status",],
+  "stderr": "- Validating the API definition located at ./__tests__/__fixtures__/very-invalid-oas.json...
+✖ Validating the API definition located at ./__tests__/__fixtures__/very-invalid-oas.json...
+",
+  "stdout": "",
+}
 `;
 
-exports[`rdme openapi validate > error handling > should throw an error if an invalid OpenAPI 3.0 definition is supplied 1`] = `[MissingPointerError: Token "Error" does not exist.]`;
+exports[`rdme openapi validate > error handling > should throw an error if an invalid OpenAPI 3.0 definition is supplied 1`] = `
+{
+  "error": [MissingPointerError: Token "Error" does not exist.],
+  "stderr": "- Validating the API definition located at ./__tests__/__fixtures__/invalid-oas.json...
+✖ Validating the API definition located at ./__tests__/__fixtures__/invalid-oas.json...
+",
+  "stdout": "",
+}
+`;
 
 exports[`rdme openapi validate > error handling > should throw an error if an invalid OpenAPI 3.1 definition is supplied 1`] = `
-[SyntaxError: OpenAPI schema validation failed.
+{
+  "error": [SyntaxError: OpenAPI schema validation failed.
 
 REQUIRED must have required property 'name'
 
@@ -185,11 +282,17 @@ REQUIRED must have required property 'name'
      |                  ^ name is missing here!
   27 |         "type": "mutualTLS"
   28 |       }
-  29 |     }]
+  29 |     }],
+  "stderr": "- Validating the API definition located at ./__tests__/__fixtures__/invalid-oas-3.1.json...
+✖ Validating the API definition located at ./__tests__/__fixtures__/invalid-oas-3.1.json...
+",
+  "stdout": "",
+}
 `;
 
 exports[`rdme openapi validate > error handling > should throw an error if an invalid Swagger definition is supplied 1`] = `
-[SyntaxError: Swagger schema validation failed.
+{
+  "error": [SyntaxError: Swagger schema validation failed.
 
 ADDITIONAL PROPERTY must NOT have additional properties
 
@@ -199,5 +302,51 @@ ADDITIONAL PROPERTY must NOT have additional properties
      |         ^^^^^^^^^^^^^^^^^^^^^^^ this-shouldnt-be-here is not expected to be here!
   26 |       }
   27 |     }
-  28 |   ],]
+  28 |   ],],
+  "stderr": "- Validating the API definition located at ./__tests__/__fixtures__/invalid-swagger.json...
+✖ Validating the API definition located at ./__tests__/__fixtures__/invalid-swagger.json...
+",
+  "stdout": "",
+}
+`;
+
+exports[`rdme openapi validate > error handling > should throw an error if invalid JSON is supplied 1`] = `
+{
+  "error": [SyntaxError: Unexpected end of JSON input],
+  "stderr": "- Validating the API definition located at ./__tests__/__fixtures__/invalid-json/yikes.json...
+✖ Validating the API definition located at ./__tests__/__fixtures__/invalid-json/yikes.json...
+",
+  "stdout": "",
+}
+`;
+
+exports[`rdme openapi validate > should adhere to .gitignore in subdirectories 1`] = `
+{
+  "result": "nest/petstore.json is a valid OpenAPI API definition!",
+  "stderr": "- Looking for API definitions...
+- Validating the API definition located at nest/petstore.json...
+",
+  "stdout": "ℹ️  We found nest/petstore.json and are attempting to validate it.
+",
+}
+`;
+
+exports[`rdme openapi validate > should discover and upload an API definition if none is provided 1`] = `
+{
+  "result": "petstore.json is a valid OpenAPI API definition!",
+  "stderr": "- Looking for API definitions...
+- Validating the API definition located at petstore.json...
+",
+  "stdout": "ℹ️  We found petstore.json and are attempting to validate it.
+",
+}
+`;
+
+exports[`rdme openapi validate > should use specified working directory 1`] = `
+{
+  "result": "petstore.json is a valid OpenAPI API definition!",
+  "stderr": "- Validating the API definition located at petstore.json...
+",
+  "stdout": "",
+}
 `;

--- a/__tests__/commands/openapi/validate.test.ts
+++ b/__tests__/commands/openapi/validate.test.ts
@@ -121,8 +121,6 @@ describe('rdme openapi validate', () => {
     });
 
     it('should create GHA workflow if user passes in spec via prompts', async () => {
-      expect.assertions(3);
-
       const spec = '__tests__/__fixtures__/petstore-simple-weird-version.json';
       const fileName = 'validate-test-file';
       prompts.inject([spec, true, 'validate-test-branch', fileName]);
@@ -133,8 +131,6 @@ describe('rdme openapi validate', () => {
     });
 
     it('should create GHA workflow if user passes in spec via opt', async () => {
-      expect.assertions(3);
-
       const spec = '__tests__/__fixtures__/petstore-simple-weird-version.json';
       const fileName = 'validate-test-opt-spec-file';
       prompts.inject([true, 'validate-test-opt-spec-branch', fileName]);
@@ -146,8 +142,6 @@ describe('rdme openapi validate', () => {
     });
 
     it('should create GHA workflow if user passes in spec via opt (including workingDirectory)', async () => {
-      expect.assertions(3);
-
       const spec = 'petstore.json';
       const fileName = 'validate-test-opt-spec-workdir-file';
       prompts.inject([true, 'validate-test-opt-spec-github-branch', fileName]);
@@ -161,8 +155,6 @@ describe('rdme openapi validate', () => {
     });
 
     it('should create GHA workflow if user passes in spec via opt (github flag enabled)', async () => {
-      expect.assertions(3);
-
       const spec = '__tests__/__fixtures__/petstore-simple-weird-version.json';
       const fileName = 'validate-test-opt-spec-github-file';
       prompts.inject(['validate-test-opt-spec-github-branch', fileName]);

--- a/__tests__/commands/openapi/validate.test.ts
+++ b/__tests__/commands/openapi/validate.test.ts
@@ -1,37 +1,27 @@
-/* eslint-disable no-console */
+ 
 
 import fs from 'node:fs';
 
-import chalk from 'chalk';
 import prompts from 'prompts';
-import { describe, beforeAll, beforeEach, afterEach, it, expect, vi, type MockInstance } from 'vitest';
+import { describe, beforeAll, beforeEach, afterEach, it, expect, vi } from 'vitest';
 
 import Command from '../../../src/commands/openapi/validate.js';
 import { after, before } from '../../helpers/get-gha-setup.js';
-import { runCommandAndReturnResult, runCommandWithHooks } from '../../helpers/oclif.js';
-
-let consoleInfoSpy: MockInstance<typeof console.info>;
-
-const getCommandOutput = () => {
-  return [consoleInfoSpy.mock.calls.join('\n\n')].filter(Boolean).join('\n\n');
-};
+import { runCommand, runCommandWithHooks, type OclifOutput } from '../../helpers/oclif.js';
 
 describe('rdme openapi validate', () => {
-  let run: (args?: string[]) => Promise<string>;
+  let run: (args?: string[]) => OclifOutput;
   let testWorkingDir: string;
 
   beforeAll(() => {
-    run = runCommandAndReturnResult(Command);
+    run = runCommand(Command);
   });
 
   beforeEach(() => {
-    consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     testWorkingDir = process.cwd();
   });
 
   afterEach(() => {
-    consoleInfoSpy.mockRestore();
-
     process.chdir(testWorkingDir);
   });
 
@@ -42,66 +32,53 @@ describe('rdme openapi validate', () => {
     ['OpenAPI 3.0', 'yaml', '3.0'],
     ['OpenAPI 3.1', 'json', '3.1'],
     ['OpenAPI 3.1', 'yaml', '3.1'],
-  ])('should support validating a %s definition (format: %s)', (_, format, specVersion) => {
-    expect(console.info).toHaveBeenCalledTimes(0);
-
-    return expect(
-      run([require.resolve(`@readme/oas-examples/${specVersion}/${format}/petstore.${format}`)]),
-    ).resolves.toContain(
+  ])('should support validating a %s definition (format: %s)', async (_, format, specVersion) => {
+    expect(
+      (await run([require.resolve(`@readme/oas-examples/${specVersion}/${format}/petstore.${format}`)])).result,
+    ).toContain(
       `petstore.${format} is a valid ${specVersion === '2.0' ? 'Swagger' : 'OpenAPI'} API definition!`,
     );
   });
 
   it('should discover and upload an API definition if none is provided', async () => {
-    await expect(run(['--workingDirectory', './__tests__/__fixtures__/relative-ref-oas'])).resolves.toBe(
-      chalk.green('petstore.json is a valid OpenAPI API definition!'),
-    );
-
-    expect(console.info).toHaveBeenCalledTimes(1);
-
-    const output = getCommandOutput();
-
-    expect(output).toBe(chalk.yellow('ℹ️  We found petstore.json and are attempting to validate it.'));
+    const result = await run(['--workingDirectory', './__tests__/__fixtures__/relative-ref-oas']);
+    expect(result).toMatchSnapshot();
   });
 
-  it('should use specified working directory', () => {
-    return expect(
-      run(['petstore.json', '--workingDirectory', './__tests__/__fixtures__/relative-ref-oas']),
-    ).resolves.toBe(chalk.green('petstore.json is a valid OpenAPI API definition!'));
+  it('should use specified working directory', async () => {
+    const result = await run(['petstore.json', '--workingDirectory', './__tests__/__fixtures__/relative-ref-oas']);
+    expect(result).toMatchSnapshot();
   });
 
-  it('should adhere to .gitignore in subdirectories', () => {
+  it('should adhere to .gitignore in subdirectories', async () => {
     fs.copyFileSync(
       require.resolve('@readme/oas-examples/3.0/json/petstore-simple.json'),
       './__tests__/__fixtures__/nested-gitignored-oas/nest/petstore-ignored.json',
     );
 
-    return expect(run(['--workingDirectory', './__tests__/__fixtures__/nested-gitignored-oas'])).resolves.toBe(
-      chalk.green('nest/petstore.json is a valid OpenAPI API definition!'),
-    );
+    const result = await run(['--workingDirectory', './__tests__/__fixtures__/nested-gitignored-oas']);
+    expect(result).toMatchSnapshot();
   });
 
   describe('error handling', () => {
     it('should throw an error if invalid JSON is supplied', () => {
-      return expect(run(['./__tests__/__fixtures__/invalid-json/yikes.json'])).rejects.toStrictEqual(
-        new SyntaxError('Unexpected end of JSON input'),
-      );
+      return expect(run(['./__tests__/__fixtures__/invalid-json/yikes.json'])).resolves.toMatchSnapshot();
     });
 
     it('should throw an error if an invalid OpenAPI 3.0 definition is supplied', () => {
-      return expect(run(['./__tests__/__fixtures__/invalid-oas.json'])).rejects.toMatchSnapshot();
+      return expect(run(['./__tests__/__fixtures__/invalid-oas.json'])).resolves.toMatchSnapshot();
     });
 
     it('should throw an error if an invalid OpenAPI 3.1 definition is supplied', () => {
-      return expect(run(['./__tests__/__fixtures__/invalid-oas-3.1.json'])).rejects.toMatchSnapshot();
+      return expect(run(['./__tests__/__fixtures__/invalid-oas-3.1.json'])).resolves.toMatchSnapshot();
     });
 
     it('should throw an error if an invalid Swagger definition is supplied', () => {
-      return expect(run(['./__tests__/__fixtures__/invalid-swagger.json'])).rejects.toMatchSnapshot();
+      return expect(run(['./__tests__/__fixtures__/invalid-swagger.json'])).resolves.toMatchSnapshot();
     });
 
     it('should throw an error if an invalid API definition has many errors', () => {
-      return expect(run(['./__tests__/__fixtures__/very-invalid-oas.json'])).rejects.toMatchSnapshot();
+      return expect(run(['./__tests__/__fixtures__/very-invalid-oas.json'])).resolves.toMatchSnapshot();
     });
   });
 
@@ -118,7 +95,7 @@ describe('rdme openapi validate', () => {
       vi.stubEnv('TEST_RDME_CREATEGHA', 'true');
       const spec = '__tests__/__fixtures__/petstore-simple-weird-version.json';
 
-      await expect(run([spec])).resolves.toBe(chalk.green(`${spec} is a valid OpenAPI API definition!`));
+      await expect(run([spec])).resolves.toMatchSnapshot();
     });
 
     it('should fail if user attempts to pass `--github` flag in CI environment', async () => {
@@ -129,8 +106,8 @@ describe('rdme openapi validate', () => {
             '__tests__/__fixtures__/petstore-simple-weird-version.json',
             '--github',
           ])
-        ).error.message,
-      ).toContain('The `--github` flag is only for usage in non-CI environments');
+        ).error,
+      ).toMatchSnapshot();
     });
   });
 
@@ -148,22 +125,15 @@ describe('rdme openapi validate', () => {
     });
 
     it('should create GHA workflow if user passes in spec via prompts', async () => {
-      expect.assertions(6);
+      expect.assertions(3);
 
       const spec = '__tests__/__fixtures__/petstore-simple-weird-version.json';
       const fileName = 'validate-test-file';
       prompts.inject([spec, true, 'validate-test-branch', fileName]);
 
       await expect(run()).resolves.toMatchSnapshot();
-
       expect(yamlOutput).toMatchSnapshot();
       expect(fs.writeFileSync).toHaveBeenCalledWith(`.github/workflows/${fileName}.yml`, expect.any(String));
-      expect(console.info).toHaveBeenCalledTimes(2);
-
-      const output = getCommandOutput();
-
-      expect(output).toMatch("Looks like you're running this command in a GitHub Repository!");
-      expect(output).toMatch('is a valid OpenAPI API definition!');
     });
 
     it('should create GHA workflow if user passes in spec via opt', async () => {
@@ -210,11 +180,7 @@ describe('rdme openapi validate', () => {
     it('should reject if user says no to creating GHA workflow', () => {
       const spec = '__tests__/__fixtures__/petstore-simple-weird-version.json';
       prompts.inject([spec, false]);
-      return expect(run()).rejects.toStrictEqual(
-        new Error(
-          'GitHub Actions workflow creation cancelled. If you ever change your mind, you can run this command again with the `--github` flag.',
-        ),
-      );
+      return expect(run()).resolves.toMatchSnapshot();
     });
   });
 });

--- a/__tests__/commands/openapi/validate.test.ts
+++ b/__tests__/commands/openapi/validate.test.ts
@@ -1,5 +1,3 @@
- 
-
 import fs from 'node:fs';
 
 import prompts from 'prompts';
@@ -35,9 +33,7 @@ describe('rdme openapi validate', () => {
   ])('should support validating a %s definition (format: %s)', async (_, format, specVersion) => {
     expect(
       (await run([require.resolve(`@readme/oas-examples/${specVersion}/${format}/petstore.${format}`)])).result,
-    ).toContain(
-      `petstore.${format} is a valid ${specVersion === '2.0' ? 'Swagger' : 'OpenAPI'} API definition!`,
-    );
+    ).toContain(`petstore.${format} is a valid ${specVersion === '2.0' ? 'Swagger' : 'OpenAPI'} API definition!`);
   });
 
   it('should discover and upload an API definition if none is provided', async () => {


### PR DESCRIPTION
## 🧰 Changes

rewrites our tests for `openapi validate` to be more compliant with [our contributing guidelines](https://github.com/readmeio/rdme/blob/next/CONTRIBUTING.md#code-style-guidelines). i initially wrote them this way to minimize the amount of legwork to get `oclif` working but this approach to testing is far more comprehensive and it should be much easier to drop in stray console logs for debugging purposes.

## 🧬 QA & Testing

do tests still pass?
