### PR TITLE
docs: migration guide + legacy doc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ With `rdme`, you can manage your API definition (we support [OpenAPI](https://sp
 Not using ReadMe for your docs? No worries. `rdme` has a variety of tools to help you identify issues with your API definition — no ReadMe account required.
 
 > [!NOTE]
-> If you're using [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored), you'll want to use `rdme@10` or later. If you're **not** using ReadMe Refactored, you'll want to use `rdme@9`. More info can be found in our [migration guide](https://github.com/readmeio/rdme/blob/next/documentation/migration-guide.md).
+> If you're using [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored), you'll want to use `rdme@10` or later. If you're **not** using ReadMe Refactored, you'll want to use `rdme@9`. More info can be found in our [migration guide](https://github.com/readmeio/rdme/blob/v10/documentation/migration-guide.md).
 
 # Table of Contents
 

--- a/documentation/legacy/github-actions-docs-example.md
+++ b/documentation/legacy/github-actions-docs-example.md
@@ -19,7 +19,7 @@ Check out `.github/workflows/docs.yml` for more info on this!
 
 > 🚧 Deprecated Guidance
 >
-> This example is only applicable for projects that have yet to migrate to [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored), which requires `rdme@9`. You can find more info in [our `rdme` migration guide](https://github.com/readmeio/rdme/blob/next/documentation/migration-guide.md) or by reaching out to us at [support@readme.io](mailto:support@readme.io).
+> This example is only applicable for projects that are still on our legacy project architecture and have not yet migrated to [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored). The legacy project architecture requires `rdme@9`. You can find more info in [our `rdme` migration guide](https://github.com/readmeio/rdme/blob/v10/documentation/migration-guide.md) or by reaching out to us at [support@readme.io](mailto:support@readme.io).
 >
 > We will be updating this document with our latest guidance soon. Thanks for your patience!
 

--- a/documentation/legacy/github-actions-openapi-example.md
+++ b/documentation/legacy/github-actions-openapi-example.md
@@ -18,7 +18,7 @@ Check out `.github/workflows/docs.yml` for more info on this!
 
 > 🚧 Deprecated Guidance
 >
-> This example is only applicable for projects that have yet to migrate to [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored), which requires `rdme@9`. You can find more info in [our `rdme` migration guide](https://github.com/readmeio/rdme/blob/next/documentation/migration-guide.md) or by reaching out to us at [support@readme.io](mailto:support@readme.io).
+> This example is only applicable for projects that are still on our legacy project architecture and have not yet migrated to [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored). The legacy project architecture requires `rdme@9`. You can find more info in [our `rdme` migration guide](https://github.com/readmeio/rdme/blob/v10/documentation/migration-guide.md) or by reaching out to us at [support@readme.io](mailto:support@readme.io).
 >
 > We will be updating this document with our latest guidance soon. Thanks for your patience!
 

--- a/documentation/legacy/rdme.md
+++ b/documentation/legacy/rdme.md
@@ -53,7 +53,7 @@ To see detailed CLI setup instructions and all available commands, check out [th
 
 > 🚧 Deprecated Guidance
 >
-> This guidance is only applicable for projects that have yet to migrate to [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored), which requires `rdme@9`. You can find more info in [our `rdme` migration guide](https://github.com/readmeio/rdme/blob/next/documentation/migration-guide.md) or by reaching out to us at [support@readme.io](mailto:support@readme.io).
+> This guidance is only applicable for projects that are still on our legacy project architecture and have not yet migrated to [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored). The legacy project architecture requires `rdme@9`. You can find more info in [our `rdme` migration guide](https://github.com/readmeio/rdme/blob/v10/documentation/migration-guide.md) or by reaching out to us at [support@readme.io](mailto:support@readme.io).
 >
 > We will be updating this document with our latest guidance soon. Thanks for your patience!
 
@@ -143,7 +143,7 @@ While there are [dozens of event options available](https://docs.github.com/acti
 
 > 🚧 Deprecated Guidance
 >
-> This guidance is only applicable for projects that have yet to migrate to [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored), which requires `rdme@9`. You can find more info in [our `rdme` migration guide](https://github.com/readmeio/rdme/blob/next/documentation/migration-guide.md) or by reaching out to us at [support@readme.io](mailto:support@readme.io).
+> This guidance is only applicable for projects that are still on our legacy project architecture and have not yet migrated to [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored). The legacy project architecture requires `rdme@9`. You can find more info in [our `rdme` migration guide](https://github.com/readmeio/rdme/blob/v10/documentation/migration-guide.md) or by reaching out to us at [support@readme.io](mailto:support@readme.io).
 >
 > We will be updating this document with our latest guidance soon. Thanks for your patience!
 
@@ -223,7 +223,7 @@ The following section has links to full GitHub Actions workflow file examples.
 
 > 🚧 Deprecated Guidance
 >
-> This guidance is only applicable for projects that have yet to migrate to [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored), which requires `rdme@9`. You can find more info in [our `rdme` migration guide](https://github.com/readmeio/rdme/blob/next/documentation/migration-guide.md) or by reaching out to us at [support@readme.io](mailto:support@readme.io).
+> This guidance is only applicable for projects that are still on our legacy project architecture and have not yet migrated to [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored). The legacy project architecture requires `rdme@9`. You can find more info in [our `rdme` migration guide](https://github.com/readmeio/rdme/blob/v10/documentation/migration-guide.md) or by reaching out to us at [support@readme.io](mailto:support@readme.io).
 >
 > We will be updating this document with our latest guidance soon. Thanks for your patience!
 

--- a/documentation/migration-guide.md
+++ b/documentation/migration-guide.md
@@ -74,7 +74,6 @@ If you're using the `rdme` GitHub Action, update your GitHub Actions workflow fi
    - Replace: `openapi` → `openapi upload` (see more in step 3 below)
    - Replace: `categories` → use [Git-based workflow](https://docs.readme.com/main/docs/bi-directional-sync)
    - Replace: `custompages` → use [Git-based workflow](https://docs.readme.com/main/docs/bi-directional-sync)
-   - Replace: `docs` (and its `guides` alias) → `docs upload` (see more in step 4 below)
    - Replace: `versions` → use [Git-based workflow](https://docs.readme.com/main/docs/bi-directional-sync)
    - Remove: `open`
 
@@ -87,18 +86,6 @@ If you're using the `rdme` GitHub Action, update your GitHub Actions workflow fi
    - Previously with `openapi`, the `--id` flag was an ObjectId that required an initial upload to ReadMe, which made it difficult to upsert API definitions and manage many at scale. With `openapi upload`, the `--id` flag has been renamed to `--slug` and is now optional. The slug (i.e., the unique identifier for your API definition resource in ReadMe) is inferred from the file path or URL to your API definition.
 
    Read more in [the `openapi upload` command docs](https://github.com/readmeio/rdme/tree/v10/documentation/commands/openapi.md#rdme-openapi-upload-spec) and in [the ReadMe API migration guide](https://docs.readme.com/main/reference/api-migration-guide).
-
-4. **`docs` has been replaced by `docs upload`**
-
-   If you previously uploaded Markdown files to your Guides section via `rdme docs`, the command is now `rdme docs upload`. The command semantics are largely the same, but with a few small changes:
-
-   - The `--dryRun` flag has been deprecated in favor of `--dry-run`.
-
-   - Like `openapi upload` above, there is no prompt to select your ReadMe project version if you omit the `--version` flag. It now defaults to `stable` (i.e., your main ReadMe project version).
-
-   - `rdme docs upload` will now automatically validate your frontmatter and flag any issues prior to syncing. This is particularly helpful if you're coming from `rdme@9` or earlier, since the shape of certain frontmatter attributes (e.g., `category`, `parent`) have slightly changed. If you run this command in a non-CI environment, any outdated frontmatter will be detected and you'll have the ability to update it automatically.
-
-   Read more in [the `docs upload` command docs](https://github.com/readmeio/rdme/tree/v10/documentation/commands/docs.md#rdme-docs-upload-path) and in [the ReadMe API migration guide](https://docs.readme.com/main/reference/api-migration-guide).
 
 ## Migrating to `rdme@9`
 


### PR DESCRIPTION
## 🧰 Changes

@mjcuva pointed out a few gaps in our documentation as it currently exists:

- [x] some of these migration guide links were improperly pointing to the `next` branch when they should be pointing to the `v10` tag
- [x] the migration guide mentions `docs upload` which isn't technically out yet (i'll plan to add this back in https://github.com/readmeio/rdme/pull/1166
- [x] made a few tweaks to the callout language in the legacy doc so it's even clearer what these examples are doing.

## 🧬 QA & Testing

are you happy with these changes?
