### PR TITLE
feat(docs): add `--hide-experimental-warning` flag

### DIFF
--- a/__tests__/commands/docs/__snapshots__/migrate.test.ts.snap
+++ b/__tests__/commands/docs/__snapshots__/migrate.test.ts.snap
@@ -13,6 +13,18 @@ See more help with --help],
 exports[`rdme docs migrate > should error out if no plugins are installed 1`] = `
 {
   "error": [Error: This command requires a valid migration plugin.],
+  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
+ ›    Use at your own risk!
+- 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/new-docs\` directory...
+✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/new-docs\` directory... 1 file(s) found!
+",
+  "stdout": "",
+}
+`;
+
+exports[`rdme docs migrate > should hide warning if \`--hide-experimental-warning\` flag is passed 1`] = `
+{
+  "error": [Error: This command requires a valid migration plugin.],
   "stderr": "- 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/new-docs\` directory...
 ✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/new-docs\` directory... 1 file(s) found!
 ",

--- a/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
@@ -692,3 +692,29 @@ exports[`rdme docs upload > given that the file path is a single file > should e
   "stdout": "",
 }
 `;
+
+exports[`rdme docs upload > given that the file path is a single file > should hide the warning if the \`--hide-experimental-warning\` flag is passed 1`] = `
+{
+  "result": {
+    "created": [
+      {
+        "filePath": "__tests__/__fixtures__/docs/new-docs/new-doc.md",
+        "response": {},
+        "result": "created",
+        "slug": "new-doc",
+      },
+    ],
+    "failed": [],
+    "skipped": [],
+    "updated": [],
+  },
+  "stderr": "- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🚀 Uploading files to ReadMe...
+✔ 🚀 Uploading files to ReadMe... done!
+",
+  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
+   - new-doc (__tests__/__fixtures__/docs/new-docs/new-doc.md)
+",
+}
+`;

--- a/__tests__/commands/docs/migrate.test.ts
+++ b/__tests__/commands/docs/migrate.test.ts
@@ -15,6 +15,11 @@ describe('rdme docs migrate', () => {
     expect(output).toMatchSnapshot();
   });
 
+  it('should hide warning if `--hide-experimental-warning` flag is passed', async () => {
+    const output = await run(['__tests__/__fixtures__/docs/new-docs', '--hide-experimental-warning']);
+    expect(output).toMatchSnapshot();
+  });
+
   it('should error out if no plugins are installed', async () => {
     const output = await run(['__tests__/__fixtures__/docs/new-docs']);
     expect(output).toMatchSnapshot();

--- a/__tests__/commands/docs/upload.test.ts
+++ b/__tests__/commands/docs/upload.test.ts
@@ -55,6 +55,31 @@ describe('rdme docs upload', () => {
       mock.done();
     });
 
+    it('should hide the warning if the `--hide-experimental-warning` flag is passed', async () => {
+      const mock = getAPIv2Mock({ authorization })
+        .get('/versions/stable/guides/new-doc')
+        .reply(404)
+        .post('/versions/stable/guides', {
+          category: { uri: '/versions/stable/categories/guides/category-slug' },
+          slug: 'new-doc',
+          title: 'This is the document title',
+          content: { body: '\nBody\n' },
+        })
+        .reply(201, {});
+
+      const result = await run([
+        '__tests__/__fixtures__/docs/new-docs/new-doc.md',
+        '--key',
+        key,
+        '--hide-experimental-warning',
+      ]);
+
+      expect(result).toMatchSnapshot();
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+      mock.done();
+    });
+
     it('should allow for user to specify version via --version flag', async () => {
       const mock = getAPIv2Mock({ authorization })
         .get('/versions/1.2.3/guides/new-doc')

--- a/src/commands/docs/migrate.ts
+++ b/src/commands/docs/migrate.ts
@@ -33,6 +33,10 @@ export default class DocsMigrateCommand extends BaseCommand<typeof DocsMigrateCo
   };
 
   static flags = {
+    'hide-experimental-warning': Flags.boolean({
+      description: 'Hides the warning message about this command being in an experimental alpha.',
+      hidden: true,
+    }),
     out: Flags.string({
       summary: 'The directory to write the migration output to. Defaults to a temporary directory.',
     }),
@@ -43,6 +47,9 @@ export default class DocsMigrateCommand extends BaseCommand<typeof DocsMigrateCo
   };
 
   async run() {
+    if (!this.flags['hide-experimental-warning']) {
+      this.warn(alphaNotice);
+    }
     const { path: rawPathInput }: { path: string } = this.args;
     const { out: rawOutputDir, 'skip-validation': skipValidation } = this.flags;
 

--- a/src/commands/docs/upload.ts
+++ b/src/commands/docs/upload.ts
@@ -50,6 +50,10 @@ export default class DocsUploadCommand extends BaseCommand<typeof DocsUploadComm
       aliases: ['dryRun'],
       deprecateAliases: true,
     }),
+    'hide-experimental-warning': Flags.boolean({
+      description: 'Hides the warning message about this command being in an experimental alpha.',
+      hidden: true,
+    }),
     'skip-validation': Flags.boolean({
       description:
         'Skips the pre-upload validation of the Markdown files. This flag can be a useful escape hatch but its usage is not recommended.',
@@ -68,7 +72,9 @@ export default class DocsUploadCommand extends BaseCommand<typeof DocsUploadComm
     skipped: PushResult[];
     updated: PushResult[];
   }> {
-    this.warn(alphaNotice);
+    if (!this.flags['hide-experimental-warning']) {
+      this.warn(alphaNotice);
+    }
     return syncPagePath.call(this);
   }
 }


### PR DESCRIPTION
## 🧰 Changes

noticed the outputs of our demo include a warning output. exposes a little flag for us to hide that warning.

## 🧬 QA & Testing

see tests
