### PR TITLE
docs: improved flag sorting

### DIFF
--- a/documentation/commands/changelogs.md
+++ b/documentation/commands/changelogs.md
@@ -11,15 +11,15 @@ Upload Markdown files to your ReadMe project as Changelog posts.
 
 ```
 USAGE
-  $ rdme changelogs PATH --key <value> [--github] [--dryRun]
+  $ rdme changelogs PATH --key <value> [--dryRun] [--github]
 
 ARGUMENTS
   PATH  Path to a local Markdown file or folder of Markdown files.
 
 FLAGS
+  --key=<value>  (required) ReadMe project API key
   --dryRun       Runs the command without creating nor updating any changelogs in ReadMe. Useful for debugging.
   --github       Create a new GitHub Actions workflow for this command.
-  --key=<value>  (required) ReadMe project API key
 
 DESCRIPTION
   Upload Markdown files to your ReadMe project as Changelog posts.

--- a/documentation/commands/login.md
+++ b/documentation/commands/login.md
@@ -11,13 +11,13 @@ Login to a ReadMe project.
 
 ```
 USAGE
-  $ rdme login [--email <value>] [--password <value>] [--otp <value>] [--project <value>]
+  $ rdme login [--email <value>] [--password <value>] [--project <value>] [--otp <value>]
 
 FLAGS
   --email=<value>     Your email address
-  --otp=<value>       Your one-time password (if you have two-factor authentication enabled)
   --password=<value>  Your password
   --project=<value>   The subdomain of the project you wish to log into
+  --otp=<value>       Your one-time password (if you have two-factor authentication enabled)
 
 DESCRIPTION
   Login to a ReadMe project.

--- a/documentation/commands/plugins.md
+++ b/documentation/commands/plugins.md
@@ -123,8 +123,8 @@ ARGUMENTS
 
 FLAGS
   -h, --help          Show CLI help.
-  -v, --verbose
       --[no-]install  Install dependencies after linking the plugin.
+  -v, --verbose
 
 DESCRIPTION
   Links a plugin into the CLI for development.

--- a/src/commands/changelogs.ts
+++ b/src/commands/changelogs.ts
@@ -34,11 +34,11 @@ export default class ChangelogsCommand extends BaseCommand<typeof ChangelogsComm
   ];
 
   static flags = {
-    github: githubFlag,
     key: keyFlag,
     dryRun: Flags.boolean({
       description: 'Runs the command without creating nor updating any changelogs in ReadMe. Useful for debugging.',
     }),
+    github: githubFlag,
   };
 
   async run() {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -10,8 +10,8 @@ export default class LoginCommand extends BaseCommand<typeof LoginCommand> {
   static flags = {
     email: Flags.string({ description: 'Your email address' }),
     password: Flags.string({ description: 'Your password' }),
-    otp: Flags.string({ description: 'Your one-time password (if you have two-factor authentication enabled)' }),
     project: Flags.string({ description: 'The subdomain of the project you wish to log into' }),
+    otp: Flags.string({ description: 'Your one-time password (if you have two-factor authentication enabled)' }),
   };
 
   async run() {

--- a/src/lib/help.ts
+++ b/src/lib/help.ts
@@ -37,7 +37,7 @@ function owlbert(this: CustomHelpClass) {
 // Oclif docs on customizing the help class: https://oclif.io/docs/help_classes/
 export default class CustomHelpClass extends Help {
   constructor(config: Config, opts?: Partial<HelpOptions>) {
-    super(config, { ...opts, hideAliasesFromRoot: true });
+    super(config, { ...opts, flagSortOrder: 'none', hideAliasesFromRoot: true });
   }
 
   formatRoot() {


### PR DESCRIPTION
## 🧰 Changes

reworks how the help screens + docs sort our flags so we can define the order. noticed this in https://github.com/readmeio/rdme/pull/1238 now that we're using `--branch` instead of `--version`.

as a general nit, i prefer the `--key` flag is always first, and then the `--branch` (f.k.a. `--version`) flag is always second.
