### PR TITLE
docs: convert legacy docs to MDX syntax

### DIFF
--- a/documentation/legacy/github-actions-docs-example.mdx
+++ b/documentation/legacy/github-actions-docs-example.mdx
@@ -4,7 +4,8 @@ category:
   uri: documentation
 ---
 
-<!--
+{/* prettier-ignore */}
+{/* <!--
 
 Hello curious raw Markdown reader! 👋
 This Markdown page is syncing to ReadMe via the `rdme` GitHub Action 🦉
@@ -15,7 +16,7 @@ We also do some fancy little find-and-replace action to swap out every instance
 of `RDME_VERSION` below with the latest version of rdme.
 Check out `.github/workflows/docs.yml` for more info on this!
 
--->
+--> \*/}
 
 > 🚧 Deprecated Guidance
 >

--- a/documentation/legacy/github-actions-openapi-example.mdx
+++ b/documentation/legacy/github-actions-openapi-example.mdx
@@ -4,7 +4,8 @@ category:
   uri: documentation
 ---
 
-<!--
+{/* prettier-ignore */}
+{/*
 
 Hello curious raw Markdown reader! 👋
 This Markdown page is syncing to ReadMe via the `rdme` GitHub Action 🦉
@@ -14,7 +15,7 @@ We also do some fancy little find-and-replace action to swap out every instance
 of `RDME_VERSION` below with the latest version of rdme.
 Check out `.github/workflows/docs.yml` for more info on this!
 
--->
+\*/}
 
 > 🚧 Deprecated Guidance
 >
@@ -73,20 +74,9 @@ To update your OpenAPI definition, run the following:
 
 </details>
 
-We have a walkthrough video available which goes over the whole end-to-end process of obtaining the API definition ID and constructing the GitHub Actions workflow file:
+We have a walkthrough video available which goes over the whole end-to-end process of obtaining the API definition ID and constructing the GitHub Actions workflow file.
 
-<!--
-This is a custom HTML block that we use in ReadMe.
-We'll need this to render an iframe of the Loom video demo.
-Using our embedly-powered embed block renders an iframe that's way too tall, hence we're using HTML.
-You can see the video here: https://www.loom.com/share/e32c20a9dc2f4eeeab42d0c18ba24478
--->
-
-[block:html]
-{
-"html": "<div style=\"position: relative; padding-bottom: 62.5%; height: 0;\"><iframe src=\"https://www.loom.com/embed/e32c20a9dc2f4eeeab42d0c18ba24478\" frameborder=\"0\" webkitallowfullscreen mozallowfullscreen allowfullscreen style=\"position: absolute; top: 0; left: 0; width: 100%; height: 100%;\"></iframe></div>"
-}
-[/block]
+You can find the video here: [https://www.loom.com/share/e32c20a9dc2f4eeeab42d0c18ba24478](https://www.loom.com/share/e32c20a9dc2f4eeeab42d0c18ba24478).
 
 Once you've obtained your API definition ID (let's call it `API_DEFINITION_ID`), your full GitHub Workflow file will look something like this:
 

--- a/documentation/legacy/legacy-github-action.mdx
+++ b/documentation/legacy/legacy-github-action.mdx
@@ -7,13 +7,14 @@ privacy:
   view: anyone_with_link
 ---
 
