### PR TITLE
ci: excluding dependabot from our dry run action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
   action:
     name: GitHub Action Dry Run
     runs-on: ubuntu-latest
+    # Dependabot doesn't have access to secrets so this action will always fail.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout GitHub Action
         uses: actions/checkout@v4


### PR DESCRIPTION
## 🧰 Changes

Excludes our GitHub Action dry run CI step from being run for Dependabot-created PRs as they will always fail because Dependabot doesn't get access to the `secrets` environment variable.