### PR TITLE
fix: remove `/version` API deprecation warnings

### DIFF
--- a/__tests__/__fixtures__/docs/existing-docs/subdir/another-doc.md
+++ b/__tests__/__fixtures__/docs/existing-docs/subdir/another-doc.md
@@ -1,7 +1,7 @@
 ---
 title: This is another document title
 category:
-  uri: /versions/stable/categories/guides/category-slug
+  uri: /branches/stable/categories/guides/category-slug
 ---
 
 Another body

--- a/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
@@ -678,7 +678,7 @@ exports[`rdme docs upload > given that the file path is a single file > given th
 }
 `;
 
-exports[`rdme docs upload > given that the file path is a single file > should allow for user to specify version via --version flag 1`] = `
+exports[`rdme docs upload > given that the file path is a single file > should allow for user to specify branch via --branch flag 1`] = `
 {
   "result": {
     "created": [

--- a/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/docs/__snapshots__/upload.test.ts.snap
@@ -706,6 +706,35 @@ exports[`rdme docs upload > given that the file path is a single file > should a
 }
 `;
 
+exports[`rdme docs upload > given that the file path is a single file > should allow for user to specify branch via legacy --version flag 1`] = `
+{
+  "result": {
+    "created": [
+      {
+        "filePath": "__tests__/__fixtures__/docs/new-docs/new-doc.md",
+        "response": {},
+        "result": "created",
+        "slug": "new-doc",
+      },
+    ],
+    "failed": [],
+    "skipped": [],
+    "updated": [],
+  },
+  "stderr": " ›   Warning: The "--version" flag has been deprecated. Use "--branch" instead.
+ ›   Warning: This command is in an experimental alpha and is likely to change.
+ ›    Use at your own risk!
+- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🚀 Uploading files to ReadMe...
+✔ 🚀 Uploading files to ReadMe... done!
+",
+  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
+   - new-doc (__tests__/__fixtures__/docs/new-docs/new-doc.md)
+",
+}
+`;
+
 exports[`rdme docs upload > given that the file path is a single file > should create a guides page in ReadMe 1`] = `
 {
   "result": {

--- a/__tests__/commands/docs/upload.test.ts
+++ b/__tests__/commands/docs/upload.test.ts
@@ -736,10 +736,10 @@ describe('rdme docs upload', () => {
       nock.cleanAll();
 
       const mock = getAPIv2Mock({ authorization })
-        .get('/branches/1.2.3/guides/new-doc')
+        .get('/branches/stable/guides/new-doc')
         .reply(404)
-        .post('/branches/1.2.3/guides', {
-          category: { uri: '/branches/1.2.3/categories/guides/category-slug' },
+        .post('/branches/stable/guides', {
+          category: { uri: '/branches/stable/categories/guides/category-slug' },
           slug: 'new-doc',
           title: 'This is the document title',
           content: { body: '\nBody\n' },
@@ -752,14 +752,7 @@ describe('rdme docs upload', () => {
           data: { git: { connection: { status: 'active' } } },
         });
 
-      const result = await run([
-        '__tests__/__fixtures__/docs/new-docs/new-doc.md',
-        '--key',
-        key,
-        '--version',
-        '1.2.3',
-        '--skip-validation',
-      ]);
+      const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key, '--skip-validation']);
 
       expect(result).toMatchSnapshot();
       expect(fs.writeFileSync).not.toHaveBeenCalled();

--- a/__tests__/commands/docs/upload.test.ts
+++ b/__tests__/commands/docs/upload.test.ts
@@ -100,6 +100,26 @@ describe('rdme docs upload', () => {
       mock.done();
     });
 
+    it('should allow for user to specify branch via legacy --version flag', async () => {
+      const mock = getAPIv2Mock({ authorization })
+        .get('/branches/4.5.6/guides/new-doc')
+        .reply(404)
+        .post('/branches/4.5.6/guides', {
+          category: { uri: '/branches/4.5.6/categories/guides/category-slug' },
+          slug: 'new-doc',
+          title: 'This is the document title',
+          content: { body: '\nBody\n' },
+        })
+        .reply(201, {});
+
+      const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key, '--version', '4.5.6']);
+
+      expect(result).toMatchSnapshot();
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+      mock.done();
+    });
+
     describe('given that the --dry-run flag is passed', () => {
       it('should not create anything in ReadMe', async () => {
         const mock = getAPIv2Mock({ authorization }).get('/branches/stable/guides/new-doc').reply(404);

--- a/__tests__/commands/docs/upload.test.ts
+++ b/__tests__/commands/docs/upload.test.ts
@@ -80,7 +80,7 @@ describe('rdme docs upload', () => {
       mock.done();
     });
 
-    it('should allow for user to specify version via --version flag', async () => {
+    it('should allow for user to specify branch via --branch flag', async () => {
       const mock = getAPIv2Mock({ authorization })
         .get('/branches/1.2.3/guides/new-doc')
         .reply(404)
@@ -92,7 +92,7 @@ describe('rdme docs upload', () => {
         })
         .reply(201, {});
 
-      const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key, '--version', '1.2.3']);
+      const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key, '--branch', '1.2.3']);
 
       expect(result).toMatchSnapshot();
       expect(fs.writeFileSync).not.toHaveBeenCalled();

--- a/__tests__/commands/docs/upload.test.ts
+++ b/__tests__/commands/docs/upload.test.ts
@@ -37,10 +37,10 @@ describe('rdme docs upload', () => {
   describe('given that the file path is a single file', () => {
     it('should create a guides page in ReadMe', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .get('/versions/stable/guides/new-doc')
+        .get('/branches/stable/guides/new-doc')
         .reply(404)
-        .post('/versions/stable/guides', {
-          category: { uri: '/versions/stable/categories/guides/category-slug' },
+        .post('/branches/stable/guides', {
+          category: { uri: '/branches/stable/categories/guides/category-slug' },
           slug: 'new-doc',
           title: 'This is the document title',
           content: { body: '\nBody\n' },
@@ -57,10 +57,10 @@ describe('rdme docs upload', () => {
 
     it('should hide the warning if the `--hide-experimental-warning` flag is passed', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .get('/versions/stable/guides/new-doc')
+        .get('/branches/stable/guides/new-doc')
         .reply(404)
-        .post('/versions/stable/guides', {
-          category: { uri: '/versions/stable/categories/guides/category-slug' },
+        .post('/branches/stable/guides', {
+          category: { uri: '/branches/stable/categories/guides/category-slug' },
           slug: 'new-doc',
           title: 'This is the document title',
           content: { body: '\nBody\n' },
@@ -82,10 +82,10 @@ describe('rdme docs upload', () => {
 
     it('should allow for user to specify version via --version flag', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .get('/versions/1.2.3/guides/new-doc')
+        .get('/branches/1.2.3/guides/new-doc')
         .reply(404)
-        .post('/versions/1.2.3/guides', {
-          category: { uri: '/versions/1.2.3/categories/guides/category-slug' },
+        .post('/branches/1.2.3/guides', {
+          category: { uri: '/branches/1.2.3/categories/guides/category-slug' },
           slug: 'new-doc',
           title: 'This is the document title',
           content: { body: '\nBody\n' },
@@ -102,7 +102,7 @@ describe('rdme docs upload', () => {
 
     describe('given that the --dry-run flag is passed', () => {
       it('should not create anything in ReadMe', async () => {
-        const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/new-doc').reply(404);
+        const mock = getAPIv2Mock({ authorization }).get('/branches/stable/guides/new-doc').reply(404);
 
         const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key, '--dry-run']);
 
@@ -113,7 +113,7 @@ describe('rdme docs upload', () => {
       });
 
       it('should not update anything in ReadMe', async () => {
-        const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/some-slug').reply(200);
+        const mock = getAPIv2Mock({ authorization }).get('/branches/stable/guides/some-slug').reply(200);
 
         const result = await run(['__tests__/__fixtures__/docs/slug-docs/new-doc-slug.md', '--key', key, '--dry-run']);
 
@@ -124,7 +124,7 @@ describe('rdme docs upload', () => {
       });
 
       it('should error out if a non-404 error is returned from the GET request', async () => {
-        const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/some-slug').reply(500);
+        const mock = getAPIv2Mock({ authorization }).get('/branches/stable/guides/some-slug').reply(500);
 
         const result = await run(['__tests__/__fixtures__/docs/slug-docs/new-doc-slug.md', '--key', key, '--dry-run']);
 
@@ -135,7 +135,7 @@ describe('rdme docs upload', () => {
       });
 
       it('should error out if a non-404 error is returned from the GET request (with a json body)', async () => {
-        const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/some-slug').reply(500, {
+        const mock = getAPIv2Mock({ authorization }).get('/branches/stable/guides/some-slug').reply(500, {
           title: 'bad request',
           detail: 'something went so so wrong',
           status: 500,
@@ -153,10 +153,10 @@ describe('rdme docs upload', () => {
     describe('given that the slug is passed in the frontmatter', () => {
       it('should use that slug to create a page in ReadMe', async () => {
         const mock = getAPIv2Mock({ authorization })
-          .get('/versions/stable/guides/some-slug')
+          .get('/branches/stable/guides/some-slug')
           .reply(404)
-          .post('/versions/stable/guides', {
-            category: { uri: '/versions/stable/categories/guides/some-category-uri' },
+          .post('/branches/stable/guides', {
+            category: { uri: '/branches/stable/categories/guides/some-category-uri' },
             title: 'This is the document title',
             content: { body: '\nBody\n' },
             slug: 'some-slug',
@@ -173,10 +173,10 @@ describe('rdme docs upload', () => {
 
       it('should use that slug update an existing guides page in ReadMe', async () => {
         const mock = getAPIv2Mock({ authorization })
-          .get('/versions/stable/guides/some-slug')
+          .get('/branches/stable/guides/some-slug')
           .reply(200)
-          .patch('/versions/stable/guides/some-slug', {
-            category: { uri: '/versions/stable/categories/guides/some-category-uri' },
+          .patch('/branches/stable/guides/some-slug', {
+            category: { uri: '/branches/stable/categories/guides/some-category-uri' },
             title: 'This is the document title',
             content: { body: '\nBody\n' },
           })
@@ -194,10 +194,10 @@ describe('rdme docs upload', () => {
     describe('given that the file has frontmatter issues', () => {
       it('should fix the frontmatter issues in the file and create the corrected file in ReadMe', async () => {
         const mock = getAPIv2Mock({ authorization })
-          .get('/versions/stable/guides/legacy-category')
+          .get('/branches/stable/guides/legacy-category')
           .reply(404)
-          .post('/versions/stable/guides', {
-            category: { uri: '/versions/stable/categories/guides/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f' },
+          .post('/branches/stable/guides', {
+            category: { uri: '/branches/stable/categories/guides/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f' },
             slug: 'legacy-category',
             title: 'This is the document title',
             content: { body: '\nBody\n' },
@@ -228,10 +228,10 @@ describe('rdme docs upload', () => {
           });
 
         const mock = getAPIv2Mock({ authorization })
-          .get('/versions/stable/guides/legacy-category')
+          .get('/branches/stable/guides/legacy-category')
           .reply(404)
-          .post('/versions/stable/guides', {
-            category: { uri: '/versions/stable/categories/guides/mapped-uri' },
+          .post('/branches/stable/guides', {
+            category: { uri: '/branches/stable/categories/guides/mapped-uri' },
             slug: 'legacy-category',
             title: 'This is the document title',
             content: { body: '\nBody\n' },
@@ -269,9 +269,9 @@ describe('rdme docs upload', () => {
 
       it('should skip client-side validation if the --skip-validation flag is passed', async () => {
         const mock = getAPIv2Mock({ authorization })
-          .get('/versions/stable/guides/legacy-category')
+          .get('/branches/stable/guides/legacy-category')
           .reply(404)
-          .post('/versions/stable/guides', {
+          .post('/branches/stable/guides', {
             category: '5ae122e10fdf4e39bb34db6f',
             slug: 'legacy-category',
             title: 'This is the document title',
@@ -294,11 +294,11 @@ describe('rdme docs upload', () => {
 
       it('should warn user if the file has no autofixable issues', async () => {
         const mock = getAPIv2Mock({ authorization })
-          .get('/versions/stable/guides/invalid-attributes')
+          .get('/branches/stable/guides/invalid-attributes')
           .reply(404)
-          .post('/versions/stable/guides', {
+          .post('/branches/stable/guides', {
             category: {
-              uri: '/versions/stable/categories/guides/some-category-uri',
+              uri: '/branches/stable/categories/guides/some-category-uri',
               'is-this-a-valid-property': 'nope',
             },
             slug: 'invalid-attributes',
@@ -322,15 +322,15 @@ describe('rdme docs upload', () => {
       afterEach(githubActionsEnv.after);
 
       it('should create a guides page in ReadMe and include `x-readme-source-url` source header', async () => {
-        const getMock = getAPIv2MockForGHA({ authorization }).get('/versions/stable/guides/new-doc').reply(404);
+        const getMock = getAPIv2MockForGHA({ authorization }).get('/branches/stable/guides/new-doc').reply(404);
 
         const postMock = getAPIv2MockForGHA({
           authorization,
           'x-readme-source-url':
             'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/__tests__/__fixtures__/docs/new-docs/new-doc.md',
         })
-          .post('/versions/stable/guides', {
-            category: { uri: '/versions/stable/categories/guides/category-slug' },
+          .post('/branches/stable/guides', {
+            category: { uri: '/branches/stable/categories/guides/category-slug' },
             slug: 'new-doc',
             title: 'This is the document title',
             content: { body: '\nBody\n' },
@@ -363,15 +363,15 @@ describe('rdme docs upload', () => {
       });
 
       it('should bypass prompt if `--confirm-autofixes` flag is passed', async () => {
-        const getMock = getAPIv2MockForGHA({ authorization }).get('/versions/stable/guides/legacy-category').reply(404);
+        const getMock = getAPIv2MockForGHA({ authorization }).get('/branches/stable/guides/legacy-category').reply(404);
 
         const postMock = getAPIv2MockForGHA({
           authorization,
           'x-readme-source-url':
             'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/__tests__/__fixtures__/docs/mixed-docs/legacy-category.md',
         })
-          .post('/versions/stable/guides', {
-            category: { uri: '/versions/stable/categories/guides/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f' },
+          .post('/branches/stable/guides', {
+            category: { uri: '/branches/stable/categories/guides/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f' },
             slug: 'legacy-category',
             title: 'This is the document title',
             content: { body: '\nBody\n' },
@@ -402,7 +402,7 @@ describe('rdme docs upload', () => {
     });
 
     it('should error out if a non-404 error is returned from the GET request', async () => {
-      const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/new-doc').reply(500);
+      const mock = getAPIv2Mock({ authorization }).get('/branches/stable/guides/new-doc').reply(500);
 
       const result = await run(['__tests__/__fixtures__/docs/new-docs/new-doc.md', '--key', key]);
 
@@ -413,7 +413,7 @@ describe('rdme docs upload', () => {
     });
 
     it('should error out if a non-404 error is returned from the GET request (with a json body)', async () => {
-      const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/new-doc').reply(500, {
+      const mock = getAPIv2Mock({ authorization }).get('/branches/stable/guides/new-doc').reply(500, {
         title: 'bad request',
         detail: 'something went so so wrong',
         status: 500,
@@ -428,7 +428,7 @@ describe('rdme docs upload', () => {
     });
 
     it('should not throw an error if `max-errors` flag is set to -1', async () => {
-      const mock = getAPIv2Mock({ authorization }).get('/versions/stable/guides/new-doc').reply(500, {
+      const mock = getAPIv2Mock({ authorization }).get('/branches/stable/guides/new-doc').reply(500, {
         title: 'bad request',
         detail: 'something went so so wrong',
         status: 500,
@@ -460,21 +460,21 @@ describe('rdme docs upload', () => {
   describe('given that the file path is a directory', () => {
     it('should create a guides page in ReadMe for each file in the directory and its subdirectories', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .get('/versions/stable/guides/simple-doc')
+        .get('/branches/stable/guides/simple-doc')
         .reply(404)
-        .post('/versions/stable/guides', {
+        .post('/branches/stable/guides', {
           slug: 'simple-doc',
           title: 'This is the document title',
           content: { body: '\nBody\n' },
         })
         .reply(201, {})
-        .get('/versions/stable/guides/another-doc')
+        .get('/branches/stable/guides/another-doc')
         .reply(404)
-        .post('/versions/stable/guides', {
+        .post('/branches/stable/guides', {
           slug: 'another-doc',
           title: 'This is another document title',
           content: { body: '\nAnother body\n' },
-          category: { uri: '/versions/stable/categories/guides/category-slug' },
+          category: { uri: '/branches/stable/categories/guides/category-slug' },
         })
         .reply(201, {});
 
@@ -488,18 +488,18 @@ describe('rdme docs upload', () => {
 
     it('should update existing guides pages in ReadMe for each file in the directory and its subdirectories', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .get('/versions/stable/guides/simple-doc')
+        .get('/branches/stable/guides/simple-doc')
         .reply(200)
-        .patch('/versions/stable/guides/simple-doc', {
+        .patch('/branches/stable/guides/simple-doc', {
           title: 'This is the document title',
           content: { body: '\nBody\n' },
         })
         .reply(201, {})
-        .get('/versions/stable/guides/another-doc')
+        .get('/branches/stable/guides/another-doc')
         .reply(200)
-        .patch('/versions/stable/guides/another-doc', {
+        .patch('/branches/stable/guides/another-doc', {
           title: 'This is another document title',
-          category: { uri: '/versions/stable/categories/guides/category-slug' },
+          category: { uri: '/branches/stable/categories/guides/category-slug' },
           content: { body: '\nAnother body\n' },
         })
         .reply(201, {});
@@ -514,20 +514,20 @@ describe('rdme docs upload', () => {
 
     it('should handle complex frontmatter', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .get('/versions/stable/guides/basic')
+        .get('/branches/stable/guides/basic')
         .reply(200)
-        .patch('/versions/stable/guides/basic', {
+        .patch('/branches/stable/guides/basic', {
           title: 'This is the document title',
-          category: { uri: '/versions/stable/categories/guides/category-slug' },
+          category: { uri: '/branches/stable/categories/guides/category-slug' },
           content: { body: 'frontmatter body', excerpt: 'frontmatter excerpt' },
           type: 'basic',
         })
         .reply(201, {})
-        .get('/versions/stable/guides/link')
+        .get('/branches/stable/guides/link')
         .reply(200)
-        .patch('/versions/stable/guides/link', {
+        .patch('/branches/stable/guides/link', {
           title: 'This is the document title',
-          category: { uri: '/versions/stable/categories/guides/category-slug' },
+          category: { uri: '/branches/stable/categories/guides/category-slug' },
           content: {
             body: '\nBody\n',
             excerpt: 'frontmatter excerpt',
@@ -548,35 +548,35 @@ describe('rdme docs upload', () => {
     describe('given that the directory contains parent/child docs', () => {
       it('should upload parents before children', async () => {
         const mock = getAPIv2Mock({ authorization })
-          .get('/versions/stable/guides/child')
+          .get('/branches/stable/guides/child')
           .reply(404)
-          .post('/versions/stable/guides', {
+          .post('/branches/stable/guides', {
             slug: 'child',
             title: 'Child',
-            parent: { uri: '/versions/stable/guides/parent' },
+            parent: { uri: '/branches/stable/guides/parent' },
             content: { body: '\nBody\n' },
           })
           .reply(201, {})
-          .get('/versions/stable/guides/friend')
+          .get('/branches/stable/guides/friend')
           .reply(404)
-          .post('/versions/stable/guides', {
+          .post('/branches/stable/guides', {
             slug: 'friend',
             title: 'Friend',
             content: { body: '\nBody\n' },
           })
           .reply(201, {})
-          .get('/versions/stable/guides/parent')
+          .get('/branches/stable/guides/parent')
           .reply(404)
-          .post('/versions/stable/guides', {
+          .post('/branches/stable/guides', {
             slug: 'parent',
             title: 'Parent',
-            parent: { uri: '/versions/stable/guides/grandparent' },
+            parent: { uri: '/branches/stable/guides/grandparent' },
             content: { body: '\nBody\n' },
           })
           .reply(201, {})
-          .get('/versions/stable/guides/grandparent')
+          .get('/branches/stable/guides/grandparent')
           .reply(404)
-          .post('/versions/stable/guides', {
+          .post('/branches/stable/guides', {
             slug: 'grandparent',
             title: 'Grandparent',
             content: { body: '\nBody\n' },
@@ -600,35 +600,35 @@ describe('rdme docs upload', () => {
 
     it('should handle a mix of creates and updates and failures and skipped files', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .get('/versions/stable/guides/invalid-attributes')
+        .get('/branches/stable/guides/invalid-attributes')
         .reply(404)
-        .post('/versions/stable/guides', {
-          category: { uri: '/versions/stable/categories/guides/some-category-uri', 'is-this-a-valid-property': 'nope' },
+        .post('/branches/stable/guides', {
+          category: { uri: '/branches/stable/categories/guides/some-category-uri', 'is-this-a-valid-property': 'nope' },
           slug: 'invalid-attributes',
           title: 'This is the document title',
           content: { body: '\nBody\n' },
         })
         .reply(201, {})
-        .get('/versions/stable/guides/legacy-category')
+        .get('/branches/stable/guides/legacy-category')
         .reply(200)
-        .patch('/versions/stable/guides/legacy-category', {
-          category: { uri: '/versions/stable/categories/guides/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f' },
+        .patch('/branches/stable/guides/legacy-category', {
+          category: { uri: '/branches/stable/categories/guides/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f' },
           title: 'This is the document title',
           content: { body: '\nBody\n' },
         })
         .reply(201, {})
-        .get('/versions/stable/guides/some-slug')
+        .get('/branches/stable/guides/some-slug')
         .reply(404)
-        .post('/versions/stable/guides', {
+        .post('/branches/stable/guides', {
           slug: 'some-slug',
           title: 'This is the document title',
-          category: { uri: '/versions/stable/categories/guides/some-category-uri' },
+          category: { uri: '/branches/stable/categories/guides/some-category-uri' },
           content: { body: '\nBody\n' },
         })
         .reply(500, {})
-        .get('/versions/stable/guides/simple-doc')
+        .get('/branches/stable/guides/simple-doc')
         .reply(404)
-        .post('/versions/stable/guides', {
+        .post('/branches/stable/guides', {
           slug: 'simple-doc',
           title: 'This is the document title',
           content: { body: '\nBody\n' },
@@ -647,35 +647,35 @@ describe('rdme docs upload', () => {
 
     it('should handle a mix of creates and updates and failures and skipped files and not error out with `max-errors` flag', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .get('/versions/stable/guides/invalid-attributes')
+        .get('/branches/stable/guides/invalid-attributes')
         .reply(404)
-        .post('/versions/stable/guides', {
-          category: { uri: '/versions/stable/categories/guides/some-category-uri', 'is-this-a-valid-property': 'nope' },
+        .post('/branches/stable/guides', {
+          category: { uri: '/branches/stable/categories/guides/some-category-uri', 'is-this-a-valid-property': 'nope' },
           slug: 'invalid-attributes',
           title: 'This is the document title',
           content: { body: '\nBody\n' },
         })
         .reply(201, {})
-        .get('/versions/stable/guides/legacy-category')
+        .get('/branches/stable/guides/legacy-category')
         .reply(200)
-        .patch('/versions/stable/guides/legacy-category', {
-          category: { uri: '/versions/stable/categories/guides/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f' },
+        .patch('/branches/stable/guides/legacy-category', {
+          category: { uri: '/branches/stable/categories/guides/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f' },
           title: 'This is the document title',
           content: { body: '\nBody\n' },
         })
         .reply(201, {})
-        .get('/versions/stable/guides/some-slug')
+        .get('/branches/stable/guides/some-slug')
         .reply(404)
-        .post('/versions/stable/guides', {
+        .post('/branches/stable/guides', {
           slug: 'some-slug',
           title: 'This is the document title',
-          category: { uri: '/versions/stable/categories/guides/some-category-uri' },
+          category: { uri: '/branches/stable/categories/guides/some-category-uri' },
           content: { body: '\nBody\n' },
         })
         .reply(500, {})
-        .get('/versions/stable/guides/simple-doc')
+        .get('/branches/stable/guides/simple-doc')
         .reply(404)
-        .post('/versions/stable/guides', {
+        .post('/branches/stable/guides', {
           slug: 'simple-doc',
           title: 'This is the document title',
           content: { body: '\nBody\n' },
@@ -694,13 +694,13 @@ describe('rdme docs upload', () => {
 
     it('should handle a mix of creates and updates and failures and skipped files (dry run)', async () => {
       const mock = getAPIv2Mock({ authorization })
-        .get('/versions/stable/guides/invalid-attributes')
+        .get('/branches/stable/guides/invalid-attributes')
         .reply(404)
-        .get('/versions/stable/guides/legacy-category')
+        .get('/branches/stable/guides/legacy-category')
         .reply(200)
-        .get('/versions/stable/guides/some-slug')
+        .get('/branches/stable/guides/some-slug')
         .reply(500)
-        .get('/versions/stable/guides/simple-doc')
+        .get('/branches/stable/guides/simple-doc')
         .reply(500);
 
       prompts.inject([true]);
@@ -736,10 +736,10 @@ describe('rdme docs upload', () => {
       nock.cleanAll();
 
       const mock = getAPIv2Mock({ authorization })
-        .get('/versions/1.2.3/guides/new-doc')
+        .get('/branches/1.2.3/guides/new-doc')
         .reply(404)
-        .post('/versions/1.2.3/guides', {
-          category: { uri: '/versions/1.2.3/categories/guides/category-slug' },
+        .post('/branches/1.2.3/guides', {
+          category: { uri: '/branches/1.2.3/categories/guides/category-slug' },
           slug: 'new-doc',
           title: 'This is the document title',
           content: { body: '\nBody\n' },

--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -14,7 +14,7 @@ exports[`rdme openapi upload > given that the API definition is a URL > should c
 {
   "result": {
     "status": "done",
-    "uri": "/versions/1.0.0/apis/openapi.json",
+    "uri": "/branches/1.0.0/apis/openapi.json",
   },
   "stderr": "- Validating the API definition located at https://example.com/openapi.json...
 - Creating your API definition to ReadMe...
@@ -39,7 +39,7 @@ exports[`rdme openapi upload > given that the API definition is a URL > should u
 {
   "result": {
     "status": "done",
-    "uri": "/versions/1.0.0/apis/openapi.json",
+    "uri": "/branches/1.0.0/apis/openapi.json",
   },
   "stderr": "- Validating the API definition located at https://example.com/openapi.json...
 - Updating your API definition to ReadMe...
@@ -80,7 +80,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 {
   "result": {
     "status": "done",
-    "uri": "/versions/1.0.0/apis/custom-slug.json",
+    "uri": "/branches/1.0.0/apis/custom-slug.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
  ›   Warning: The slug of your API Definition will be set to 
@@ -99,7 +99,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 {
   "result": {
     "status": "done",
-    "uri": "/versions/1.0.0/apis/custom-slug.json",
+    "uri": "/branches/1.0.0/apis/custom-slug.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
  ›   Warning: The slug of your API Definition will be set to 
@@ -118,7 +118,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 {
   "result": {
     "status": "done",
-    "uri": "/versions/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
+    "uri": "/branches/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
  ›   Warning: The slug of your API Definition will be set to 
@@ -180,7 +180,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 {
   "result": {
     "status": "done",
-    "uri": "/versions/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
+    "uri": "/branches/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
  ›   Warning: The slug of your API Definition will be set to 
@@ -199,7 +199,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > g
 {
   "result": {
     "status": "done",
-    "uri": "/versions/stable/apis/__tests____fixtures__petstore-simple-weird-version.json",
+    "uri": "/branches/stable/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
  ›   Warning: The slug of your API Definition will be set to 
@@ -218,7 +218,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > g
 {
   "result": {
     "status": "done",
-    "uri": "/versions/1.2.3/apis/__tests____fixtures__petstore-simple-weird-version.json",
+    "uri": "/branches/1.2.3/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
  ›   Warning: The slug of your API Definition will be set to 
@@ -237,7 +237,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
 {
   "result": {
     "status": "done",
-    "uri": "/versions/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
+    "uri": "/branches/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
  ›   Warning: The slug of your API Definition will be set to 
@@ -256,7 +256,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
 {
   "result": {
     "status": "done",
-    "uri": "/versions/1.0.0/apis/__tests____fixtures__postmanpetstore.collection.yaml",
+    "uri": "/branches/1.0.0/apis/__tests____fixtures__postmanpetstore.collection.yaml",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/postman/petstore.collection.yaml...
  ›   Warning: The slug of your API Definition will be set to 
@@ -290,7 +290,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
 {
   "result": {
     "status": "done",
-    "uri": "/versions/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
+    "uri": "/branches/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
  ›   Warning: The slug of your API Definition will be set to 

--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -252,6 +252,26 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
 }
 `;
 
+exports[`rdme openapi upload > given that the API definition is a local file > should create a new JSON API definition in ReadMe with deprecated \`--version\` flag 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/branches/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
+  },
+  "stderr": " ›   Warning: The "--version" flag has been deprecated. Use "--branch" instead.
+- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The slug of your API Definition will be set to 
+ ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
+ ›   slug is not visible to your end users. To set this slug to something else,
+ ›    use the \`--slug\` flag.
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... done!
+",
+  "stdout": "🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
+",
+}
+`;
+
 exports[`rdme openapi upload > given that the API definition is a local file > should create a new YAML API definition in ReadMe 1`] = `
 {
   "result": {

--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`rdme openapi upload > flag error handling > should throw if an error if both \`--version\` and \`--useSpecVersion\` flags are passed 1`] = `
+exports[`rdme openapi upload > flag error handling > should throw if an error if both \`--branch\` and \`--useSpecVersion\` flags are passed 1`] = `
 {
   "error": [Error: The following error occurred:
-  --version=1.0.0 cannot also be provided when using --useSpecVersion
+  --branch=1.0.0 cannot also be provided when using --useSpecVersion
 See more help with --help],
   "stderr": "",
   "stdout": "",
@@ -195,7 +195,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 }
 `;
 
-exports[`rdme openapi upload > given that the API definition is a local file > given that the \`--version\` flag is not set > should default to the \`stable\` version 1`] = `
+exports[`rdme openapi upload > given that the API definition is a local file > given that the \`--branch\` flag is not set > should default to the \`stable\` version 1`] = `
 {
   "result": {
     "status": "done",
@@ -214,7 +214,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > g
 }
 `;
 
-exports[`rdme openapi upload > given that the API definition is a local file > given that the \`--version\` flag is not set > should use the version from the spec file if --\`useSpecVersion\` is passed 1`] = `
+exports[`rdme openapi upload > given that the API definition is a local file > given that the \`--branch\` flag is not set > should use the version from the spec file if --\`useSpecVersion\` is passed 1`] = `
 {
   "result": {
     "status": "done",

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -10,7 +10,7 @@ import { githubActionsEnv } from '../../helpers/git-mock.js';
 import { runCommand, type OclifOutput } from '../../helpers/oclif.js';
 
 const key = 'rdme_123';
-const version = '1.0.0';
+const branch = '1.0.0';
 const filename = '__tests__/__fixtures__/petstore-simple-weird-version.json';
 const yamlFile = '__tests__/__fixtures__/postman/petstore.collection.yaml';
 const fileUrl = 'https://example.com/openapi.json';
@@ -26,7 +26,7 @@ describe('rdme openapi upload', () => {
 
   describe('flag error handling', () => {
     it('should throw if an error if both `--branch` and `--useSpecVersion` flags are passed', async () => {
-      const result = await run(['--useSpecVersion', '--branch', version, filename, '--key', key]);
+      const result = await run(['--useSpecVersion', '--branch', branch, filename, '--key', key]);
 
       expect(result).toMatchSnapshot();
     });
@@ -35,19 +35,19 @@ describe('rdme openapi upload', () => {
   describe('given that the API definition is a local file', () => {
     it('should create a new JSON API definition in ReadMe', async () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/branches/${version}/apis`)
+        .get(`/branches/${branch}/apis`)
         .reply(200, { data: [] })
-        .post(`/branches/${version}/apis`, body =>
+        .post(`/branches/${branch}/apis`, body =>
           body.match(`form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`),
         )
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/branches/${version}/apis/${slugifiedFilename}`,
+            uri: `/branches/${branch}/apis/${slugifiedFilename}`,
           },
         });
 
-      const result = await run(['--branch', version, filename, '--key', key]);
+      const result = await run(['--branch', branch, filename, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -56,19 +56,19 @@ describe('rdme openapi upload', () => {
 
     it('should create a new JSON API definition in ReadMe with deprecated `--version` flag', async () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/branches/${version}/apis`)
+        .get(`/branches/${branch}/apis`)
         .reply(200, { data: [] })
-        .post(`/branches/${version}/apis`, body =>
+        .post(`/branches/${branch}/apis`, body =>
           body.match(`form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`),
         )
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/branches/${version}/apis/${slugifiedFilename}`,
+            uri: `/branches/${branch}/apis/${slugifiedFilename}`,
           },
         });
 
-      const result = await run(['--version', version, filename, '--key', key]);
+      const result = await run(['--version', branch, filename, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -77,19 +77,19 @@ describe('rdme openapi upload', () => {
 
     it('should create a new YAML API definition in ReadMe', async () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/branches/${version}/apis`)
+        .get(`/branches/${branch}/apis`)
         .reply(200, { data: [] })
-        .post(`/branches/${version}/apis`, body =>
+        .post(`/branches/${branch}/apis`, body =>
           body.match(`form-data; name="schema"; filename="${slugifiedYamlFile}"\r\nContent-Type: application/x-yaml`),
         )
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/branches/${version}/apis/${slugifiedYamlFile}`,
+            uri: `/branches/${branch}/apis/${slugifiedYamlFile}`,
           },
         });
 
-      const result = await run(['--branch', version, yamlFile, '--key', key]);
+      const result = await run(['--branch', branch, yamlFile, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -100,7 +100,7 @@ describe('rdme openapi upload', () => {
       prompts.inject([true]);
 
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/branches/${version}/apis`)
+        .get(`/branches/${branch}/apis`)
         .reply(200, { data: [{ filename: slugifiedFilename }] })
         .put(`/branches/1.0.0/apis/${slugifiedFilename}`, body =>
           body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
@@ -108,11 +108,11 @@ describe('rdme openapi upload', () => {
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/branches/${version}/apis/${slugifiedFilename}`,
+            uri: `/branches/${branch}/apis/${slugifiedFilename}`,
           },
         });
 
-      const result = await run(['--branch', version, filename, '--key', key]);
+      const result = await run(['--branch', branch, filename, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -121,19 +121,19 @@ describe('rdme openapi upload', () => {
 
     it('should handle upload failures', async () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/branches/${version}/apis`)
+        .get(`/branches/${branch}/apis`)
         .reply(200, { data: [] })
-        .post(`/branches/${version}/apis`, body =>
+        .post(`/branches/${branch}/apis`, body =>
           body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
         )
         .reply(200, {
           data: {
             upload: { status: 'fail' },
-            uri: `/branches/${version}/apis/${slugifiedFilename}`,
+            uri: `/branches/${branch}/apis/${slugifiedFilename}`,
           },
         });
 
-      const result = await run(['--branch', version, filename, '--key', key]);
+      const result = await run(['--branch', branch, filename, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -145,19 +145,19 @@ describe('rdme openapi upload', () => {
         const customSlug = 'custom-slug';
         const customSlugWithExtension = `${customSlug}.json`;
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/branches/${version}/apis`)
+          .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${version}/apis`, body =>
+          .post(`/branches/${branch}/apis`, body =>
             body.match(`form-data; name="schema"; filename="${customSlugWithExtension}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'done' },
-              uri: `/branches/${version}/apis/${customSlugWithExtension}`,
+              uri: `/branches/${branch}/apis/${customSlugWithExtension}`,
             },
           });
 
-        const result = await run(['--branch', version, filename, '--key', key, '--slug', customSlug]);
+        const result = await run(['--branch', branch, filename, '--key', key, '--slug', customSlug]);
 
         expect(result).toMatchSnapshot();
 
@@ -167,17 +167,17 @@ describe('rdme openapi upload', () => {
       it('should use the provided slug (includes file extension) as the filename', async () => {
         const customSlug = 'custom-slug.json';
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/branches/${version}/apis`)
+          .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${version}/apis`, body => body.match(`form-data; name="schema"; filename="${customSlug}"`))
+          .post(`/branches/${branch}/apis`, body => body.match(`form-data; name="schema"; filename="${customSlug}"`))
           .reply(200, {
             data: {
               upload: { status: 'done' },
-              uri: `/branches/${version}/apis/${customSlug}`,
+              uri: `/branches/${branch}/apis/${customSlug}`,
             },
           });
 
-        const result = await run(['--branch', version, filename, '--key', key, '--slug', customSlug]);
+        const result = await run(['--branch', branch, filename, '--key', key, '--slug', customSlug]);
 
         expect(result).toMatchSnapshot();
 
@@ -187,7 +187,7 @@ describe('rdme openapi upload', () => {
       it('should handle a slug with an invalid file extension', async () => {
         const customSlug = 'custom-slug.yikes';
 
-        const result = await run(['--branch', version, filename, '--key', key, '--slug', customSlug]);
+        const result = await run(['--branch', branch, filename, '--key', key, '--slug', customSlug]);
 
         expect(result).toMatchSnapshot();
       });
@@ -195,7 +195,7 @@ describe('rdme openapi upload', () => {
       it('should handle a slug with a valid but mismatching file extension', async () => {
         const customSlug = 'custom-slug.yml';
 
-        const result = await run(['--branch', version, filename, '--key', key, '--slug', customSlug]);
+        const result = await run(['--branch', branch, filename, '--key', key, '--slug', customSlug]);
 
         expect(result).toMatchSnapshot();
       });
@@ -204,34 +204,34 @@ describe('rdme openapi upload', () => {
     describe('and the upload status initially is a pending state', () => {
       it('should poll the API until the upload is complete', async () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/branches/${version}/apis`)
+          .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${version}/apis`, body =>
+          .post(`/branches/${branch}/apis`, body =>
             body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'pending' },
-              uri: `/branches/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
             },
           })
-          .get(`/branches/${version}/apis/${slugifiedFilename}`)
+          .get(`/branches/${branch}/apis/${slugifiedFilename}`)
           .times(9)
           .reply(200, {
             data: {
               upload: { status: 'pending' },
-              uri: `/branches/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
             },
           })
-          .get(`/branches/${version}/apis/${slugifiedFilename}`)
+          .get(`/branches/${branch}/apis/${slugifiedFilename}`)
           .reply(200, {
             data: {
               upload: { status: 'done' },
-              uri: `/branches/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
             },
           });
 
-        const result = await run(['--branch', version, filename, '--key', key]);
+        const result = await run(['--branch', branch, filename, '--key', key]);
 
         expect(result).toMatchSnapshot();
 
@@ -240,27 +240,27 @@ describe('rdme openapi upload', () => {
 
       it('should poll the API and handle timeouts', async () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/branches/${version}/apis`)
+          .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${version}/apis`, body =>
+          .post(`/branches/${branch}/apis`, body =>
             body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'pending' },
-              uri: `/branches/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
             },
           })
-          .get(`/branches/${version}/apis/${slugifiedFilename}`)
+          .get(`/branches/${branch}/apis/${slugifiedFilename}`)
           .times(10)
           .reply(200, {
             data: {
               upload: { status: 'pending' },
-              uri: `/branches/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
             },
           });
 
-        const result = await run(['--branch', version, filename, '--key', key]);
+        const result = await run(['--branch', branch, filename, '--key', key]);
 
         expect(result).toMatchSnapshot();
 
@@ -269,21 +269,21 @@ describe('rdme openapi upload', () => {
 
       it('should poll the API once and handle a failure state with a 4xx', async () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/branches/${version}/apis`)
+          .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${version}/apis`, body =>
+          .post(`/branches/${branch}/apis`, body =>
             body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'pending' },
-              uri: `/branches/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
             },
           })
-          .get(`/branches/${version}/apis/${slugifiedFilename}`)
+          .get(`/branches/${branch}/apis/${slugifiedFilename}`)
           .reply(400);
 
-        const result = await run(['--branch', version, filename, '--key', key]);
+        const result = await run(['--branch', branch, filename, '--key', key]);
 
         expect(result).toMatchSnapshot();
 
@@ -292,26 +292,26 @@ describe('rdme openapi upload', () => {
 
       it('should poll the API once and handle an unexpected state with a 2xx', async () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/branches/${version}/apis`)
+          .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${version}/apis`, body =>
+          .post(`/branches/${branch}/apis`, body =>
             body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'pending' },
-              uri: `/branches/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
             },
           })
-          .get(`/branches/${version}/apis/${slugifiedFilename}`)
+          .get(`/branches/${branch}/apis/${slugifiedFilename}`)
           .reply(200, {
             data: {
               upload: { status: 'something-unexpected' },
-              uri: `/branches/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
             },
           });
 
-        const result = await run(['--branch', version, filename, '--key', key]);
+        const result = await run(['--branch', branch, filename, '--key', key]);
 
         expect(result).toMatchSnapshot();
 
@@ -326,7 +326,7 @@ describe('rdme openapi upload', () => {
 
       it('should overwrite an existing API definition without asking for confirmation', async () => {
         const mock = getAPIv2MockForGHA({ authorization: `Bearer ${key}` })
-          .get(`/branches/${version}/apis`)
+          .get(`/branches/${branch}/apis`)
           .reply(200, { data: [{ filename: slugifiedFilename }] })
           .put(`/branches/1.0.0/apis/${slugifiedFilename}`, body =>
             body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
@@ -334,11 +334,11 @@ describe('rdme openapi upload', () => {
           .reply(200, {
             data: {
               upload: { status: 'done' },
-              uri: `/branches/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
             },
           });
 
-        const result = await run(['--branch', version, filename, '--key', key]);
+        const result = await run(['--branch', branch, filename, '--key', key]);
 
         expect(result).toMatchSnapshot();
 
@@ -397,17 +397,17 @@ describe('rdme openapi upload', () => {
       const fileMock = nock('https://example.com').get('/openapi.json').reply(200, petstore);
 
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/branches/${version}/apis`)
+        .get(`/branches/${branch}/apis`)
         .reply(200, {})
-        .post(`/branches/${version}/apis`, body => body.match(`form-data; name="url"\r\n\r\n${fileUrl}`))
+        .post(`/branches/${branch}/apis`, body => body.match(`form-data; name="url"\r\n\r\n${fileUrl}`))
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/branches/${version}/apis/openapi.json`,
+            uri: `/branches/${branch}/apis/openapi.json`,
           },
         });
 
-      const result = await run(['--branch', version, fileUrl, '--key', key]);
+      const result = await run(['--branch', branch, fileUrl, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -421,17 +421,17 @@ describe('rdme openapi upload', () => {
       const fileMock = nock('https://example.com').get('/openapi.json').reply(200, petstore);
 
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/branches/${version}/apis`)
+        .get(`/branches/${branch}/apis`)
         .reply(200, { data: [{ filename: 'openapi.json' }] })
         .put('/branches/1.0.0/apis/openapi.json', body => body.match(`form-data; name="url"\r\n\r\n${fileUrl}`))
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/branches/${version}/apis/openapi.json`,
+            uri: `/branches/${branch}/apis/openapi.json`,
           },
         });
 
-      const result = await run(['--branch', version, fileUrl, '--key', key]);
+      const result = await run(['--branch', branch, fileUrl, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -442,7 +442,7 @@ describe('rdme openapi upload', () => {
     it('should handle issues fetching from the URL', async () => {
       const fileMock = nock('https://example.com').get('/openapi.json').reply(400, {});
 
-      const result = await run(['--branch', version, fileUrl, '--key', key]);
+      const result = await run(['--branch', branch, fileUrl, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -453,19 +453,19 @@ describe('rdme openapi upload', () => {
   describe('given that the confirm overwrite flag is passed', () => {
     it('should overwrite an existing API definition without asking for confirmation', async () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/branches/${version}/apis`)
+        .get(`/branches/${branch}/apis`)
         .reply(200, { data: [{ filename: slugifiedFilename }] })
-        .put(`/branches/${version}/apis/${slugifiedFilename}`, body =>
+        .put(`/branches/${branch}/apis/${slugifiedFilename}`, body =>
           body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
         )
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/branches/${version}/apis/${slugifiedFilename}`,
+            uri: `/branches/${branch}/apis/${slugifiedFilename}`,
           },
         });
 
-      const result = await run(['--branch', version, filename, '--key', key, '--confirm-overwrite']);
+      const result = await run(['--branch', branch, filename, '--key', key, '--confirm-overwrite']);
 
       expect(result.stdout).toContain('was successfully updated in ReadMe!');
 

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -25,8 +25,8 @@ describe('rdme openapi upload', () => {
   });
 
   describe('flag error handling', () => {
-    it('should throw if an error if both `--version` and `--useSpecVersion` flags are passed', async () => {
-      const result = await run(['--useSpecVersion', '--version', version, filename, '--key', key]);
+    it('should throw if an error if both `--branch` and `--useSpecVersion` flags are passed', async () => {
+      const result = await run(['--useSpecVersion', '--branch', version, filename, '--key', key]);
 
       expect(result).toMatchSnapshot();
     });
@@ -47,7 +47,7 @@ describe('rdme openapi upload', () => {
           },
         });
 
-      const result = await run(['--version', version, filename, '--key', key]);
+      const result = await run(['--branch', version, filename, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -68,7 +68,7 @@ describe('rdme openapi upload', () => {
           },
         });
 
-      const result = await run(['--version', version, yamlFile, '--key', key]);
+      const result = await run(['--branch', version, yamlFile, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -91,7 +91,7 @@ describe('rdme openapi upload', () => {
           },
         });
 
-      const result = await run(['--version', version, filename, '--key', key]);
+      const result = await run(['--branch', version, filename, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -112,7 +112,7 @@ describe('rdme openapi upload', () => {
           },
         });
 
-      const result = await run(['--version', version, filename, '--key', key]);
+      const result = await run(['--branch', version, filename, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -136,7 +136,7 @@ describe('rdme openapi upload', () => {
             },
           });
 
-        const result = await run(['--version', version, filename, '--key', key, '--slug', customSlug]);
+        const result = await run(['--branch', version, filename, '--key', key, '--slug', customSlug]);
 
         expect(result).toMatchSnapshot();
 
@@ -156,7 +156,7 @@ describe('rdme openapi upload', () => {
             },
           });
 
-        const result = await run(['--version', version, filename, '--key', key, '--slug', customSlug]);
+        const result = await run(['--branch', version, filename, '--key', key, '--slug', customSlug]);
 
         expect(result).toMatchSnapshot();
 
@@ -166,7 +166,7 @@ describe('rdme openapi upload', () => {
       it('should handle a slug with an invalid file extension', async () => {
         const customSlug = 'custom-slug.yikes';
 
-        const result = await run(['--version', version, filename, '--key', key, '--slug', customSlug]);
+        const result = await run(['--branch', version, filename, '--key', key, '--slug', customSlug]);
 
         expect(result).toMatchSnapshot();
       });
@@ -174,7 +174,7 @@ describe('rdme openapi upload', () => {
       it('should handle a slug with a valid but mismatching file extension', async () => {
         const customSlug = 'custom-slug.yml';
 
-        const result = await run(['--version', version, filename, '--key', key, '--slug', customSlug]);
+        const result = await run(['--branch', version, filename, '--key', key, '--slug', customSlug]);
 
         expect(result).toMatchSnapshot();
       });
@@ -210,7 +210,7 @@ describe('rdme openapi upload', () => {
             },
           });
 
-        const result = await run(['--version', version, filename, '--key', key]);
+        const result = await run(['--branch', version, filename, '--key', key]);
 
         expect(result).toMatchSnapshot();
 
@@ -239,7 +239,7 @@ describe('rdme openapi upload', () => {
             },
           });
 
-        const result = await run(['--version', version, filename, '--key', key]);
+        const result = await run(['--branch', version, filename, '--key', key]);
 
         expect(result).toMatchSnapshot();
 
@@ -262,7 +262,7 @@ describe('rdme openapi upload', () => {
           .get(`/branches/${version}/apis/${slugifiedFilename}`)
           .reply(400);
 
-        const result = await run(['--version', version, filename, '--key', key]);
+        const result = await run(['--branch', version, filename, '--key', key]);
 
         expect(result).toMatchSnapshot();
 
@@ -290,7 +290,7 @@ describe('rdme openapi upload', () => {
             },
           });
 
-        const result = await run(['--version', version, filename, '--key', key]);
+        const result = await run(['--branch', version, filename, '--key', key]);
 
         expect(result).toMatchSnapshot();
 
@@ -317,7 +317,7 @@ describe('rdme openapi upload', () => {
             },
           });
 
-        const result = await run(['--version', version, filename, '--key', key]);
+        const result = await run(['--branch', version, filename, '--key', key]);
 
         expect(result).toMatchSnapshot();
 
@@ -325,7 +325,7 @@ describe('rdme openapi upload', () => {
       });
     });
 
-    describe('given that the `--version` flag is not set', () => {
+    describe('given that the `--branch` flag is not set', () => {
       it('should default to the `stable` version', async () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get('/branches/stable/apis')
@@ -386,7 +386,7 @@ describe('rdme openapi upload', () => {
           },
         });
 
-      const result = await run(['--version', version, fileUrl, '--key', key]);
+      const result = await run(['--branch', version, fileUrl, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -410,7 +410,7 @@ describe('rdme openapi upload', () => {
           },
         });
 
-      const result = await run(['--version', version, fileUrl, '--key', key]);
+      const result = await run(['--branch', version, fileUrl, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -421,7 +421,7 @@ describe('rdme openapi upload', () => {
     it('should handle issues fetching from the URL', async () => {
       const fileMock = nock('https://example.com').get('/openapi.json').reply(400, {});
 
-      const result = await run(['--version', version, fileUrl, '--key', key]);
+      const result = await run(['--branch', version, fileUrl, '--key', key]);
 
       expect(result).toMatchSnapshot();
 
@@ -444,7 +444,7 @@ describe('rdme openapi upload', () => {
           },
         });
 
-      const result = await run(['--version', version, filename, '--key', key, '--confirm-overwrite']);
+      const result = await run(['--branch', version, filename, '--key', key, '--confirm-overwrite']);
 
       expect(result.stdout).toContain('was successfully updated in ReadMe!');
 

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -35,15 +35,15 @@ describe('rdme openapi upload', () => {
   describe('given that the API definition is a local file', () => {
     it('should create a new JSON API definition in ReadMe', async () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/versions/${version}/apis`)
+        .get(`/branches/${version}/apis`)
         .reply(200, { data: [] })
-        .post(`/versions/${version}/apis`, body =>
+        .post(`/branches/${version}/apis`, body =>
           body.match(`form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`),
         )
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/versions/${version}/apis/${slugifiedFilename}`,
+            uri: `/branches/${version}/apis/${slugifiedFilename}`,
           },
         });
 
@@ -56,15 +56,15 @@ describe('rdme openapi upload', () => {
 
     it('should create a new YAML API definition in ReadMe', async () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/versions/${version}/apis`)
+        .get(`/branches/${version}/apis`)
         .reply(200, { data: [] })
-        .post(`/versions/${version}/apis`, body =>
+        .post(`/branches/${version}/apis`, body =>
           body.match(`form-data; name="schema"; filename="${slugifiedYamlFile}"\r\nContent-Type: application/x-yaml`),
         )
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/versions/${version}/apis/${slugifiedYamlFile}`,
+            uri: `/branches/${version}/apis/${slugifiedYamlFile}`,
           },
         });
 
@@ -79,15 +79,15 @@ describe('rdme openapi upload', () => {
       prompts.inject([true]);
 
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/versions/${version}/apis`)
+        .get(`/branches/${version}/apis`)
         .reply(200, { data: [{ filename: slugifiedFilename }] })
-        .put(`/versions/1.0.0/apis/${slugifiedFilename}`, body =>
+        .put(`/branches/1.0.0/apis/${slugifiedFilename}`, body =>
           body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
         )
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/versions/${version}/apis/${slugifiedFilename}`,
+            uri: `/branches/${version}/apis/${slugifiedFilename}`,
           },
         });
 
@@ -100,15 +100,15 @@ describe('rdme openapi upload', () => {
 
     it('should handle upload failures', async () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/versions/${version}/apis`)
+        .get(`/branches/${version}/apis`)
         .reply(200, { data: [] })
-        .post(`/versions/${version}/apis`, body =>
+        .post(`/branches/${version}/apis`, body =>
           body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
         )
         .reply(200, {
           data: {
             upload: { status: 'fail' },
-            uri: `/versions/${version}/apis/${slugifiedFilename}`,
+            uri: `/branches/${version}/apis/${slugifiedFilename}`,
           },
         });
 
@@ -124,15 +124,15 @@ describe('rdme openapi upload', () => {
         const customSlug = 'custom-slug';
         const customSlugWithExtension = `${customSlug}.json`;
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/versions/${version}/apis`)
+          .get(`/branches/${version}/apis`)
           .reply(200, { data: [] })
-          .post(`/versions/${version}/apis`, body =>
+          .post(`/branches/${version}/apis`, body =>
             body.match(`form-data; name="schema"; filename="${customSlugWithExtension}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'done' },
-              uri: `/versions/${version}/apis/${customSlugWithExtension}`,
+              uri: `/branches/${version}/apis/${customSlugWithExtension}`,
             },
           });
 
@@ -146,13 +146,13 @@ describe('rdme openapi upload', () => {
       it('should use the provided slug (includes file extension) as the filename', async () => {
         const customSlug = 'custom-slug.json';
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/versions/${version}/apis`)
+          .get(`/branches/${version}/apis`)
           .reply(200, { data: [] })
-          .post(`/versions/${version}/apis`, body => body.match(`form-data; name="schema"; filename="${customSlug}"`))
+          .post(`/branches/${version}/apis`, body => body.match(`form-data; name="schema"; filename="${customSlug}"`))
           .reply(200, {
             data: {
               upload: { status: 'done' },
-              uri: `/versions/${version}/apis/${customSlug}`,
+              uri: `/branches/${version}/apis/${customSlug}`,
             },
           });
 
@@ -183,30 +183,30 @@ describe('rdme openapi upload', () => {
     describe('and the upload status initially is a pending state', () => {
       it('should poll the API until the upload is complete', async () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/versions/${version}/apis`)
+          .get(`/branches/${version}/apis`)
           .reply(200, { data: [] })
-          .post(`/versions/${version}/apis`, body =>
+          .post(`/branches/${version}/apis`, body =>
             body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'pending' },
-              uri: `/versions/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${version}/apis/${slugifiedFilename}`,
             },
           })
-          .get(`/versions/${version}/apis/${slugifiedFilename}`)
+          .get(`/branches/${version}/apis/${slugifiedFilename}`)
           .times(9)
           .reply(200, {
             data: {
               upload: { status: 'pending' },
-              uri: `/versions/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${version}/apis/${slugifiedFilename}`,
             },
           })
-          .get(`/versions/${version}/apis/${slugifiedFilename}`)
+          .get(`/branches/${version}/apis/${slugifiedFilename}`)
           .reply(200, {
             data: {
               upload: { status: 'done' },
-              uri: `/versions/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${version}/apis/${slugifiedFilename}`,
             },
           });
 
@@ -219,23 +219,23 @@ describe('rdme openapi upload', () => {
 
       it('should poll the API and handle timeouts', async () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/versions/${version}/apis`)
+          .get(`/branches/${version}/apis`)
           .reply(200, { data: [] })
-          .post(`/versions/${version}/apis`, body =>
+          .post(`/branches/${version}/apis`, body =>
             body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'pending' },
-              uri: `/versions/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${version}/apis/${slugifiedFilename}`,
             },
           })
-          .get(`/versions/${version}/apis/${slugifiedFilename}`)
+          .get(`/branches/${version}/apis/${slugifiedFilename}`)
           .times(10)
           .reply(200, {
             data: {
               upload: { status: 'pending' },
-              uri: `/versions/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${version}/apis/${slugifiedFilename}`,
             },
           });
 
@@ -248,18 +248,18 @@ describe('rdme openapi upload', () => {
 
       it('should poll the API once and handle a failure state with a 4xx', async () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/versions/${version}/apis`)
+          .get(`/branches/${version}/apis`)
           .reply(200, { data: [] })
-          .post(`/versions/${version}/apis`, body =>
+          .post(`/branches/${version}/apis`, body =>
             body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'pending' },
-              uri: `/versions/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${version}/apis/${slugifiedFilename}`,
             },
           })
-          .get(`/versions/${version}/apis/${slugifiedFilename}`)
+          .get(`/branches/${version}/apis/${slugifiedFilename}`)
           .reply(400);
 
         const result = await run(['--version', version, filename, '--key', key]);
@@ -271,22 +271,22 @@ describe('rdme openapi upload', () => {
 
       it('should poll the API once and handle an unexpected state with a 2xx', async () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/versions/${version}/apis`)
+          .get(`/branches/${version}/apis`)
           .reply(200, { data: [] })
-          .post(`/versions/${version}/apis`, body =>
+          .post(`/branches/${version}/apis`, body =>
             body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'pending' },
-              uri: `/versions/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${version}/apis/${slugifiedFilename}`,
             },
           })
-          .get(`/versions/${version}/apis/${slugifiedFilename}`)
+          .get(`/branches/${version}/apis/${slugifiedFilename}`)
           .reply(200, {
             data: {
               upload: { status: 'something-unexpected' },
-              uri: `/versions/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${version}/apis/${slugifiedFilename}`,
             },
           });
 
@@ -305,15 +305,15 @@ describe('rdme openapi upload', () => {
 
       it('should overwrite an existing API definition without asking for confirmation', async () => {
         const mock = getAPIv2MockForGHA({ authorization: `Bearer ${key}` })
-          .get(`/versions/${version}/apis`)
+          .get(`/branches/${version}/apis`)
           .reply(200, { data: [{ filename: slugifiedFilename }] })
-          .put(`/versions/1.0.0/apis/${slugifiedFilename}`, body =>
+          .put(`/branches/1.0.0/apis/${slugifiedFilename}`, body =>
             body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'done' },
-              uri: `/versions/${version}/apis/${slugifiedFilename}`,
+              uri: `/branches/${version}/apis/${slugifiedFilename}`,
             },
           });
 
@@ -328,15 +328,15 @@ describe('rdme openapi upload', () => {
     describe('given that the `--version` flag is not set', () => {
       it('should default to the `stable` version', async () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get('/versions/stable/apis')
+          .get('/branches/stable/apis')
           .reply(200, { data: [] })
-          .post('/versions/stable/apis', body =>
+          .post('/branches/stable/apis', body =>
             body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'done' },
-              uri: `/versions/stable/apis/${slugifiedFilename}`,
+              uri: `/branches/stable/apis/${slugifiedFilename}`,
             },
           });
 
@@ -350,15 +350,15 @@ describe('rdme openapi upload', () => {
       it('should use the version from the spec file if --`useSpecVersion` is passed', async () => {
         const altVersion = '1.2.3';
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-          .get(`/versions/${altVersion}/apis`)
+          .get(`/branches/${altVersion}/apis`)
           .reply(200, { data: [] })
-          .post(`/versions/${altVersion}/apis`, body =>
+          .post(`/branches/${altVersion}/apis`, body =>
             body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
           )
           .reply(200, {
             data: {
               upload: { status: 'done' },
-              uri: `/versions/${altVersion}/apis/${slugifiedFilename}`,
+              uri: `/branches/${altVersion}/apis/${slugifiedFilename}`,
             },
           });
 
@@ -376,13 +376,13 @@ describe('rdme openapi upload', () => {
       const fileMock = nock('https://example.com').get('/openapi.json').reply(200, petstore);
 
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/versions/${version}/apis`)
+        .get(`/branches/${version}/apis`)
         .reply(200, {})
-        .post(`/versions/${version}/apis`, body => body.match(`form-data; name="url"\r\n\r\n${fileUrl}`))
+        .post(`/branches/${version}/apis`, body => body.match(`form-data; name="url"\r\n\r\n${fileUrl}`))
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/versions/${version}/apis/openapi.json`,
+            uri: `/branches/${version}/apis/openapi.json`,
           },
         });
 
@@ -400,13 +400,13 @@ describe('rdme openapi upload', () => {
       const fileMock = nock('https://example.com').get('/openapi.json').reply(200, petstore);
 
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/versions/${version}/apis`)
+        .get(`/branches/${version}/apis`)
         .reply(200, { data: [{ filename: 'openapi.json' }] })
-        .put('/versions/1.0.0/apis/openapi.json', body => body.match(`form-data; name="url"\r\n\r\n${fileUrl}`))
+        .put('/branches/1.0.0/apis/openapi.json', body => body.match(`form-data; name="url"\r\n\r\n${fileUrl}`))
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/versions/${version}/apis/openapi.json`,
+            uri: `/branches/${version}/apis/openapi.json`,
           },
         });
 
@@ -432,15 +432,15 @@ describe('rdme openapi upload', () => {
   describe('given that the confirm overwrite flag is passed', () => {
     it('should overwrite an existing API definition without asking for confirmation', async () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .get(`/versions/${version}/apis`)
+        .get(`/branches/${version}/apis`)
         .reply(200, { data: [{ filename: slugifiedFilename }] })
-        .put(`/versions/${version}/apis/${slugifiedFilename}`, body =>
+        .put(`/branches/${version}/apis/${slugifiedFilename}`, body =>
           body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
         )
         .reply(200, {
           data: {
             upload: { status: 'done' },
-            uri: `/versions/${version}/apis/${slugifiedFilename}`,
+            uri: `/branches/${version}/apis/${slugifiedFilename}`,
           },
         });
 

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -54,6 +54,27 @@ describe('rdme openapi upload', () => {
       mock.done();
     });
 
+    it('should create a new JSON API definition in ReadMe with deprecated `--version` flag', async () => {
+      const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
+        .get(`/branches/${version}/apis`)
+        .reply(200, { data: [] })
+        .post(`/branches/${version}/apis`, body =>
+          body.match(`form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`),
+        )
+        .reply(200, {
+          data: {
+            upload: { status: 'done' },
+            uri: `/branches/${version}/apis/${slugifiedFilename}`,
+          },
+        });
+
+      const result = await run(['--version', version, filename, '--key', key]);
+
+      expect(result).toMatchSnapshot();
+
+      mock.done();
+    });
+
     it('should create a new YAML API definition in ReadMe', async () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${version}/apis`)

--- a/__tests__/lib/frontmatter.test.ts
+++ b/__tests__/lib/frontmatter.test.ts
@@ -40,7 +40,7 @@ describe('#fix', () => {
   it('should do nothing for valid frontmatter', () => {
     const data = {
       title: 'Hello, world!',
-      category: { uri: '/versions/stable/categories/guides/sup' },
+      category: { uri: '/branches/stable/categories/guides/sup' },
     };
 
     const result = fix.call(command, data, schema, emptyMappings);

--- a/documentation/commands/docs.md
+++ b/documentation/commands/docs.md
@@ -19,19 +19,20 @@ Upload Markdown files to the Guides section of your ReadMe project.
 
 ```
 USAGE
-  $ rdme docs upload PATH --key <value> [--github] [--dry-run] [--version <value>]
+  $ rdme docs upload PATH --key <value> [--branch <value>] [--dry-run]
 
 ARGUMENTS
   PATH  Path to a local Markdown file or folder of Markdown files.
 
 FLAGS
-  --dry-run          Runs the command without creating nor updating any Guides in ReadMe. Useful for debugging.
-  --github           Create a new GitHub Actions workflow for this command.
-  --key=<value>      (required) ReadMe project API key
-  --version=<value>  [default: stable] ReadMe project version
+  --key=<value>     (required) ReadMe project API key
+  --branch=<value>  [default: stable] ReadMe project version
+  --dry-run         Runs the command without creating nor updating any Guides in ReadMe. Useful for debugging.
 
 DESCRIPTION
   Upload Markdown files to the Guides section of your ReadMe project.
+
+  NOTE: This command is in an experimental alpha and is likely to change. Use at your own risk!
 
   The path can either be a directory or a single Markdown file. The Markdown files will require YAML frontmatter with
   certain ReadMe documentation attributes. Check out our docs for more info on setting up your frontmatter:
@@ -40,13 +41,13 @@ DESCRIPTION
 EXAMPLES
   The path input can be a directory. This will also upload any Markdown files that are located in subdirectories:
 
-    $ rdme docs upload documentation/ --version={project-version}
+    $ rdme docs upload documentation/ --branch={project-branch}
 
   The path input can also be individual Markdown files:
 
-    $ rdme docs upload documentation/about.md --version={project-version}
+    $ rdme docs upload documentation/about.md --branch={project-branch}
 
-  You can omit the `--version` flag to default to the `stable` version of your project:
+  You can omit the `--branch` flag to default to the `stable` branch of your project:
 
     $ rdme docs upload [path]
 
@@ -61,7 +62,7 @@ FLAG DESCRIPTIONS
     An API key for your ReadMe project. Note that API authentication is required despite being omitted from the example
     usage. See our docs for more information: https://github.com/readmeio/rdme/tree/v10#authentication
 
-  --version=<value>  ReadMe project version
+  --branch=<value>  ReadMe project version
 
     Defaults to `stable` (i.e., your main project version).
 ```

--- a/documentation/commands/openapi.md
+++ b/documentation/commands/openapi.md
@@ -140,17 +140,17 @@ Upload (or re-upload) your API definition to ReadMe.
 
 ```
 USAGE
-  $ rdme openapi upload [SPEC] --key <value> [--slug <value>] [--useSpecVersion | --version <value>]
+  $ rdme openapi upload [SPEC] --key <value> [--slug <value>] [--useSpecVersion | --branch <value>]
 
 ARGUMENTS
   SPEC  A path to your API definition — either a local file path or a URL. If your working directory and all
         subdirectories contain a single OpenAPI file, you can omit the path.
 
 FLAGS
-  --key=<value>      (required) ReadMe project API key
-  --slug=<value>     Override the slug (i.e., the unique identifier) for your API definition.
-  --useSpecVersion   Use the OpenAPI `info.version` field for your ReadMe project version
-  --version=<value>  [default: stable] ReadMe project version
+  --key=<value>     (required) ReadMe project API key
+  --branch=<value>  [default: stable] ReadMe project version
+  --slug=<value>    Override the slug (i.e., the unique identifier) for your API definition.
+  --useSpecVersion  Use the OpenAPI `info.version` field for your ReadMe project version
 
 DESCRIPTION
   Upload (or re-upload) your API definition to ReadMe.
@@ -169,16 +169,16 @@ DESCRIPTION
 EXAMPLES
   You can pass in a file name like so:
 
-    $ rdme openapi upload --version=1.0.0 openapi.json
+    $ rdme openapi upload --branch=1.0.0 openapi.json
 
   You can also pass in a file in a subdirectory (we recommend always running the CLI from the root of your
   repository):
 
-    $ rdme openapi upload --version=v1.0.0 example-directory/petstore.json
+    $ rdme openapi upload --branch=v1.0.0 example-directory/petstore.json
 
   You can also pass in a URL:
 
-    $ rdme openapi upload --version=1.0.0 https://example.com/openapi.json
+    $ rdme openapi upload --branch=1.0.0 https://example.com/openapi.json
 
   If you specify your ReadMe project version in the `info.version` field in your OpenAPI definition, you can use that:
 
@@ -189,6 +189,10 @@ FLAG DESCRIPTIONS
 
     An API key for your ReadMe project. Note that API authentication is required despite being omitted from the example
     usage. See our docs for more information: https://github.com/readmeio/rdme/tree/v10#authentication
+
+  --branch=<value>  ReadMe project version
+
+    Defaults to `stable` (i.e., your main project version). This flag is mutually exclusive with `--useSpecVersion`.
 
   --slug=<value>  Override the slug (i.e., the unique identifier) for your API definition.
 
@@ -201,11 +205,7 @@ FLAG DESCRIPTIONS
   --useSpecVersion  Use the OpenAPI `info.version` field for your ReadMe project version
 
     If included, use the version specified in the `info.version` field in your OpenAPI definition for your ReadMe
-    project version. This flag is mutually exclusive with `--version`.
-
-  --version=<value>  ReadMe project version
-
-    Defaults to `stable` (i.e., your main project version). This flag is mutually exclusive with `--useSpecVersion`.
+    project version. This flag is mutually exclusive with `--branch`.
 ```
 
 ## `rdme openapi validate [SPEC]`

--- a/src/commands/docs/upload.ts
+++ b/src/commands/docs/upload.ts
@@ -1,7 +1,7 @@
 import { Args, Flags } from '@oclif/core';
 
 import BaseCommand from '../../lib/baseCommand.js';
-import { confirmAutofixesFlag, keyFlag } from '../../lib/flags.js';
+import { branchFlag, confirmAutofixesFlag, keyFlag } from '../../lib/flags.js';
 import syncPagePath, {
   type FailedPushResult,
   type SkippedPushResult,
@@ -31,14 +31,14 @@ export default class DocsUploadCommand extends BaseCommand<typeof DocsUploadComm
     {
       description:
         'The path input can be a directory. This will also upload any Markdown files that are located in subdirectories:',
-      command: '<%= config.bin %> <%= command.id %> documentation/ --version={project-version}',
+      command: '<%= config.bin %> <%= command.id %> documentation/ --branch={project-branch}',
     },
     {
       description: 'The path input can also be individual Markdown files:',
-      command: '<%= config.bin %> <%= command.id %> documentation/about.md --version={project-version}',
+      command: '<%= config.bin %> <%= command.id %> documentation/about.md --branch={project-branch}',
     },
     {
-      description: 'You can omit the `--version` flag to default to the `stable` version of your project:',
+      description: 'You can omit the `--branch` flag to default to the `stable` branch of your project:',
       command: '<%= config.bin %> <%= command.id %> [path]',
     },
     {
@@ -50,6 +50,7 @@ export default class DocsUploadCommand extends BaseCommand<typeof DocsUploadComm
 
   static flags = {
     key: keyFlag,
+    ...branchFlag(),
     'confirm-autofixes': confirmAutofixesFlag,
     'dry-run': Flags.boolean({
       description: 'Runs the command without creating nor updating any Guides in ReadMe. Useful for debugging.',
@@ -71,11 +72,6 @@ export default class DocsUploadCommand extends BaseCommand<typeof DocsUploadComm
       description:
         'Skips the pre-upload validation of the Markdown files. This flag can be a useful escape hatch but its usage is not recommended.',
       hidden: true,
-    }),
-    version: Flags.string({
-      summary: 'ReadMe project version',
-      description: 'Defaults to `stable` (i.e., your main project version).',
-      default: 'stable',
     }),
   };
 

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -9,7 +9,7 @@ import slugify from 'slugify';
 import { file as tmpFile } from 'tmp-promise';
 
 import BaseCommand from '../../lib/baseCommand.js';
-import { keyFlag, specArg } from '../../lib/flags.js';
+import { branchFlag, keyFlag, specArg } from '../../lib/flags.js';
 import isCI, { isTest } from '../../lib/isCI.js';
 import { oraOptions } from '../../lib/logger.js';
 import prepareOas from '../../lib/prepareOas.js';
@@ -30,6 +30,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
 
   static flags = {
     key: keyFlag,
+    ...branchFlag(['This flag is mutually exclusive with `--useSpecVersion`.']),
     'confirm-overwrite': Flags.boolean({
       description:
         'If set, file overwrites will be made without a confirmation prompt. This flag can be a useful in automated environments where prompts cannot be responded to.',
@@ -45,30 +46,24 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     useSpecVersion: Flags.boolean({
       summary: 'Use the OpenAPI `info.version` field for your ReadMe project version',
       description:
-        'If included, use the version specified in the `info.version` field in your OpenAPI definition for your ReadMe project version. This flag is mutually exclusive with `--version`.',
-      exclusive: ['version'],
-    }),
-    version: Flags.string({
-      summary: 'ReadMe project version',
-      description:
-        'Defaults to `stable` (i.e., your main project version). This flag is mutually exclusive with `--useSpecVersion`.',
-      default: 'stable',
+        'If included, use the version specified in the `info.version` field in your OpenAPI definition for your ReadMe project version. This flag is mutually exclusive with `--branch`.',
+      exclusive: ['branch'],
     }),
   };
 
   static examples = [
     {
       description: 'You can pass in a file name like so:',
-      command: '<%= config.bin %> <%= command.id %> --version=1.0.0 openapi.json',
+      command: '<%= config.bin %> <%= command.id %> --branch=1.0.0 openapi.json',
     },
     {
       description:
         'You can also pass in a file in a subdirectory (we recommend always running the CLI from the root of your repository):',
-      command: '<%= config.bin %> <%= command.id %> --version=v1.0.0 example-directory/petstore.json',
+      command: '<%= config.bin %> <%= command.id %> --branch=v1.0.0 example-directory/petstore.json',
     },
     {
       description: 'You can also pass in a URL:',
-      command: '<%= config.bin %> <%= command.id %> --version=1.0.0 https://example.com/openapi.json',
+      command: '<%= config.bin %> <%= command.id %> --branch=1.0.0 https://example.com/openapi.json',
     },
     {
       description:
@@ -109,7 +104,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
 
     const { preparedSpec, specFileType, specPath, specVersion } = await prepareOas(spec, 'openapi upload');
 
-    const version = this.flags.useSpecVersion ? specVersion : this.flags.version;
+    const branch = this.flags.useSpecVersion ? specVersion : this.flags.branch;
 
     const specFileTypeIsUrl = specFileType === 'url';
 
@@ -136,7 +131,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
 
     const headers = new Headers({ authorization: `Bearer ${this.flags.key}` });
 
-    const existingAPIDefinitions = await this.readmeAPIFetch(`/branches/${version}/apis`, { headers }).then(res =>
+    const existingAPIDefinitions = await this.readmeAPIFetch(`/branches/${branch}/apis`, { headers }).then(res =>
       this.handleAPIRes(res),
     );
 
@@ -200,7 +195,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     );
 
     const response = await this.readmeAPIFetch(
-      `/branches/${version}/apis${method === 'POST' ? '' : `/${filename}`}`,
+      `/branches/${branch}/apis${method === 'POST' ? '' : `/${filename}`}`,
       options,
     )
       .then(res => this.handleAPIRes(res))

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -136,7 +136,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
 
     const headers = new Headers({ authorization: `Bearer ${this.flags.key}` });
 
-    const existingAPIDefinitions = await this.readmeAPIFetch(`/versions/${version}/apis`, { headers }).then(res =>
+    const existingAPIDefinitions = await this.readmeAPIFetch(`/branches/${version}/apis`, { headers }).then(res =>
       this.handleAPIRes(res),
     );
 
@@ -200,7 +200,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     );
 
     const response = await this.readmeAPIFetch(
-      `/versions/${version}/apis${method === 'POST' ? '' : `/${filename}`}`,
+      `/branches/${version}/apis${method === 'POST' ? '' : `/${filename}`}`,
       options,
     )
       .then(res => this.handleAPIRes(res))

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,3 +54,23 @@ export type CommandIdForTopic<
   T extends 'openapi',
   U extends keyof typeof COMMANDS = keyof typeof COMMANDS,
 > = U extends `${T}:${infer Suffix}` ? `${Suffix}` : never;
+
+/**
+ * Commands that leverage the APIv2 representations for uploading pages
+ * (e.g., Guides, API Reference, etc.).
+ *
+ * Right now this is only the `docs upload` command, but in the future, we'll be adding
+ * support for the API Reference and other page types.
+ *
+ * Note that the `changelogs` command is not included here
+ * because it is backed by APIv1.
+ */
+export type APIv2PageUploadCommands = DocsUploadCommand;
+
+/**
+ * Commands that leverage the APIv2 representations for interfacing with pages
+ * (e.g., Guides, API Reference, etc.).
+ *
+ * These commands can do more than just upload pages, but they are all backed by the APIv2 representations.
+ */
+export type APIv2PageCommands = APIv2PageUploadCommands | DocsMigrateCommand;

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,5 +1,15 @@
 import { Args, Flags } from '@oclif/core';
 
+export const branchFlag = (additionalDescription: string[] = []) => ({
+  branch: Flags.string({
+    aliases: ['version'],
+    default: 'stable',
+    deprecateAliases: true,
+    description: ['Defaults to `stable` (i.e., your main project version).'].concat(additionalDescription).join(' '),
+    summary: 'ReadMe project version',
+  }),
+});
+
 export const confirmAutofixesFlag = Flags.boolean({
   summary:
     'Bypasses the prompt and automatically fixes up any autofixable errors that are found in the Markdown files.',

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -11,6 +11,7 @@ export const branchFlag = (additionalDescription: string[] = []) => ({
 });
 
 export const confirmAutofixesFlag = Flags.boolean({
+  hidden: true,
   summary:
     'Bypasses the prompt and automatically fixes up any autofixable errors that are found in the Markdown files.',
   description:

--- a/src/lib/help.ts
+++ b/src/lib/help.ts
@@ -37,7 +37,7 @@ function owlbert(this: CustomHelpClass) {
 // Oclif docs on customizing the help class: https://oclif.io/docs/help_classes/
 export default class CustomHelpClass extends Help {
   constructor(config: Config, opts?: Partial<HelpOptions>) {
-    super(config, { ...opts, hideAliasesFromRoot: true });
+    super(config, { ...opts, hideAliasesFromRoot: true, flagSortOrder: 'none' });
   }
 
   formatRoot() {

--- a/src/lib/readmeAPIFetch.ts
+++ b/src/lib/readmeAPIFetch.ts
@@ -497,13 +497,13 @@ export async function fetchSchema(this: APIv2PageCommands) {
       return readmeAPIv2Oas;
     });
 
-  const requestBody = oas.paths?.[`/versions/{version}/${this.route}/{slug}`]?.patch?.requestBody;
+  const requestBody = oas.paths?.[`/branches/{branch}/${this.route}/{slug}`]?.patch?.requestBody;
 
   if (requestBody && 'content' in requestBody) {
     return requestBody.content['application/json'].schema;
   }
 
   this.debug(`unable to find parse out schema for ${JSON.stringify(oas)}`);
-  return readmeAPIv2Oas.paths[`/versions/{version}/${this.route}/{slug}`].patch.requestBody.content['application/json']
+  return readmeAPIv2Oas.paths[`/branches/{branch}/${this.route}/{slug}`].patch.requestBody.content['application/json']
     .schema satisfies SchemaObject;
 }

--- a/src/lib/readmeAPIFetch.ts
+++ b/src/lib/readmeAPIFetch.ts
@@ -1,6 +1,5 @@
 import type { SpecFileType } from './prepareOas.js';
-import type { CommandClass } from '../index.js';
-import type { APIv2PageCommands } from './syncPagePath.js';
+import type { APIv2PageCommands, CommandClass } from '../index.js';
 import type { Hook } from '@oclif/core';
 import type { SchemaObject } from 'oas/types';
 

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -1,10 +1,9 @@
+import type { APIv2PageUploadCommands } from '../index.js';
 import type {
   GuidesRequestRepresentation,
   GuidesResponseRepresentation,
   ProjectRepresentation,
 } from './types/index.js';
-import type DocsMigrateCommand from '../commands/docs/migrate.js';
-import type DocsUploadCommand from '../commands/docs/upload.js';
 
 import chalk from 'chalk';
 import ora from 'ora';
@@ -15,14 +14,6 @@ import { oraOptions } from './logger.js';
 import { findPages, type PageMetadata } from './readPage.js';
 import { categoryUriRegexPattern, parentUriRegexPattern } from './types/index.js';
 import { validateFrontmatter } from './validateFrontmatter.js';
-
-/**
- * Commands that leverage the APIv2 representations for pages (e.g., Guides, API Reference, etc.)
- *
- * Note that the `changelogs` command is not included here
- * because it is backed by APIv1.
- */
-export type APIv2PageCommands = DocsMigrateCommand | DocsUploadCommand;
 
 // todo: eventually this type will be used for other page types (e.g., API Reference)
 type PageRequestRepresentation = GuidesRequestRepresentation;
@@ -76,7 +67,7 @@ export type PushResult = CreatePushResult | FailedPushResult | SkippedPushResult
  * and creates/updates the corresponding page in ReadMe
  */
 async function pushPage(
-  this: APIv2PageCommands,
+  this: APIv2PageUploadCommands,
   /** the file data */
   fileData: PageMetadata,
 ): Promise<PushResult> {
@@ -225,7 +216,7 @@ function sortFiles(files: PageMetadata<PageRequestRepresentation>[]): PageMetada
  * and syncs those (either via POST or PATCH) to ReadMe.
  * @returns An array of objects with the results
  */
-export default async function syncPagePath(this: DocsUploadCommand) {
+export default async function syncPagePath(this: APIv2PageUploadCommands) {
   const { path: pathInput } = this.args;
   const { key, 'dry-run': dryRun, 'max-errors': maxErrors, 'skip-validation': skipValidation } = this.flags;
 

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -71,12 +71,12 @@ async function pushPage(
   /** the file data */
   fileData: PageMetadata,
 ): Promise<PushResult> {
-  const { key, 'dry-run': dryRun, version } = this.flags;
+  const { key, 'dry-run': dryRun, branch } = this.flags;
   const { content, filePath, slug } = fileData;
   const data = fileData.data;
   let route = `/${this.route}`;
-  if (version) {
-    route = `/branches/${version}${route}`;
+  if (branch) {
+    route = `/branches/${branch}${route}`;
   }
 
   const headers = new Headers({ authorization: `Bearer ${key}`, 'Content-Type': 'application/json' });
@@ -104,7 +104,7 @@ async function pushPage(
         this.debug(`normalizing category uri ${uri} for ${filePath}`);
         // remove leading and trailing slashes
         uri = uri.replace(/^\/|\/$/g, '');
-        payload.category.uri = `/branches/${version}/categories/${this.route}/${uri}`;
+        payload.category.uri = `/branches/${branch}/categories/${this.route}/${uri}`;
       }
     }
 
@@ -116,7 +116,7 @@ async function pushPage(
         this.debug(`normalizing parent uri ${uri} for ${filePath}`);
         // remove leading and trailing slashes
         uri = uri.replace(/^\/|\/$/g, '');
-        payload.parent.uri = `/branches/${version}/${this.route}/${uri}`;
+        payload.parent.uri = `/branches/${branch}/${this.route}/${uri}`;
       }
     }
 

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -85,7 +85,7 @@ async function pushPage(
   const data = fileData.data;
   let route = `/${this.route}`;
   if (version) {
-    route = `/versions/${version}${route}`;
+    route = `/branches/${version}${route}`;
   }
 
   const headers = new Headers({ authorization: `Bearer ${key}`, 'Content-Type': 'application/json' });
@@ -113,7 +113,7 @@ async function pushPage(
         this.debug(`normalizing category uri ${uri} for ${filePath}`);
         // remove leading and trailing slashes
         uri = uri.replace(/^\/|\/$/g, '');
-        payload.category.uri = `/versions/${version}/categories/${this.route}/${uri}`;
+        payload.category.uri = `/branches/${version}/categories/${this.route}/${uri}`;
       }
     }
 
@@ -125,7 +125,7 @@ async function pushPage(
         this.debug(`normalizing parent uri ${uri} for ${filePath}`);
         // remove leading and trailing slashes
         uri = uri.replace(/^\/|\/$/g, '');
-        payload.parent.uri = `/versions/${version}/${this.route}/${uri}`;
+        payload.parent.uri = `/branches/${version}/${this.route}/${uri}`;
       }
     }
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -3,18 +3,18 @@ import type { FromSchema } from 'json-schema-to-ts';
 import readmeAPIv2Oas from './openapiDoc.js';
 
 export const categoryUriRegexPattern =
-  readmeAPIv2Oas.paths['/versions/{version}/guides'].post.requestBody.content['application/json'].schema.properties
+  readmeAPIv2Oas.paths['/branches/{branch}/guides'].post.requestBody.content['application/json'].schema.properties
     .category.properties.uri.pattern;
 
 export const parentUriRegexPattern =
-  readmeAPIv2Oas.paths['/versions/{version}/guides'].post.requestBody.content['application/json'].schema.properties
+  readmeAPIv2Oas.paths['/branches/{branch}/guides'].post.requestBody.content['application/json'].schema.properties
     .parent.properties.uri.pattern;
 
 type guidesRequestBodySchema =
-  (typeof readmeAPIv2Oas)['paths']['/versions/{version}/guides/{slug}']['patch']['requestBody']['content']['application/json']['schema'];
+  (typeof readmeAPIv2Oas)['paths']['/branches/{branch}/guides/{slug}']['patch']['requestBody']['content']['application/json']['schema'];
 
 type guidesResponseBodySchema =
-  (typeof readmeAPIv2Oas)['paths']['/versions/{version}/guides/{slug}']['patch']['responses']['200']['content']['application/json']['schema'];
+  (typeof readmeAPIv2Oas)['paths']['/branches/{branch}/guides/{slug}']['patch']['responses']['200']['content']['application/json']['schema'];
 
 type projectSchema =
   (typeof readmeAPIv2Oas)['paths']['/projects/me']['get']['responses']['200']['content']['application/json']['schema'];

--- a/src/lib/types/openapiDoc.ts
+++ b/src/lib/types/openapiDoc.ts
@@ -14,8 +14,7 @@ const document = {
     description: 'Create beautiful product and API documentation with our developer friendly platform.',
     version: '2.0.0-beta',
     title: 'ReadMe API v2 🦉 (BETA)',
-    // @ts-expect-error custom extension
-    'x-readme-deploy': '5.341.0',
+    'x-readme-deploy': '5.344.0',
     termsOfService: 'https://readme.com/tos',
     contact: {
       name: 'API Support',
@@ -357,7 +356,7 @@ const document = {
         },
       },
     },
-    '/versions/{version}/apis': {
+    '/branches/{branch}/apis': {
       get: {
         operationId: 'getAPIs',
         summary: 'Get all API definitions',
@@ -366,11 +365,14 @@ const document = {
           "Get all API definitions from your ReadMe project.\n\n>📘\n> This route is only available to projects that are using [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored).\n\n>🚧 ReadMe's API v2 is currently in beta.\n >This API and its documentation are a work in progress. While we don't expect any major breaking changes, you may encounter occasional issues as we work toward a stable release. Make sure to [check out our API migration guide](https://docs.readme.com/main/reference/api-migration-guide), and [feel free to reach out](mailto:support@readme.io) if you have any questions or feedback!",
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
         ],
         responses: {
@@ -469,7 +471,7 @@ const document = {
                           uri: {
                             type: 'string',
                             pattern:
-                              '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
+                              '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
                             description: 'A URI to the API definition resource.',
                           },
                         },
@@ -512,11 +514,14 @@ const document = {
         },
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
         ],
         responses: {
@@ -545,7 +550,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
                           description: 'A URI to the API definition resource.',
                         },
                       },
@@ -562,7 +567,7 @@ const document = {
         },
       },
     },
-    '/versions/{version}/apis/{filename}': {
+    '/branches/{branch}/apis/{filename}': {
       get: {
         operationId: 'getAPI',
         summary: 'Get an API definition',
@@ -578,11 +583,14 @@ const document = {
             description: 'The filename of the API definition to retrieve.',
           },
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
         ],
         responses: {
@@ -678,7 +686,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
                           description: 'A URI to the API definition resource.',
                         },
                         schema: { type: 'object', additionalProperties: {}, description: 'The API schema.' },
@@ -710,11 +718,14 @@ const document = {
             description: 'The filename of the API definition to retrieve.',
           },
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
         ],
         responses: { '204': { description: 'No Content' } },
@@ -752,11 +763,14 @@ const document = {
             description: 'The filename of the API definition to retrieve.',
           },
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
         ],
         responses: {
@@ -785,7 +799,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
                           description: 'A URI to the API definition resource.',
                         },
                       },
@@ -927,7 +941,7 @@ const document = {
         },
       },
     },
-    '/versions/{version}/categories': {
+    '/branches/{branch}/categories': {
       post: {
         operationId: 'createCategory',
         summary: 'Create a category',
@@ -957,11 +971,14 @@ const document = {
         },
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
         ],
         responses: {
@@ -997,7 +1014,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/categories\\/(guides|reference)\\/((.*))',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/categories\\/(guides|reference)\\/((.*))',
                           description: 'A URI to the category resource.',
                         },
                       },
@@ -1014,7 +1031,7 @@ const document = {
         },
       },
     },
-    '/versions/{version}/categories/{section}/{title}': {
+    '/branches/{branch}/categories/{section}/{title}': {
       delete: {
         operationId: 'deleteCategory',
         summary: 'Delete a category',
@@ -1037,11 +1054,14 @@ const document = {
             description: "The category's name.",
           },
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
         ],
         responses: { '204': { description: 'No Content' } },
@@ -1088,11 +1108,14 @@ const document = {
             description: "The category's name.",
           },
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
         ],
         responses: {
@@ -1128,7 +1151,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/categories\\/(guides|reference)\\/((.*))',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/categories\\/(guides|reference)\\/((.*))',
                           description: 'A URI to the category resource.',
                         },
                       },
@@ -1920,7 +1943,7 @@ const document = {
         },
       },
     },
-    '/versions/{version}/custom_pages': {
+    '/branches/{branch}/custom_pages': {
       post: {
         operationId: 'createCustomPage',
         summary: 'Create a custom page',
@@ -1998,11 +2021,14 @@ const document = {
         },
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
         ],
         responses: {
@@ -2123,7 +2149,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/custom_pages\\/([a-f\\d]{24}|([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/custom_pages\\/([a-f\\d]{24}|([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                         },
                       },
                       required: [
@@ -2157,11 +2183,14 @@ const document = {
           "Get all custom pages from your ReadMe project.\n\n>📘\n> This route is only available to projects that are using [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored).\n\n>🚧 ReadMe's API v2 is currently in beta.\n >This API and its documentation are a work in progress. While we don't expect any major breaking changes, you may encounter occasional issues as we work toward a stable release. Make sure to [check out our API migration guide](https://docs.readme.com/main/reference/api-migration-guide), and [feel free to reach out](mailto:support@readme.io) if you have any questions or feedback!",
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
         ],
         responses: {
@@ -2285,7 +2314,7 @@ const document = {
                           uri: {
                             type: 'string',
                             pattern:
-                              '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/custom_pages\\/([a-f\\d]{24}|([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                              '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/custom_pages\\/([a-f\\d]{24}|([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                           },
                         },
                         required: [
@@ -2313,7 +2342,7 @@ const document = {
         },
       },
     },
-    '/versions/{version}/custom_pages/{slug}': {
+    '/branches/{branch}/custom_pages/{slug}': {
       get: {
         operationId: 'getCustomPage',
         summary: 'Get a custom page',
@@ -2322,11 +2351,14 @@ const document = {
           "Get a custom page from your ReadMe project.\n\n>📘\n> This route is only available to projects that are using [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored).\n\n>🚧 ReadMe's API v2 is currently in beta.\n >This API and its documentation are a work in progress. While we don't expect any major breaking changes, you may encounter occasional issues as we work toward a stable release. Make sure to [check out our API migration guide](https://docs.readme.com/main/reference/api-migration-guide), and [feel free to reach out](mailto:support@readme.io) if you have any questions or feedback!",
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
           {
             schema: { type: 'string', pattern: '([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+' },
@@ -2454,7 +2486,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/custom_pages\\/([a-f\\d]{24}|([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/custom_pages\\/([a-f\\d]{24}|([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                         },
                       },
                       required: [
@@ -2488,11 +2520,14 @@ const document = {
           "Delete a custom page from your ReadMe project.\n\n>📘\n> This route is only available to projects that are using [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored).\n\n>🚧 ReadMe's API v2 is currently in beta.\n >This API and its documentation are a work in progress. While we don't expect any major breaking changes, you may encounter occasional issues as we work toward a stable release. Make sure to [check out our API migration guide](https://docs.readme.com/main/reference/api-migration-guide), and [feel free to reach out](mailto:support@readme.io) if you have any questions or feedback!",
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
           {
             schema: { type: 'string', pattern: '([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+' },
@@ -2579,11 +2614,14 @@ const document = {
         },
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
           {
             schema: { type: 'string', pattern: '([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+' },
@@ -2711,7 +2749,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/custom_pages\\/([a-f\\d]{24}|([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/custom_pages\\/([a-f\\d]{24}|([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                         },
                       },
                       required: [
@@ -2738,7 +2776,7 @@ const document = {
         },
       },
     },
-    '/versions/{version}/guides': {
+    '/branches/{branch}/guides': {
       post: {
         operationId: 'createGuide',
         summary: 'Create a guides page',
@@ -2763,7 +2801,7 @@ const document = {
                       uri: {
                         type: 'string',
                         pattern:
-                          '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/categories\\/(guides|reference)\\/((.*))',
+                          '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/categories\\/(guides|reference)\\/((.*))',
                         description: 'A URI to the category resource.',
                       },
                     },
@@ -2842,7 +2880,7 @@ const document = {
                       uri: {
                         type: 'string',
                         pattern:
-                          '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                          '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                         nullable: true,
                       },
                     },
@@ -2877,11 +2915,14 @@ const document = {
         },
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
         ],
         responses: {
@@ -2907,7 +2948,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/categories\\/(guides|reference)\\/((.*))',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/categories\\/(guides|reference)\\/((.*))',
                               description: 'A URI to the category resource.',
                             },
                           },
@@ -3008,7 +3049,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                               nullable: true,
                               description: 'A URI to the parent page resource including the page ID or slug.',
                             },
@@ -3095,7 +3136,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                           description: 'A URI to the page resource.',
                         },
                       },
@@ -3125,7 +3166,7 @@ const document = {
         },
       },
     },
-    '/versions/{version}/guides/{slug}': {
+    '/branches/{branch}/guides/{slug}': {
       get: {
         operationId: 'getGuide',
         summary: 'Get a guides page',
@@ -3134,11 +3175,14 @@ const document = {
           "Get a page from the Guides section of your ReadMe project.\n\n>📘\n> This route is only available to projects that are using [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored).\n\n>🚧 ReadMe's API v2 is currently in beta.\n >This API and its documentation are a work in progress. While we don't expect any major breaking changes, you may encounter occasional issues as we work toward a stable release. Make sure to [check out our API migration guide](https://docs.readme.com/main/reference/api-migration-guide), and [feel free to reach out](mailto:support@readme.io) if you have any questions or feedback!",
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
           {
             schema: { type: 'string', pattern: '([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+' },
@@ -3171,7 +3215,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/categories\\/(guides|reference)\\/((.*))',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/categories\\/(guides|reference)\\/((.*))',
                               description: 'A URI to the category resource.',
                             },
                           },
@@ -3272,7 +3316,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                               nullable: true,
                               description: 'A URI to the parent page resource including the page ID or slug.',
                             },
@@ -3359,7 +3403,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                           description: 'A URI to the page resource.',
                         },
                       },
@@ -3396,11 +3440,14 @@ const document = {
           "Delete a page from the Guides section of your ReadMe project.\n\n>📘\n> This route is only available to projects that are using [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored).\n\n>🚧 ReadMe's API v2 is currently in beta.\n >This API and its documentation are a work in progress. While we don't expect any major breaking changes, you may encounter occasional issues as we work toward a stable release. Make sure to [check out our API migration guide](https://docs.readme.com/main/reference/api-migration-guide), and [feel free to reach out](mailto:support@readme.io) if you have any questions or feedback!",
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
           {
             schema: { type: 'string', pattern: '([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+' },
@@ -3436,7 +3483,7 @@ const document = {
                       uri: {
                         type: 'string',
                         pattern:
-                          '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/categories\\/(guides|reference)\\/((.*))',
+                          '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/categories\\/(guides|reference)\\/((.*))',
                         description: 'A URI to the category resource.',
                       },
                     },
@@ -3514,7 +3561,7 @@ const document = {
                       uri: {
                         type: 'string',
                         pattern:
-                          '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                          '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                         nullable: true,
                       },
                     },
@@ -3547,11 +3594,14 @@ const document = {
         },
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
           {
             schema: { type: 'string', pattern: '([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+' },
@@ -3584,7 +3634,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/categories\\/(guides|reference)\\/((.*))',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/categories\\/(guides|reference)\\/((.*))',
                               description: 'A URI to the category resource.',
                             },
                           },
@@ -3685,7 +3735,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                               nullable: true,
                               description: 'A URI to the parent page resource including the page ID or slug.',
                             },
@@ -3772,7 +3822,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                           description: 'A URI to the page resource.',
                         },
                       },
@@ -4793,7 +4843,7 @@ const document = {
                             not_found: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/custom_pages\\/([a-f\\d]{24}|([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/custom_pages\\/([a-f\\d]{24}|([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                               nullable: true,
                               description:
                                 'The page you wish to be served to your users when they encounter a 404. This can either map to the `uri` of a Custom Page on your project or be set to `null`. If `null` then the default ReadMe 404 page will be served. The version within the `uri` must be mapped to your stable version.',
@@ -5188,7 +5238,7 @@ const document = {
         },
       },
     },
-    '/versions/{version}/reference': {
+    '/branches/{branch}/reference': {
       post: {
         operationId: 'createReference',
         summary: 'Create a reference page',
@@ -5213,7 +5263,7 @@ const document = {
                       uri: {
                         type: 'string',
                         pattern:
-                          '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/categories\\/(guides|reference)\\/((.*))',
+                          '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/categories\\/(guides|reference)\\/((.*))',
                         description: 'A URI to the category resource.',
                       },
                     },
@@ -5292,7 +5342,7 @@ const document = {
                       uri: {
                         type: 'string',
                         pattern:
-                          '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                          '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                         nullable: true,
                       },
                     },
@@ -5327,7 +5377,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/recipes\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/recipes\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                               description:
                                 'URI of the recipe that this API reference is connected to. The recipe and API reference must exist within the same version.',
                             },
@@ -5443,7 +5493,7 @@ const document = {
                       uri: {
                         type: 'string',
                         pattern:
-                          '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
+                          '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
                         nullable: true,
                       },
                     },
@@ -5459,11 +5509,14 @@ const document = {
         },
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
         ],
         responses: {
@@ -5489,7 +5542,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/categories\\/(guides|reference)\\/((.*))',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/categories\\/(guides|reference)\\/((.*))',
                               description: 'A URI to the category resource.',
                             },
                           },
@@ -5590,7 +5643,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                               nullable: true,
                               description: 'A URI to the parent page resource including the page ID or slug.',
                             },
@@ -5727,7 +5780,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
                               nullable: true,
                               description: 'A URI to the API resource.',
                             },
@@ -5747,7 +5800,7 @@ const document = {
                                   uri: {
                                     type: 'string',
                                     pattern:
-                                      '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/recipes\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                                      '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/recipes\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                                     description:
                                       'URI of the recipe that this API reference is connected to. The recipe and API reference must exist within the same version.',
                                   },
@@ -5823,7 +5876,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                           description: 'A URI to the page resource.',
                         },
                       },
@@ -5856,7 +5909,7 @@ const document = {
         },
       },
     },
-    '/versions/{version}/reference/{slug}': {
+    '/branches/{branch}/reference/{slug}': {
       get: {
         operationId: 'getReference',
         summary: 'Get a reference page',
@@ -5881,11 +5934,14 @@ const document = {
               'Whether or not to reduce the attached API definition. Defaults to `true` if not specified (subject to change while API v2 is still in beta).',
           },
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
           {
             schema: { type: 'string', pattern: '([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+' },
@@ -5918,7 +5974,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/categories\\/(guides|reference)\\/((.*))',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/categories\\/(guides|reference)\\/((.*))',
                               description: 'A URI to the category resource.',
                             },
                           },
@@ -6019,7 +6075,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                               nullable: true,
                               description: 'A URI to the parent page resource including the page ID or slug.',
                             },
@@ -6156,7 +6212,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
                               nullable: true,
                               description: 'A URI to the API resource.',
                             },
@@ -6176,7 +6232,7 @@ const document = {
                                   uri: {
                                     type: 'string',
                                     pattern:
-                                      '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/recipes\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                                      '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/recipes\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                                     description:
                                       'URI of the recipe that this API reference is connected to. The recipe and API reference must exist within the same version.',
                                   },
@@ -6252,7 +6308,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                           description: 'A URI to the page resource.',
                         },
                       },
@@ -6292,11 +6348,14 @@ const document = {
           "Delete a page from the API Reference section of your ReadMe project.\n\n>📘\n> This route is only available to projects that are using [ReadMe Refactored](https://docs.readme.com/main/docs/welcome-to-readme-refactored).\n\n>🚧 ReadMe's API v2 is currently in beta.\n >This API and its documentation are a work in progress. While we don't expect any major breaking changes, you may encounter occasional issues as we work toward a stable release. Make sure to [check out our API migration guide](https://docs.readme.com/main/reference/api-migration-guide), and [feel free to reach out](mailto:support@readme.io) if you have any questions or feedback!",
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
           {
             schema: { type: 'string', pattern: '([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+' },
@@ -6332,7 +6391,7 @@ const document = {
                       uri: {
                         type: 'string',
                         pattern:
-                          '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/categories\\/(guides|reference)\\/((.*))',
+                          '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/categories\\/(guides|reference)\\/((.*))',
                         description: 'A URI to the category resource.',
                       },
                     },
@@ -6410,7 +6469,7 @@ const document = {
                       uri: {
                         type: 'string',
                         pattern:
-                          '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                          '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                         nullable: true,
                       },
                     },
@@ -6445,7 +6504,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/recipes\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/recipes\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                               description:
                                 'URI of the recipe that this API reference is connected to. The recipe and API reference must exist within the same version.',
                             },
@@ -6555,7 +6614,7 @@ const document = {
                       uri: {
                         type: 'string',
                         pattern:
-                          '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
+                          '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
                         nullable: true,
                       },
                     },
@@ -6572,11 +6631,14 @@ const document = {
         },
         parameters: [
           {
-            schema: { type: 'string', pattern: 'stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?' },
+            schema: {
+              type: 'string',
+              pattern: '(v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?',
+            },
             in: 'path',
-            name: 'version',
+            name: 'branch',
             required: true,
-            description: 'Project version number or `stable` for your stable project version.',
+            description: "Project version number, `stable` for your project's stable version, or a valid branch name.",
           },
           {
             schema: { type: 'string', pattern: '([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+' },
@@ -6609,7 +6671,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/categories\\/(guides|reference)\\/((.*))',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/categories\\/(guides|reference)\\/((.*))',
                               description: 'A URI to the category resource.',
                             },
                           },
@@ -6710,7 +6772,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                               nullable: true,
                               description: 'A URI to the parent page resource including the page ID or slug.',
                             },
@@ -6847,7 +6909,7 @@ const document = {
                             uri: {
                               type: 'string',
                               pattern:
-                                '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
+                                '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/apis\\/((([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+.(json|yaml|yml)))',
                               nullable: true,
                               description: 'A URI to the API resource.',
                             },
@@ -6867,7 +6929,7 @@ const document = {
                                   uri: {
                                     type: 'string',
                                     pattern:
-                                      '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/recipes\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                                      '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/recipes\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                                     description:
                                       'URI of the recipe that this API reference is connected to. The recipe and API reference must exist within the same version.',
                                   },
@@ -6943,7 +7005,7 @@ const document = {
                         uri: {
                           type: 'string',
                           pattern:
-                            '\\/versions\\/(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
+                            '\\/(versions|branches)\\/((v{0,1})(stable|([0-9]+)(?:\\.([0-9]+))?(?:\\.([0-9]+))?(-.*)?)(_(.*))?)\\/(guides|reference)\\/(([a-z0-9-_ ]|[^\\\\x00-\\\\x7F])+)',
                           description: 'A URI to the page resource.',
                         },
                       },
@@ -7177,6 +7239,6 @@ const document = {
     { name: 'Projects' },
     { name: 'Search' },
   ],
-} as const satisfies OASDocument;
+} as const satisfies OASDocument & { info: { 'x-readme-deploy': string } };
 
 export default document;


### PR DESCRIPTION
## 🧰 Changes

`rdme` users are now seeing these deprecation warnings to do some underlying ReadMe APIv2 changes:

```
⚠️  ReadMe API Warning: Our `/versions` endpoint URI family has been renamed to `/branches` and will be removed in the future.
```

with the changes in this PR, the documented flag to use for the `openapi upload` and `docs upload` command is `--branch`. the `--version` flag will continue to work, but users will now see this warning[^1]:

```
›   Warning: The "--version" flag has been deprecated. Use "--branch" instead.
```

## 🧬 QA & Testing

added a bunch of test coverage to account for this and also updated our docs throughout. please flag any discrepancies you see!

[^1]: i know, it's on my list to consolidate our warning formatting 🫠
