### PR TITLE
fix(docs/upload): switch from `HEAD` to `GET` for initial page fetch

### DIFF
--- a/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
@@ -322,7 +322,7 @@ exports[`rdme docs upload > given that the file path is a single file > and the 
 
 exports[`rdme docs upload > given that the file path is a single file > given that the --dry-run flag is passed > should error out if a non-404 error is returned from the HEAD request 1`] = `
 {
-  "error": [APIv2Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
+  "error": [Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
  ›    Use at your own risk!
 - 🔬 Validating frontmatter data...
@@ -621,9 +621,9 @@ exports[`rdme docs upload > given that the file path is a single file > should c
 }
 `;
 
-exports[`rdme docs upload > given that the file path is a single file > should error out if a non-404 error is returned from the HEAD request 1`] = `
+exports[`rdme docs upload > given that the file path is a single file > should error out if a non-404 error is returned from the GET request 1`] = `
 {
-  "error": [APIv2Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
+  "error": [Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
  ›    Use at your own risk!
 - 🔬 Validating frontmatter data...

--- a/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
@@ -320,6 +320,24 @@ exports[`rdme docs upload > given that the file path is a single file > and the 
 }
 `;
 
+exports[`rdme docs upload > given that the file path is a single file > given that the --dry-run flag is passed > should error out if a non-404 error is returned from the GET request (with a json body) 1`] = `
+{
+  "error": [APIv2Error: ReadMe API error: bad request
+
+something went so so wrong],
+  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
+ ›    Use at your own risk!
+- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🎭 Uploading files to ReadMe (but not really because it's a dry run)...
+✖ 🎭 Uploading files to ReadMe (but not really because it's a dry run)... 1 file(s) failed.
+",
+  "stdout": "🚨 Unable to fetch data about the following 1 page(s):
+   - __tests__/__fixtures__/docs/slug-docs/new-doc-slug.md: bad request
+",
+}
+`;
+
 exports[`rdme docs upload > given that the file path is a single file > given that the --dry-run flag is passed > should error out if a non-404 error is returned from the GET request 1`] = `
 {
   "error": [Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
@@ -617,6 +635,24 @@ exports[`rdme docs upload > given that the file path is a single file > should c
 ",
   "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
    - new-doc (__tests__/__fixtures__/docs/new-docs/new-doc.md)
+",
+}
+`;
+
+exports[`rdme docs upload > given that the file path is a single file > should error out if a non-404 error is returned from the GET request (with a json body) 1`] = `
+{
+  "error": [APIv2Error: ReadMe API error: bad request
+
+something went so so wrong],
+  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
+ ›    Use at your own risk!
+- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🚀 Uploading files to ReadMe...
+✖ 🚀 Uploading files to ReadMe... 1 file(s) failed.
+",
+  "stdout": "🚨 Received errors when attempting to upload 1 page(s):
+   - __tests__/__fixtures__/docs/new-docs/new-doc.md: bad request
 ",
 }
 `;

--- a/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
@@ -320,7 +320,7 @@ exports[`rdme docs upload > given that the file path is a single file > and the 
 }
 `;
 
-exports[`rdme docs upload > given that the file path is a single file > given that the --dry-run flag is passed > should error out if a non-404 error is returned from the HEAD request 1`] = `
+exports[`rdme docs upload > given that the file path is a single file > given that the --dry-run flag is passed > should error out if a non-404 error is returned from the GET request 1`] = `
 {
   "error": [Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.

--- a/__tests__/commands/docs/upload.test.ts
+++ b/__tests__/commands/docs/upload.test.ts
@@ -108,6 +108,21 @@ describe('rdme docs upload', () => {
 
         mock.done();
       });
+
+      it('should error out if a non-404 error is returned from the GET request (with a json body)', async () => {
+        const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/some-slug').reply(500, {
+          title: 'bad request',
+          detail: 'something went so so wrong',
+          status: 500,
+        });
+
+        const result = await run(['__tests__/__fixtures__/docs/slug-docs/new-doc-slug.md', '--key', key, '--dry-run']);
+
+        expect(result).toMatchSnapshot();
+        expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+        mock.done();
+      });
     });
 
     describe('given that the slug is passed in the frontmatter', () => {
@@ -325,6 +340,21 @@ describe('rdme docs upload', () => {
 
     it('should error out if a non-404 error is returned from the GET request', async () => {
       const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/new-doc').reply(500);
+
+      const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key]);
+
+      expect(result).toMatchSnapshot();
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+      mock.done();
+    });
+
+    it('should error out if a non-404 error is returned from the GET request (with a json body)', async () => {
+      const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/new-doc').reply(500, {
+        title: 'bad request',
+        detail: 'something went so so wrong',
+        status: 500,
+      });
 
       const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key]);
 

--- a/__tests__/commands/docs/upload.test.ts
+++ b/__tests__/commands/docs/upload.test.ts
@@ -98,7 +98,7 @@ describe('rdme docs upload', () => {
         mock.done();
       });
 
-      it('should error out if a non-404 error is returned from the HEAD request', async () => {
+      it('should error out if a non-404 error is returned from the GET request', async () => {
         const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/some-slug').reply(500);
 
         const result = await run(['__tests__/__fixtures__/docs/slug-docs/new-doc-slug.md', '--key', key, '--dry-run']);

--- a/__tests__/commands/docs/upload.test.ts
+++ b/__tests__/commands/docs/upload.test.ts
@@ -37,7 +37,7 @@ describe('rdme docs upload', () => {
   describe('given that the file path is a single file', () => {
     it('should create a guides page in ReadMe', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .head('/versions/stable/guides/new-doc')
+        .get('/versions/stable/guides/new-doc')
         .reply(404)
         .post('/versions/stable/guides', {
           category: { uri: '/versions/stable/categories/guides/category-slug' },
@@ -57,7 +57,7 @@ describe('rdme docs upload', () => {
 
     it('should allow for user to specify version via --version flag', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .head('/versions/1.2.3/guides/new-doc')
+        .get('/versions/1.2.3/guides/new-doc')
         .reply(404)
         .post('/versions/1.2.3/guides', {
           category: { uri: '/versions/1.2.3/categories/guides/category-slug' },
@@ -77,7 +77,7 @@ describe('rdme docs upload', () => {
 
     describe('given that the --dry-run flag is passed', () => {
       it('should not create anything in ReadMe', async () => {
-        const mock = getAPIv2Mock({ authorization }).head('/versions/stable/guides/new-doc').reply(404);
+        const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/new-doc').reply(404);
 
         const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key, '--dry-run']);
 
@@ -88,7 +88,7 @@ describe('rdme docs upload', () => {
       });
 
       it('should not update anything in ReadMe', async () => {
-        const mock = getAPIv2Mock({ authorization }).head('/versions/stable/guides/some-slug').reply(200);
+        const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/some-slug').reply(200);
 
         const result = await run(['__tests__/__fixtures__/docs/slug-docs/new-doc-slug.md', '--key', key, '--dry-run']);
 
@@ -99,7 +99,7 @@ describe('rdme docs upload', () => {
       });
 
       it('should error out if a non-404 error is returned from the HEAD request', async () => {
-        const mock = getAPIv2Mock({ authorization }).head('/versions/stable/guides/some-slug').reply(500);
+        const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/some-slug').reply(500);
 
         const result = await run(['__tests__/__fixtures__/docs/slug-docs/new-doc-slug.md', '--key', key, '--dry-run']);
 
@@ -113,7 +113,7 @@ describe('rdme docs upload', () => {
     describe('given that the slug is passed in the frontmatter', () => {
       it('should use that slug to create a page in ReadMe', async () => {
         const mock = getAPIv2Mock({ authorization })
-          .head('/versions/stable/guides/some-slug')
+          .get('/versions/stable/guides/some-slug')
           .reply(404)
           .post('/versions/stable/guides', {
             category: { uri: '/versions/stable/categories/guides/some-category-uri' },
@@ -133,7 +133,7 @@ describe('rdme docs upload', () => {
 
       it('should use that slug update an existing guides page in ReadMe', async () => {
         const mock = getAPIv2Mock({ authorization })
-          .head('/versions/stable/guides/some-slug')
+          .get('/versions/stable/guides/some-slug')
           .reply(200)
           .patch('/versions/stable/guides/some-slug', {
             category: { uri: '/versions/stable/categories/guides/some-category-uri' },
@@ -154,7 +154,7 @@ describe('rdme docs upload', () => {
     describe('given that the file has frontmatter issues', () => {
       it('should fix the frontmatter issues in the file and create the corrected file in ReadMe', async () => {
         const mock = getAPIv2Mock({ authorization })
-          .head('/versions/stable/guides/legacy-category')
+          .get('/versions/stable/guides/legacy-category')
           .reply(404)
           .post('/versions/stable/guides', {
             category: { uri: '/versions/stable/categories/guides/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f' },
@@ -188,7 +188,7 @@ describe('rdme docs upload', () => {
           });
 
         const mock = getAPIv2Mock({ authorization })
-          .head('/versions/stable/guides/legacy-category')
+          .get('/versions/stable/guides/legacy-category')
           .reply(404)
           .post('/versions/stable/guides', {
             category: { uri: '/versions/stable/categories/guides/mapped-uri' },
@@ -229,7 +229,7 @@ describe('rdme docs upload', () => {
 
       it('should skip client-side validation if the --skip-validation flag is passed', async () => {
         const mock = getAPIv2Mock({ authorization })
-          .head('/versions/stable/guides/legacy-category')
+          .get('/versions/stable/guides/legacy-category')
           .reply(404)
           .post('/versions/stable/guides', {
             category: '5ae122e10fdf4e39bb34db6f',
@@ -254,7 +254,7 @@ describe('rdme docs upload', () => {
 
       it('should warn user if the file has no autofixable issues', async () => {
         const mock = getAPIv2Mock({ authorization })
-          .head('/versions/stable/guides/invalid-attributes')
+          .get('/versions/stable/guides/invalid-attributes')
           .reply(404)
           .post('/versions/stable/guides', {
             category: {
@@ -282,7 +282,7 @@ describe('rdme docs upload', () => {
       afterEach(githubActionsEnv.after);
 
       it('should create a guides page in ReadMe and include `x-readme-source-url` source header', async () => {
-        const headMock = getAPIv2MockForGHA({ authorization }).head('/versions/stable/guides/new-doc').reply(404);
+        const headMock = getAPIv2MockForGHA({ authorization }).get('/versions/stable/guides/new-doc').reply(404);
 
         const postMock = getAPIv2MockForGHA({
           authorization,
@@ -323,8 +323,8 @@ describe('rdme docs upload', () => {
       });
     });
 
-    it('should error out if a non-404 error is returned from the HEAD request', async () => {
-      const mock = getAPIv2Mock({ authorization }).head('/versions/stable/guides/new-doc').reply(500);
+    it('should error out if a non-404 error is returned from the GET request', async () => {
+      const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/new-doc').reply(500);
 
       const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key]);
 
@@ -352,7 +352,7 @@ describe('rdme docs upload', () => {
   describe('given that the file path is a directory', () => {
     it('should create a guides page in ReadMe for each file in the directory and its subdirectories', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .head('/versions/stable/guides/simple-doc')
+        .get('/versions/stable/guides/simple-doc')
         .reply(404)
         .post('/versions/stable/guides', {
           slug: 'simple-doc',
@@ -360,7 +360,7 @@ describe('rdme docs upload', () => {
           content: { body: '\nBody\n' },
         })
         .reply(201, {})
-        .head('/versions/stable/guides/another-doc')
+        .get('/versions/stable/guides/another-doc')
         .reply(404)
         .post('/versions/stable/guides', {
           slug: 'another-doc',
@@ -380,14 +380,14 @@ describe('rdme docs upload', () => {
 
     it('should update existing guides pages in ReadMe for each file in the directory and its subdirectories', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .head('/versions/stable/guides/simple-doc')
+        .get('/versions/stable/guides/simple-doc')
         .reply(200)
         .patch('/versions/stable/guides/simple-doc', {
           title: 'This is the document title',
           content: { body: '\nBody\n' },
         })
         .reply(201, {})
-        .head('/versions/stable/guides/another-doc')
+        .get('/versions/stable/guides/another-doc')
         .reply(200)
         .patch('/versions/stable/guides/another-doc', {
           title: 'This is another document title',
@@ -406,7 +406,7 @@ describe('rdme docs upload', () => {
 
     it('should handle complex frontmatter', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .head('/versions/stable/guides/basic')
+        .get('/versions/stable/guides/basic')
         .reply(200)
         .patch('/versions/stable/guides/basic', {
           title: 'This is the document title',
@@ -415,7 +415,7 @@ describe('rdme docs upload', () => {
           type: 'basic',
         })
         .reply(201, {})
-        .head('/versions/stable/guides/link')
+        .get('/versions/stable/guides/link')
         .reply(200)
         .patch('/versions/stable/guides/link', {
           title: 'This is the document title',
@@ -440,7 +440,7 @@ describe('rdme docs upload', () => {
     describe('given that the directory contains parent/child docs', () => {
       it('should upload parents before children', async () => {
         const mock = getAPIv2Mock({ authorization })
-          .head('/versions/stable/guides/child')
+          .get('/versions/stable/guides/child')
           .reply(404)
           .post('/versions/stable/guides', {
             slug: 'child',
@@ -449,7 +449,7 @@ describe('rdme docs upload', () => {
             content: { body: '\nBody\n' },
           })
           .reply(201, {})
-          .head('/versions/stable/guides/friend')
+          .get('/versions/stable/guides/friend')
           .reply(404)
           .post('/versions/stable/guides', {
             slug: 'friend',
@@ -457,7 +457,7 @@ describe('rdme docs upload', () => {
             content: { body: '\nBody\n' },
           })
           .reply(201, {})
-          .head('/versions/stable/guides/parent')
+          .get('/versions/stable/guides/parent')
           .reply(404)
           .post('/versions/stable/guides', {
             slug: 'parent',
@@ -466,7 +466,7 @@ describe('rdme docs upload', () => {
             content: { body: '\nBody\n' },
           })
           .reply(201, {})
-          .head('/versions/stable/guides/grandparent')
+          .get('/versions/stable/guides/grandparent')
           .reply(404)
           .post('/versions/stable/guides', {
             slug: 'grandparent',
@@ -492,7 +492,7 @@ describe('rdme docs upload', () => {
 
     it('should handle a mix of creates and updates and failures and skipped files', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .head('/versions/stable/guides/invalid-attributes')
+        .get('/versions/stable/guides/invalid-attributes')
         .reply(404)
         .post('/versions/stable/guides', {
           category: { uri: '/versions/stable/categories/guides/some-category-uri', 'is-this-a-valid-property': 'nope' },
@@ -501,7 +501,7 @@ describe('rdme docs upload', () => {
           content: { body: '\nBody\n' },
         })
         .reply(201, {})
-        .head('/versions/stable/guides/legacy-category')
+        .get('/versions/stable/guides/legacy-category')
         .reply(200)
         .patch('/versions/stable/guides/legacy-category', {
           category: { uri: '/versions/stable/categories/guides/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f' },
@@ -509,7 +509,7 @@ describe('rdme docs upload', () => {
           content: { body: '\nBody\n' },
         })
         .reply(201, {})
-        .head('/versions/stable/guides/some-slug')
+        .get('/versions/stable/guides/some-slug')
         .reply(404)
         .post('/versions/stable/guides', {
           slug: 'some-slug',
@@ -518,7 +518,7 @@ describe('rdme docs upload', () => {
           content: { body: '\nBody\n' },
         })
         .reply(500, {})
-        .head('/versions/stable/guides/simple-doc')
+        .get('/versions/stable/guides/simple-doc')
         .reply(404)
         .post('/versions/stable/guides', {
           slug: 'simple-doc',
@@ -539,13 +539,13 @@ describe('rdme docs upload', () => {
 
     it('should handle a mix of creates and updates and failures and skipped files (dry run)', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .head('/versions/stable/guides/invalid-attributes')
+        .get('/versions/stable/guides/invalid-attributes')
         .reply(404)
-        .head('/versions/stable/guides/legacy-category')
+        .get('/versions/stable/guides/legacy-category')
         .reply(200)
-        .head('/versions/stable/guides/some-slug')
+        .get('/versions/stable/guides/some-slug')
         .reply(500)
-        .head('/versions/stable/guides/simple-doc')
+        .get('/versions/stable/guides/simple-doc')
         .reply(500);
 
       prompts.inject([true]);
@@ -581,7 +581,7 @@ describe('rdme docs upload', () => {
       nock.cleanAll();
 
       const mock = getAPIv2Mock({ authorization })
-        .head('/versions/1.2.3/guides/new-doc')
+        .get('/versions/1.2.3/guides/new-doc')
         .reply(404)
         .post('/versions/1.2.3/guides', {
           category: { uri: '/versions/1.2.3/categories/guides/category-slug' },

--- a/src/lib/readmeAPIFetch.ts
+++ b/src/lib/readmeAPIFetch.ts
@@ -381,11 +381,6 @@ export async function handleAPIv2Res<R extends ResponseBody = ResponseBody, T ex
    */
   this: T,
   res: Response,
-  /**
-   * If we're making a request where we don't care about the body (e.g. a HEAD or DELETE request),
-   * we can skip parsing the JSON body using this flag.
-   */
-  skipJsonParsing = false,
 ): Promise<R> {
   const contentType = res.headers.get('content-type') || '';
   const extension = mime.extension(contentType) || contentType.includes('json') ? 'json' : false;
@@ -394,12 +389,6 @@ export async function handleAPIv2Res<R extends ResponseBody = ResponseBody, T ex
     // https://x.com/cramforce/status/1762142087930433999
     const body = await res.text();
     this.debug(`received status code ${res.status} from ${res.url} with no content: ${body}`);
-    return {} as R;
-  } else if (skipJsonParsing) {
-    // to prevent a memory leak, we should still consume the response body? even though we don't use it?
-    // https://x.com/cramforce/status/1762142087930433999
-    const body = await res.text();
-    this.debug(`received status code ${res.status} from ${res.url} and not parsing JSON b/c of flag: ${body}`);
     return {} as R;
   } else if (extension === 'json') {
     const body = (await res.json()) as R;

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -144,8 +144,7 @@ async function pushPage(
     }).then(async res => {
       if (!res.ok) {
         if (res.status !== 404) {
-          const body = await this.handleAPIRes(res);
-          throw new APIv2Error(body);
+          return this.handleAPIRes(res);
         }
         this.debug(`error retrieving data for ${slug}, creating page`);
         return createPage();

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -139,12 +139,14 @@ async function pushPage(
     };
 
     return this.readmeAPIFetch(`${route}/${slug}`, {
-      method: 'HEAD',
+      method: 'GET',
       headers,
     }).then(async res => {
-      await this.handleAPIRes(res, true);
       if (!res.ok) {
-        if (res.status !== 404) throw new APIv2Error(res);
+        if (res.status !== 404) {
+          const body = await this.handleAPIRes(res);
+          throw new APIv2Error(body);
+        }
         this.debug(`error retrieving data for ${slug}, creating page`);
         return createPage();
       }


### PR DESCRIPTION
| 🚥 Resolves RM-11904 |
| :------------------- |

## 🧰 Changes

when making `HEAD` requests, there is no response body, meaning that errors are totally unhelpful. this switches our initial page fetch requests to use the `GET` method.
