### PR TITLE
chore: replacing `reviewers` in dependabot with a CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @erunion
+* @kanadgupta

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
-    reviewers:
-      - erunion
-      - kanadgupta
     labels:
       - dependencies
     commit-message:
@@ -18,9 +15,6 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 10
-    reviewers:
-      - erunion
-      - kanadgupta
     labels:
       - dependencies
     groups:


### PR DESCRIPTION
## 🧰 Changes

GitHub is sunsetting `reviewers` support in Dependabot in favor of relying on existing CODEOWNERS functionality. 

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
