### PR TITLE
feat: expose fetch utils

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -1,7 +1,7 @@
 import type { KnipConfig } from 'knip';
 
 const config: KnipConfig = {
-  entry: ['src/index.ts', 'src/types.ts', 'src/lib/help.ts', 'bin/*.js'],
+  entry: ['src/index.ts', 'src/types.ts', 'src/utils.ts', 'src/lib/help.ts', 'bin/*.js'],
   ignore: ['dist-gha/**'],
   // we're choosing not to include semantic release deps in our main dev-deps
   // since we're only using it in CI

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "swagger"
   ],
   "exports": {
-    "./types": "./dist/types.js"
+    ".": "./dist/index.js",
+    "./types": "./dist/types.js",
+    "./utils": "./dist/utils.js"
   },
   "repository": {
     "type": "git",

--- a/src/lib/readmeAPIFetch.ts
+++ b/src/lib/readmeAPIFetch.ts
@@ -1,6 +1,7 @@
 import type { SpecFileType } from './prepareOas.js';
 import type { CommandClass } from '../index.js';
 import type { CommandsThatSyncMarkdown } from './syncPagePath.js';
+import type { Hook } from '@oclif/core';
 import type { SchemaObject } from 'oas/types';
 
 import path from 'node:path';
@@ -227,7 +228,7 @@ export async function readmeAPIv1Fetch(
  * Wrapper for the `fetch` API so we can add rdme-specific headers to all ReadMe API v2 requests.
  */
 export async function readmeAPIv2Fetch(
-  this: CommandClass['prototype'],
+  this: CommandClass['prototype'] | Hook.Context,
   /** The pathname to make the request to. Must have a leading slash. */
   pathname: string,
   options: RequestInit = { headers: new Headers() },
@@ -367,7 +368,7 @@ export async function handleAPIv1Res(
  * If we receive non-JSON responses, we consider them errors and throw them.
  */
 export async function handleAPIv2Res(
-  this: CommandClass['prototype'],
+  this: CommandClass['prototype'] | Hook.Context,
   res: Response,
   /**
    * If we're making a request where we don't care about the body (e.g. a HEAD or DELETE request),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,1 @@
+export { readmeAPIv2Fetch, handleAPIv2Res } from './lib/readmeAPIFetch.js';


### PR DESCRIPTION
## 🧰 Changes

exposes a handful of utils in a new `rdme/utils` export. figured this would be a good spot to add more as we think of them.

## 🧬 QA & Testing

do tests pass?
