### PR TITLE
fix: timeouts on `doc:upload`

### DIFF
--- a/src/lib/readmeAPIFetch.ts
+++ b/src/lib/readmeAPIFetch.ts
@@ -322,6 +322,7 @@ export async function readmeAPIv2Fetch<T extends Hook.Context = Hook.Context>(
     })
     .catch(e => {
       this.debug(`error making fetch request: ${e}`);
+      this.debug(e.stack);
       throw e;
     });
 }

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -296,7 +296,7 @@ export default async function syncPagePath(this: APIv2PageCommands) {
       const res = await pushPage.call(this, fileData);
       rawResults.push({
         status: 'fulfilled',
-        value: res
+        value: res,
       });
     } catch (err) {
       rawResults.push({


### PR DESCRIPTION
## 🧰 Changes

We've been running into issues with `doc:upload` calls processing 6 pages and then failing out with undici timeout errors despite no actual request ever happening. I don't really know what's going on with the `allSettled` or undici and why it's consistently failing but reworking `doc:upload` to process each page in the batch one by one resolves our issues (albeit at the expensive of making the command slower).