### PR TITLE
feat(docs/migrate): migration stats

### DIFF
--- a/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
@@ -206,6 +206,72 @@ exports[`rdme docs upload > given that the file path is a directory > should han
 }
 `;
 
+exports[`rdme docs upload > given that the file path is a directory > should handle a mix of creates and updates and failures and skipped files and not error out with \`max-errors\` flag 1`] = `
+{
+  "result": {
+    "created": [
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/invalid-attributes.md",
+        "response": {},
+        "result": "created",
+        "slug": "invalid-attributes",
+      },
+    ],
+    "failed": [
+      {
+        "error": [APIv2Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/new-doc-slug.mdx",
+        "result": "failed",
+        "slug": "some-slug",
+      },
+      {
+        "error": [APIv2Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/simple-doc.md",
+        "result": "failed",
+        "slug": "simple-doc",
+      },
+    ],
+    "skipped": [
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/doc-sans-attributes.md",
+        "result": "skipped",
+        "slug": "doc-sans-attributes",
+      },
+    ],
+    "updated": [
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/legacy-category.md",
+        "response": {},
+        "result": "updated",
+        "slug": "legacy-category",
+      },
+    ],
+  },
+  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
+ ›    Use at your own risk!
+- 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory...
+✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory... 5 file(s) found!
+- 🔬 Validating frontmatter data...
+⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
+ ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
+ ›   upload will proceed but we recommend addressing these issues. Please get 
+ ›   in touch with us at support@readme.io if you need a hand.
+- 🚀 Uploading files to ReadMe...
+✖ 🚀 Uploading files to ReadMe... 2 file(s) failed.
+",
+  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
+   - invalid-attributes (__tests__/__fixtures__/docs/mixed-docs/invalid-attributes.md)
+🔄 Successfully updated 1 page(s) in ReadMe:
+   - legacy-category (__tests__/__fixtures__/docs/mixed-docs/legacy-category.md)
+⏭️ Skipped 1 page(s) in ReadMe due to no frontmatter data:
+   - doc-sans-attributes (__tests__/__fixtures__/docs/mixed-docs/doc-sans-attributes.md)
+🚨 Received errors when attempting to upload 2 page(s):
+   - __tests__/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
+   - __tests__/__fixtures__/docs/mixed-docs/simple-doc.md: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
+",
+}
+`;
+
 exports[`rdme docs upload > given that the file path is a directory > should handle complex frontmatter 1`] = `
 {
   "result": {
@@ -715,6 +781,36 @@ exports[`rdme docs upload > given that the file path is a single file > should h
 ",
   "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
    - new-doc (__tests__/__fixtures__/docs/new-docs/new-doc.md)
+",
+}
+`;
+
+exports[`rdme docs upload > given that the file path is a single file > should not throw an error if \`max-errors\` flag is set to -1 1`] = `
+{
+  "result": {
+    "created": [],
+    "failed": [
+      {
+        "error": [APIv2Error: ReadMe API error: bad request
+
+something went so so wrong],
+        "filePath": "__tests__/__fixtures__/docs/new-docs/new-doc.md",
+        "result": "failed",
+        "slug": "new-doc",
+      },
+    ],
+    "skipped": [],
+    "updated": [],
+  },
+  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
+ ›    Use at your own risk!
+- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🚀 Uploading files to ReadMe...
+✖ 🚀 Uploading files to ReadMe... 1 file(s) failed.
+",
+  "stdout": "🚨 Received errors when attempting to upload 1 page(s):
+   - __tests__/__fixtures__/docs/new-docs/new-doc.md: bad request
 ",
 }
 `;

--- a/src/commands/docs/upload.ts
+++ b/src/commands/docs/upload.ts
@@ -2,7 +2,12 @@ import { Args, Flags } from '@oclif/core';
 
 import BaseCommand from '../../lib/baseCommand.js';
 import { keyFlag } from '../../lib/flags.js';
