### PR TITLE
fix: problem with `FormData` compositions on Node 24

### DIFF
--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -177,15 +177,15 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
       const { path } = await tmpFile({ prefix: 'rdme-openapi-', postfix: fileExtension });
       this.debug(`creating temporary file at ${path}`);
       fs.writeFileSync(path, specToUpload);
-      const stream = fs.createReadStream(path);
 
-      this.debug('file and stream created, streaming into form data payload');
-      body.append('schema', {
-        [Symbol.toStringTag]: 'File',
-        name: filename,
-        stream: () => stream,
-        type: isYaml ? 'application/x-yaml' : 'application/json',
-      });
+      this.debug('temporary file created, processing into form data payload');
+      body.append(
+        'schema',
+        new File([fs.readFileSync(path)], filename, {
+          type: isYaml ? 'application/x-yaml' : 'application/json',
+        }),
+        filename
+      );
     }
 
     const options: RequestInit = { headers, method, body };


### PR DESCRIPTION
| 🚥 Resolves CX-1950 |
| :------------------- |

## 🧰 Changes

Undici changed something with how streams are processed in `FormData` payloads in the version that ships with Node 24 that has broken OpenAPI definition uploads within rdme there. Because we don't _really_ need to send these API definitions as a stream in our `multipart/form-data` payload to our public API I've changed them to just send it as a regular `File` object.

## 🧬 QA & Testing

Tested this locally on Node 22 and 24 and everything is green.
