### PR TITLE
feat(docs/migrate): add ability to unzip archives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "tmp-promise": "^3.0.3",
         "toposort": "^2.0.2",
         "undici": "^5.28.4",
+        "unzipper": "^0.12.3",
         "validator": "^13.7.0"
       },
       "bin": {
@@ -61,6 +62,7 @@
         "@types/prompts": "^2.4.2",
         "@types/semver": "^7.3.12",
         "@types/toposort": "^2.0.7",
+        "@types/unzipper": "^0.10.11",
         "@types/validator": "^13.7.6",
         "@vitest/coverage-v8": "^3.0.0",
         "@vitest/expect": "^3.0.0",
@@ -4725,6 +4727,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/unzipper": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@types/unzipper/-/unzipper-0.10.11.tgz",
+      "integrity": "sha512-D25im2zjyMCcgL9ag6N46+wbtJBnXIr7SI4zHf9eJD2Dw2tEB5e+p5MYkrxKIVRscs5QV0EhtU9rgXSPx90oJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/validator": {
       "version": "13.12.3",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.3.tgz",
@@ -5854,6 +5866,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -6812,7 +6830,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -7369,6 +7386,15 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -10430,7 +10456,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -13810,6 +13835,12 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT"
     },
     "node_modules/node-readfiles": {
       "version": "0.2.0",
@@ -17657,7 +17688,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prompts": {
@@ -18023,7 +18053,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "integrity": "sha512-TXcFfb63BQe1+ySzsHZI/5v1aJPCShfqvWJ64ayNImXMsN1Cd0YGk/wm8KB7/OeessgPc9QvS9Zou8QTkFzsLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -18038,7 +18067,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/redent": {
@@ -19449,7 +19477,6 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-argv": {
@@ -20847,6 +20874,54 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.3.3"
       }
     },
+    "node_modules/unzipper": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "^11.2.0",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/unzipper/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/unzipper/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/unzipper/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -20977,7 +21052,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "tmp-promise": "^3.0.3",
     "toposort": "^2.0.2",
     "undici": "^5.28.4",
+    "unzipper": "^0.12.3",
     "validator": "^13.7.0"
   },
   "devDependencies": {
@@ -95,6 +96,7 @@
     "@types/prompts": "^2.4.2",
     "@types/semver": "^7.3.12",
     "@types/toposort": "^2.0.7",
+    "@types/unzipper": "^0.10.11",
     "@types/validator": "^13.7.6",
     "@vitest/coverage-v8": "^3.0.0",
     "@vitest/expect": "^3.0.0",

--- a/src/commands/docs/migrate.ts
+++ b/src/commands/docs/migrate.ts
@@ -12,6 +12,7 @@ import { oraOptions } from '../../lib/logger.js';
 import promptTerminal from '../../lib/promptWrapper.js';
 import { fetchMappings, fetchSchema } from '../../lib/readmeAPIFetch.js';
 import { findPages } from '../../lib/readPage.js';
+import { unzip } from '../../lib/unzip.js';
 
 const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
 
@@ -47,12 +48,13 @@ export default class DocsMigrateCommand extends BaseCommand<typeof DocsMigrateCo
 
     const outputDir = rawOutputDir || (await dir({ prefix: 'rdme-migration-output' })).path;
 
-    let pathInput = rawPathInput;
+    const zipResults = await unzip(rawPathInput);
+    let { pathInput } = zipResults;
 
     // todo: fix this type once https://github.com/oclif/core/pull/1359 is merged
     const fileScanHookResults: Hook.Result<PluginHooks['pre_markdown_file_scan']['return']> = await this.config.runHook(
       'pre_markdown_file_scan',
-      { pathInput },
+      zipResults,
     );
 
     fileScanHookResults.successes.forEach(success => {

--- a/src/commands/docs/migrate.ts
+++ b/src/commands/docs/migrate.ts
@@ -12,7 +12,7 @@ import { oraOptions } from '../../lib/logger.js';
 import promptTerminal from '../../lib/promptWrapper.js';
 import { fetchMappings, fetchSchema } from '../../lib/readmeAPIFetch.js';
 import { findPages } from '../../lib/readPage.js';
-import { unzip } from '../../lib/unzip.js';
+import { attemptUnzip } from '../../lib/unzip.js';
 
 const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
 
@@ -48,7 +48,7 @@ export default class DocsMigrateCommand extends BaseCommand<typeof DocsMigrateCo
 
     const outputDir = rawOutputDir || (await dir({ prefix: 'rdme-migration-output' })).path;
 
-    const zipResults = await unzip(rawPathInput);
+    const zipResults = await attemptUnzip(rawPathInput);
     let { pathInput } = zipResults;
 
     // todo: fix this type once https://github.com/oclif/core/pull/1359 is merged

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -14,6 +14,14 @@ import { handleAPIv2Res, readmeAPIv2Fetch, type ResponseBody } from './readmeAPI
 type Flags<T extends typeof OclifCommand> = Interfaces.InferredFlags<(typeof BaseCommand)['baseFlags'] & T['flags']>;
 type Args<T extends typeof OclifCommand> = Interfaces.InferredArgs<T['args']>;
 
+/**
+ * This is a light wrapper around the oclif command class that adds some
+ * additional functionality and standardizes the way we handle logging, error handling,
+ * and API requests.
+ *
+ * @note This class is not meant to be used directly, but rather as a base class for other commands.
+ * It is also experimental and may change in the future.
+ */
 export default abstract class BaseCommand<T extends typeof OclifCommand> extends OclifCommand {
   constructor(argv: string[], config: Config) {
     super(argv, config);

--- a/src/lib/hooks/exported.ts
+++ b/src/lib/hooks/exported.ts
@@ -1,20 +1,80 @@
 import type { PageMetadata } from '../readPage.js';
 import type { Hooks } from '@oclif/core/interfaces';
 
+interface MarkdownFileScanResultOptsBase {
+  // required for the oclif hook types
+  [key: string]: unknown;
+  /**
+   * The path to the input file or directory as passed to the command line.
+   */
+  pathInput: string;
+  /**
+   * Whether or not the path input is a zip file.
+   */
+  zipped: boolean;
+}
+
+interface MarkdownFileScanResultOptsZipped extends MarkdownFileScanResultOptsBase {
+  /**
+   * The path to the temporary directory where the zip file was unzipped.
+   * This is only present if the input file was a zip file.
+   */
+  unzippedDir: string;
+  zipped: true;
+}
+
+interface MarkdownFileScanResultOptsUnzipped extends MarkdownFileScanResultOptsBase {
+  zipped: false;
+}
+
 /**
+ * The options passed to the `pre_markdown_file_scan` hook.
+ */
+export type MarkdownFileScanResultOpts = MarkdownFileScanResultOptsUnzipped | MarkdownFileScanResultOptsZipped;
+
+/**
+ * Hooks for usage in `rdme` plugins that invoke the `docs migrate` command.
+ *
  * @note These hooks are under active development for internal usage and are subject to change.
  */
 export interface PluginHooks extends Hooks {
+  /**
+   * This hook is called before the Markdown files are searched for with the path input argument.
+   * If the path input is a zip file, it will be unzipped to a temporary directory.
+   *
+   * It can be used to modify the path input to point to a different directory or file.
+   *
+   * For example, say the user wants to upload a zip file. This hook can be used to
+   * set the working directory to a subdirectory within the unzipped contents.
+   */
   pre_markdown_file_scan: {
-    options: {
-      pathInput: string;
-    };
+    options: MarkdownFileScanResultOpts;
+
+    /**
+     * The new directory to scan for Markdown files. If `null` is returned,
+     * this means the original path input will be used.
+     */
     return: string | null;
   };
+
+  /**
+   * This hook is called after the Markdown files are scanned and before they are validated.
+   * It can be used to modify the list of pages that will be validated.
+   *
+   * For example, this hook can be used to add or remove pages
+   * (or to modify the content/frontmatter of an existing page)
+   * from the list of pages that were found in the input directory.
+   */
   pre_markdown_validation: {
     options: {
+      /**
+       * The list of pages that were found in the input directory.
+       */
       pages: PageMetadata[];
     };
+    /**
+     * The list of pages that will be validated and written to the output directory.
+     */
     return: PageMetadata[];
   };
 }

--- a/src/lib/readPage.ts
+++ b/src/lib/readPage.ts
@@ -13,6 +13,11 @@ import ora from 'ora';
 import { oraOptions } from './logger.js';
 import readdirRecursive from './readdirRecursive.js';
 
+/**
+ * The metadata for a page once it has been read.
+ * This includes the Markdown contents of the file, the parsed frontmatter data,
+ * the file path, and the derived slug.
+ */
 export interface PageMetadata<T = Record<string, unknown>> {
   /**
    * The contents of the Markdown file below the YAML frontmatter

--- a/src/lib/readmeAPIFetch.ts
+++ b/src/lib/readmeAPIFetch.ts
@@ -57,6 +57,9 @@ export interface Mappings {
   parentPages: Record<string, string>;
 }
 
+/**
+ * A generic response body type for responses from the ReadMe API.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface ResponseBody extends Record<string, any> {}
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -37,4 +37,8 @@ export type GuidesRequestRepresentation = FromSchema<
  */
 export type ProjectRepresentation = FromSchema<projectSchema, { keepDefaultedPropertiesOptional: true }>;
 
+/**
+ * Derived from our API documentation, this is the schema for the API key object
+ * as we receive it to the ReadMe API.
+ */
 export type APIKeyRepresentation = FromSchema<apiKeySchema, { keepDefaultedPropertiesOptional: true }>;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -28,4 +28,8 @@ export type GuidesRequestRepresentation = FromSchema<
   { keepDefaultedPropertiesOptional: true }
 >;
 
+/**
+ * Derived from our API documentation, this is the schema for the `project` object
+ * as we receive it to the ReadMe API.
+ */
 export type ProjectRepresentation = FromSchema<projectSchema, { keepDefaultedPropertiesOptional: true }>;

--- a/src/lib/unzip.ts
+++ b/src/lib/unzip.ts
@@ -1,0 +1,30 @@
+import type { MarkdownFileScanResultOpts } from '../types.js';
+
+import path from 'node:path';
+
+import chalk from 'chalk';
+import ora from 'ora';
+import { dir } from 'tmp-promise';
+import { Open } from 'unzipper';
+
+import { oraOptions } from './logger.js';
+
+export async function unzip(pathInput: string): Promise<MarkdownFileScanResultOpts> {
+  if (pathInput.endsWith('.zip')) {
+    const outputDir = (await dir({ prefix: 'rdme-migration-zip-contents' })).path;
+
+    const unzipSpinner = ora({ ...oraOptions() }).start(
+      `🤐 Unzipping contents of ${chalk.underline(pathInput)} to the following directory: ${chalk.underline(outputDir)}...`,
+    );
+
+    const directory = await Open.file(pathInput);
+    await directory.extract({ path: outputDir });
+
+    unzipSpinner.succeed(`${unzipSpinner.text} done!`);
+
+    const newWorkingDir = path.join(outputDir, path.basename(pathInput, '.zip'));
+
+    return { pathInput: newWorkingDir, zipped: true as const, unzippedDir: newWorkingDir };
+  }
+  return { pathInput, zipped: false as const };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
 export type { APIKeyRepresentation, GuidesRequestRepresentation, ProjectRepresentation } from './lib/types/index.js';
 export type { PageMetadata } from './lib/readPage.js';
-export type { PluginHooks } from './lib/hooks/exported.js';
+export type { MarkdownFileScanResultOpts, PluginHooks } from './lib/hooks/exported.js';
 export type { ResponseBody } from './lib/readmeAPIFetch.js';


### PR DESCRIPTION
| 🚥 Resolves RM-12508 |
| :------------------- |

## 🧰 Changes

- [x] add auto-detection(ish) of zip files and unzips them before sending that data to plugin hook
- [x] enhances our `pre_markdown_file_scan` hook to now send data about the unzip results
- [x] adds a bunch of JSDocs for our exported functions/types

## 🧬 QA & Testing

this isn't a ton of logic but it could definitely use a test or two. will do a more comprehensive pass of tests in follow-up PRs later this week.