-import syncPagePath, { type FailedPushResult, type PushResult } from '../../lib/syncPagePath.js';
+import syncPagePath, {
+  type FailedPushResult,
+  type SkippedPushResult,
+  type CreatePushResult,
+  type UpdatePushResult,
+} from '../../lib/syncPagePath.js';
 
 const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
 
@@ -54,6 +59,13 @@ export default class DocsUploadCommand extends BaseCommand<typeof DocsUploadComm
       description: 'Hides the warning message about this command being in an experimental alpha.',
       hidden: true,
     }),
+    'max-errors': Flags.integer({
+      summary: 'Maximum number of page uploading errors before the command throws an error.',
+      description:
+        'By default, this command will respond with a 1 exit code if any number of the Markdown files fail to upload. This flag allows you to set a maximum number of errors before the command fails. For example, if you set this flag to `5`, the command will respond with an error if 5 or more errors are encountered. If you do not want the command to fail under any circumstances (this could be useful for plugins where you want to handle the error handling yourself), set this flag to `-1`.',
+      default: 0,
+      hidden: true,
+    }),
     'skip-validation': Flags.boolean({
       description:
         'Skips the pre-upload validation of the Markdown files. This flag can be a useful escape hatch but its usage is not recommended.',
@@ -67,10 +79,10 @@ export default class DocsUploadCommand extends BaseCommand<typeof DocsUploadComm
   };
 
   async run(): Promise<{
-    created: PushResult[];
+    created: CreatePushResult[];
     failed: FailedPushResult[];
-    skipped: PushResult[];
-    updated: PushResult[];
+    skipped: SkippedPushResult[];
+    updated: UpdatePushResult[];
   }> {
     if (!this.flags['hide-experimental-warning']) {
       this.warn(alphaNotice);

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export const COMMANDS = {
   'openapi:validate': OpenAPIValidateCommand,
 
   whoami: WhoAmICommand,
-};
+} as const;
 
 export type CommandClass = ValueOf<typeof COMMANDS>;
 

--- a/src/lib/hooks/exported.ts
+++ b/src/lib/hooks/exported.ts
@@ -87,6 +87,15 @@ interface BasePageStat {
    */
   title: string;
 
+  /**
+   * The type of page for the sake of migration.
+   * - `empty-parent`: A parent page with no body content. These are generally placeholders used for defining the hierarchy of the docs.
+   * - `link`: A page that links to an external URL. These are generally used for linking to external documentation.
+   * - `migrated`: A page that was migrated from the input directory. This migration workflow generally relies on a configuration file
+   *  to define the hierarchy of the docs, so this means that the page was defined in the configuration file and was found in the input directory.
+   * - `unlisted`: This means that the page was found in the input directory but was **not** defined in the configuration file.
+   *  These will generally be uploaded to as hidden pages in their own category.
+   */
   type: 'empty-parent' | 'link' | 'migrated' | 'unlisted';
 
   /**
@@ -134,7 +143,7 @@ export interface MigrationStats {
   migrationOutputDir: string;
 
   /**
-   * A map where the key is the plugin name and the value is the migration stats for that plugin.
+   * A map where the key is the plugin name and the value is the migration stats object for that plugin.
    */
   results: Record<
     /**

--- a/src/lib/hooks/exported.ts
+++ b/src/lib/hooks/exported.ts
@@ -1,4 +1,5 @@
 import type { PageMetadata } from '../readPage.js';
+import type { PushResult } from '../syncPagePath.js';
 import type { Hooks } from '@oclif/core/interfaces';
 
 interface MarkdownFileScanResultOptsBase {
@@ -31,6 +32,128 @@ interface MarkdownFileScanResultOptsUnzipped extends MarkdownFileScanResultOptsB
  * The options passed to the `pre_markdown_file_scan` hook.
  */
 export type MarkdownFileScanResultOpts = MarkdownFileScanResultOptsUnzipped | MarkdownFileScanResultOptsZipped;
+
+interface BaseUploadStatus {
+  /**
+   * The status of the upload.
+   */
+  status: PushResult['result'];
+}
+
+export interface FailedUploadStatus extends BaseUploadStatus {
+  /**
+   * The error message if the upload failed.
+   */
+  error?: string;
+
+  status: 'failed';
+}
+
+export interface CreateUploadStatus extends BaseUploadStatus {
+  status: 'created';
+
+  /**
+   * The full URL in ReadMe. Only present if the upload was successful.
+   */
+  url: string;
+}
+
+export interface UpdateUploadStatus extends BaseUploadStatus {
+  status: 'updated';
+
+  /**
+   * The full URL in ReadMe. Only present if the upload was successful.
+   */
+  url: string;
+}
+
+export type UploadStatus = BaseUploadStatus | CreateUploadStatus | FailedUploadStatus | UpdateUploadStatus;
+
+interface BasePageStat {
+  /**
+   * The path to the output page file. Relative to the migration output directory.
+   *
+   * @example docs/support/index.md
+   */
+  outputPath: string;
+
+  /**
+   * The page slug in ReadMe.
+   */
+  slug: string;
+
+  /**
+   * The title of the page.
+   */
+  title: string;
+
+  type: 'empty-parent' | 'link' | 'migrated' | 'unlisted';
+
+  /**
+   * The status of the upload. If `undefined`, the upload has not started yet.
+   */
+  upload?: UploadStatus;
+}
+
+interface LinkPageStat extends BasePageStat {
+  /**
+   * The external link URL.
+   */
+  linkUrl: string;
+
+  type: 'link';
+}
+
+interface LocalPageStat extends BasePageStat {
+  /**
+   * The local path to the input page file. Relative to the root of the input directory/zip.
+   *
+   * This is very likely to be the same as the `outputPath` but is included for
+   * completeness and to allow for the possibility of the output path being different.
+   *
+   * @example docs/support/index.md
+   */
+  inputPath: string;
+
+  type: 'migrated' | 'unlisted';
+}
+
+type PageStat = BasePageStat | LinkPageStat | LocalPageStat;
+
+/**
+ * A subset of the full migration stats that are returned by a single plugin.
+ */
+export interface PluginMigrationStats {
+  pages: PageStat[];
+}
+
+export interface MigrationStats {
+  /**
+   * The directory where the migration output assets are saved to.
+   */
+  migrationOutputDir: string;
+
+  /**
+   * A map where the key is the plugin name and the value is the migration stats for that plugin.
+   */
+  results: Record<
+    /**
+     * The plugin that was run.
+     */
+    string,
+    PluginMigrationStats
+  >;
+
+  /**
+   * The ISO-formatted date string of when the migration was run.
+   */
+  timestamp: string;
+
+  /**
+   * The directory where the input was unzipped to. This is only present if the input was a zip file.
+   */
+  unzippedAssetsDir?: string;
+}
 
 /**
  * Hooks for usage in `rdme` plugins that invoke the `docs migrate` command.
@@ -72,9 +195,15 @@ export interface PluginHooks extends Hooks {
        */
       pages: PageMetadata[];
     };
-    /**
-     * The list of pages that will be validated and written to the output directory.
-     */
-    return: PageMetadata[];
+    return: {
+      /**
+       * The list of pages that will be validated and written to the output directory.
+       */
+      pages: PageMetadata[];
+      /**
+       * Reporting stats on the migration process.
+       */
+      stats: PluginMigrationStats;
+    };
   };
 }

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -27,6 +27,14 @@ type PageRepresentation = GuidesRequestRepresentation;
 
 interface BasePushResult {
   filePath: string;
+
+  /**
+   * The result of the upload operation.
+   * - `created`: The page was created in ReadMe.
+   * - `failed`: There was a failure when attempting to create or update the page.
+   * - `skipped`: The page was skipped due to no frontmatter data.
+   * - `updated`: The page was updated in ReadMe.
+   */
   result: 'created' | 'failed' | 'skipped' | 'updated';
   slug: string;
 }
