### PR TITLE
fix(v9/openapi): problem with `FormData` compositions on Node 24

### DIFF
--- a/src/lib/streamSpecToRegistry.ts
+++ b/src/lib/streamSpecToRegistry.ts
@@ -23,18 +23,10 @@ export default async function streamSpecToRegistry(
   const { path } = await tmpFile({ prefix: 'rdme-openapi-', postfix: '.json' });
   debug(`creating temporary file at ${path}`);
   await fs.writeFileSync(path, spec);
-  const stream = fs.createReadStream(path);
 
-  debug('file and stream created, streaming into form data payload');
+  debug('temporary file, created, constructed form data');
   const formData = new FormData();
-  formData.append('spec', {
-    type: 'application/json',
-    name: 'openapi.json',
-    [Symbol.toStringTag]: 'File',
-    stream() {
-      return stream;
-    },
-  });
+  formData.append('spec', new File([fs.readFileSync(path)], path, { type: 'application/json' }), path);
 
   const options = {
     body: formData,


### PR DESCRIPTION
| 🚥 Resolves CX-1950 |
| :------------------- |

## 🧰 Changes

backports https://github.com/readmeio/rdme/pull/1241 over to the `v9` channel.