-<!--
+{/* prettier-ignore */}
+{/* <!--
 
 Hello curious raw Markdown reader! 👋
 This Markdown page is syncing to ReadMe via the `rdme` GitHub Action 🦉
 Read more [on our main documentation page](rdme.md)
 
--->
+--> \*/}
 
 > ❗️Deprecated in favor of [our new GitHub Action, `rdme`](https://docs.readme.com/docs/rdme) 🔄
 >

--- a/documentation/legacy/rdme.mdx
+++ b/documentation/legacy/rdme.mdx
@@ -29,10 +29,10 @@ Check out `.github/workflows/docs.yml` for more info on this!
 </p>
 
 <p align="center">
-  <a href="https://npm.im/rdme"><img src="https://img.shields.io/npm/v/rdme?style=for-the-badge" alt="NPM Version"></a>
-  <a href="https://npm.im/rdme"><img src="https://img.shields.io/node/v/rdme?style=for-the-badge" alt="Node Version"></a>
-  <a href="https://npm.im/rdme"><img src="https://img.shields.io/npm/l/rdme?style=for-the-badge" alt="MIT License"></a>
-  <a href="https://github.com/readmeio/rdme"><img src="https://img.shields.io/github/actions/workflow/status/readmeio/rdme/ci.yml?branch=main&style=for-the-badge" alt="Build status"></a>
+  <a href="https://npm.im/rdme"><img src="https://img.shields.io/npm/v/rdme?style=for-the-badge" alt="NPM Version" /></a>
+  <a href="https://npm.im/rdme"><img src="https://img.shields.io/node/v/rdme?style=for-the-badge" alt="Node Version" /></a>
+  <a href="https://npm.im/rdme"><img src="https://img.shields.io/npm/l/rdme?style=for-the-badge" alt="MIT License" /></a>
+  <a href="https://github.com/readmeio/rdme"><img src="https://img.shields.io/github/actions/workflow/status/readmeio/rdme/ci.yml?branch=main&style=for-the-badge" alt="Build status" /></a>
 </p>
 
 <p align="center">

--- a/documentation/legacy/rdme.mdx
+++ b/documentation/legacy/rdme.mdx
@@ -8,7 +8,8 @@ content:
     Action!
 ---
 
-<!--
+{/* prettier-ignore */}
+{/* <!--
 
 Hello curious raw Markdown reader! 👋
 This Markdown page is syncing to ReadMe via the `rdme` GitHub Action 🦉
@@ -18,12 +19,13 @@ We also do some fancy little find-and-replace action to swap out every instance
 of `RDME_VERSION` below with the latest version of rdme.
 Check out `.github/workflows/docs.yml` for more info on this!
 
--->
+--> \*/}
 
 [![rdme](https://user-images.githubusercontent.com/8854718/195465739-0f0f83d5-2e18-4e6c-96ae-944e3bb6880a.png)](https://readme.com)
 
 <p align="center">
-  <a href="https://readme.com">ReadMe</a>'s official command-line interface (CLI) and <a href="#github-actions-usage">GitHub Action</a> 🌊
+  <a href="https://readme.com">ReadMe</a>'s official command-line interface (CLI) and{' '}
+  <a href="#github-actions-usage">GitHub Action</a> 🌊
 </p>
 
 <p align="center">
@@ -34,7 +36,9 @@ Check out `.github/workflows/docs.yml` for more info on this!
 </p>
 
 <p align="center">
-  <a href="https://readme.com"><img src="https://raw.githubusercontent.com/readmeio/.github/main/oss-badge.svg" /></a>
+  <a href="https://readme.com">
+    <img src="https://raw.githubusercontent.com/readmeio/.github/main/oss-badge.svg" />
+  </a>
 </p>
 
 If you're anything like us, your documentation process may be a part of a broader CI/CD process. For example, you may want to automatically update your Guides or API reference on ReadMe every time you ship new code. Enter `rdme`: ReadMe's official command-line interface (CLI) and GitHub Action!
@@ -236,13 +240,14 @@ Want to start syncing? We have several example workflow files available:
 
 Since `rdme` is a command-line tool at its core, you can use `rdme` to sync your documentation from virtually any CI/CD environment that runs shell commands—[Bitbucket Pipelines](https://support.atlassian.com/bitbucket-cloud/docs/get-started-with-bitbucket-pipelines/), [GitLab CI/CD](https://docs.gitlab.com/ee/ci/), you name it! You can do this by invoking `rdme` with `npx rdme@RDME_VERSION` in a Node.js environment. See below for several examples.
 
-<!--
+{/* prettier-ignore */}
+{/* <!--
 The two code blocks below must be joined (i.e. no newline in between) in order to render as tabbed code blocks in ReadMe.
 
 Unfortunately we need to ignore both code blocks entirely so Prettier doesn't separate them.
--->
+--> \*/}
 
-<!-- prettier-ignore-start -->
+{/* prettier-ignore-start */}
 ```yml Bitbucket Pipelines (bitbucket-pipelines.yml)
 # Official framework image. Look for the different tagged releases at:
 # https://hub.docker.com/r/library/node/tags/
@@ -282,7 +287,7 @@ node_js:
 
 script: npx rdme@RDME_VERSION openapi validate [url-or-local-path-to-file] --key=$README_API_KEY --id=API_DEFINITION_ID
 ```
-<!-- prettier-ignore-end -->
+{/* prettier-ignore-end */}
 
 If you notice any issues with any of these examples, please open up an issue on [the `rdme` repository on GitHub](https://github.com/readmeio/rdme).
 

--- a/documentation/legacy/rdme.mdx
+++ b/documentation/legacy/rdme.mdx
@@ -29,10 +29,21 @@ Check out `.github/workflows/docs.yml` for more info on this!
 </p>
 
 <p align="center">
-  <a href="https://npm.im/rdme"><img src="https://img.shields.io/npm/v/rdme?style=for-the-badge" alt="NPM Version" /></a>
-  <a href="https://npm.im/rdme"><img src="https://img.shields.io/node/v/rdme?style=for-the-badge" alt="Node Version" /></a>
-  <a href="https://npm.im/rdme"><img src="https://img.shields.io/npm/l/rdme?style=for-the-badge" alt="MIT License" /></a>
-  <a href="https://github.com/readmeio/rdme"><img src="https://img.shields.io/github/actions/workflow/status/readmeio/rdme/ci.yml?branch=main&style=for-the-badge" alt="Build status" /></a>
+  <a href="https://npm.im/rdme">
+    <img src="https://img.shields.io/npm/v/rdme?style=for-the-badge" alt="NPM Version" />
+  </a>
+  <a href="https://npm.im/rdme">
+    <img src="https://img.shields.io/node/v/rdme?style=for-the-badge" alt="Node Version" />
+  </a>
+  <a href="https://npm.im/rdme">
+    <img src="https://img.shields.io/npm/l/rdme?style=for-the-badge" alt="MIT License" />
+  </a>
+  <a href="https://github.com/readmeio/rdme">
+    <img
+      src="https://img.shields.io/github/actions/workflow/status/readmeio/rdme/ci.yml?branch=main&style=for-the-badge"
+      alt="Build status"
+    />
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## 🧰 Changes

MDX syntax doesn't support HTML comments (and wow prettier does not play nicely with MDX) 😮‍💨 this converts our synced markdown pages over to MDX