@@ -130,7 +138,7 @@ async function pushPage(
       )
         .then(res => this.handleAPIRes(res))
         .then(res => {
-          return { filePath, result: 'created', response: res?.data || {}, slug };
+          return { filePath, response: res?.data || {}, result: 'created', slug };
         });
     };
 
@@ -153,7 +161,7 @@ async function pushPage(
       )
         .then(res => this.handleAPIRes(res))
         .then(res => {
-          return { filePath, result: 'updated', response: res?.data || {}, slug };
+          return { filePath, response: res?.data || {}, result: 'updated', slug };
         });
     };
 

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -25,21 +25,40 @@ export type APIv2PageCommands = DocsMigrateCommand | DocsUploadCommand;
 
 type PageRepresentation = GuidesRequestRepresentation;
 
-export interface FailedPushResult {
-  error: APIv2Error | Error;
+interface BasePushResult {
   filePath: string;
-  result: 'failed';
+  result: 'created' | 'failed' | 'skipped' | 'updated';
   slug: string;
 }
 
-export type PushResult =
-  | FailedPushResult
-  | {
-      filePath: string;
-      response: PageRepresentation | null;
-      result: 'created' | 'skipped' | 'updated';
-      slug: string;
-    };
+export interface CreatePushResult extends BasePushResult {
+  /**
+   * The full response from the ReadMe API. If this is `null`,
+   * the page was a dry run and no request was made.
+   */
+  response: PageRepresentation | null;
+  result: 'created';
+}
+
+export interface FailedPushResult extends BasePushResult {
+  error: APIv2Error | Error;
+  result: 'failed';
+}
+
+export interface SkippedPushResult extends BasePushResult {
+  result: 'skipped';
+}
+
+export interface UpdatePushResult extends BasePushResult {
+  /**
+   * The full response from the ReadMe API. If this is `null`,
+   * the page was a dry run and no request was made.
+   */
+  response: PageRepresentation | null;
+  result: 'updated';
+}
+
+export type PushResult = CreatePushResult | FailedPushResult | SkippedPushResult | UpdatePushResult;
 
 /**
  * Reads the contents of the specified Markdown or HTML file
@@ -62,7 +81,7 @@ async function pushPage(
 
   if (!Object.keys(data).length) {
     this.debug(`No frontmatter attributes found for ${filePath}, not syncing`);
-    return { response: null, filePath, result: 'skipped', slug };
+    return { filePath, result: 'skipped', slug };
   }
 
   const payload: PageRepresentation = {
@@ -99,9 +118,9 @@ async function pushPage(
       }
     }
 
-    const createPage = (): Promise<PushResult> | PushResult => {
+    const createPage = (): CreatePushResult | Promise<CreatePushResult> => {
       if (dryRun) {
-        return { filePath, result: 'created', response: null, slug };
+        return { filePath, response: null, result: 'created', slug };
       }
 
       return this.readmeAPIFetch(
@@ -111,13 +130,13 @@ async function pushPage(
       )
         .then(res => this.handleAPIRes(res))
         .then(res => {
-          return { filePath, result: 'created', response: res, slug };
+          return { filePath, result: 'created', response: res?.data || {}, slug };
         });
     };
 
-    const updatePage = (): Promise<PushResult> | PushResult => {
+    const updatePage = (): Promise<UpdatePushResult> | UpdatePushResult => {
       if (dryRun) {
-        return { filePath, result: 'updated', response: null, slug };
+        return { filePath, response: null, result: 'updated', slug };
       }
 
       // omits the slug from the PATCH payload since this would lead to unexpected behavior
@@ -134,7 +153,7 @@ async function pushPage(
       )
         .then(res => this.handleAPIRes(res))
         .then(res => {
-          return { filePath, result: 'updated', response: res, slug };
+          return { filePath, result: 'updated', response: res?.data || {}, slug };
         });
     };
 
@@ -192,9 +211,9 @@ function sortFiles(files: PageMetadata<PageRepresentation>[]): PageMetadata<Page
  * and syncs those (either via POST or PATCH) to ReadMe.
  * @returns An array of objects with the results
  */
-export default async function syncPagePath(this: APIv2PageCommands) {
+export default async function syncPagePath(this: DocsUploadCommand) {
   const { path: pathInput }: { path: string } = this.args;
-  const { key, 'dry-run': dryRun, 'skip-validation': skipValidation } = this.flags;
+  const { key, 'dry-run': dryRun, 'max-errors': maxErrors, 'skip-validation': skipValidation } = this.flags;
 
   // check whether or not the project has bidirection syncing enabled
   // if it is, validations must be skipped to prevent frontmatter from being overwritten
@@ -307,10 +326,10 @@ export default async function syncPagePath(this: APIv2PageCommands) {
   }
 
   const results = rawResults.reduce<{
-    created: PushResult[];
+    created: CreatePushResult[];
     failed: FailedPushResult[];
-    skipped: PushResult[];
-    updated: PushResult[];
+    skipped: SkippedPushResult[];
+    updated: UpdatePushResult[];
   }>(
     (acc, result, index) => {
       if (result.status === 'fulfilled') {
@@ -392,16 +411,19 @@ export default async function syncPagePath(this: APIv2PageCommands) {
 
       this.log(`   - ${chalk.underline(filePath)}: ${errorMessage}`);
     });
-    if (results.failed.length === 1) {
-      throw results.failed[0].error;
-    } else {
-      const errors = results.failed.map(({ error }) => error);
-      throw new AggregateError(
-        errors,
-        dryRun
-          ? `Multiple dry runs failed. To see more detailed errors for a page, run \`${this.config.bin} ${this.id} <path-to-page.md>\` --dry-run.`
-          : `Multiple page uploads failed. To see more detailed errors for a page, run \`${this.config.bin} ${this.id} <path-to-page.md>\`.`,
-      );
+
+    if (results.failed.length >= maxErrors && maxErrors !== -1) {
+      if (results.failed.length === 1) {
+        throw results.failed[0].error;
+      } else {
+        const errors = results.failed.map(({ error }) => error);
+        throw new AggregateError(
+          errors,
+          dryRun
+            ? `Multiple dry runs failed. To see more detailed errors for a page, run \`${this.config.bin} ${this.id} <path-to-page.md>\` --dry-run.`
+            : `Multiple page uploads failed. To see more detailed errors for a page, run \`${this.config.bin} ${this.id} <path-to-page.md>\`.`,
+        );
+      }
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,13 @@
 export type { APIKeyRepresentation, GuidesRequestRepresentation, ProjectRepresentation } from './lib/types/index.js';
 export type { PageMetadata } from './lib/readPage.js';
-export type { MarkdownFileScanResultOpts, PluginHooks } from './lib/hooks/exported.js';
+export type {
+  MarkdownFileScanResultOpts,
+  MigrationStats,
+  PluginHooks,
+  PluginMigrationStats,
+  FailedUploadStatus,
+  CreateUploadStatus,
+  UpdateUploadStatus,
+  UploadStatus,
+} from './lib/hooks/exported.js';
 export type { ResponseBody } from './lib/readmeAPIFetch.js';


### PR DESCRIPTION
| 🚥 Resolves RM-12506 |
| :------------------- |

## 🧰 Changes

adds migration stats reporting to the `docs:migrate` command. this was a big exercise in strong types to ensure that plugin authors have enough guardrails when writing these stats for themselves.

as part of this:
- [x] added a bunch of types and a tiny bit of logic (which is technically a breaking change) to the `pre_markdown_validation` hook return types so it includes both the transformed pages as well as the stats results
- [x] added additional type safety to our syncing results (so we can use these more effectively in downstream plugins)
- [x] added a hidden `--max-errors` flag (inspired in part by [eslint's `--max-warnings` flag](https://eslint.org/docs/latest/use/command-line-interface#--max-warnings)) to `docs:upload` so users/plugin authors have the ability to control how errors are returned

## 🧬 QA & Testing

do tests + types pass?
