### PR TITLE
feat: filter `oas/analyzer` data by allowed keys

### DIFF
--- a/src/commands/openapi/inspect.ts
+++ b/src/commands/openapi/inspect.ts
@@ -106,11 +106,14 @@ function buildFeaturesReport(analysis: Analysis, features: string[]) {
 
 function buildFullReport(analysis: Analysis, definitionVersion: string, tableBorder: Record<string, string>) {
   const report: string[] = ['Here are some interesting things we found in your API definition. 🕵️', ''];
+
+  const allowedKeys = ['dereferencedFileSize', 'mediaTypes', 'operationTotal', 'rawFileSize', 'securityTypes'];
   const sizeKeys = ['rawFileSize', 'dereferencedFileSize'];
 
   // General API definition statistics
   report.push(
     ...(Object.entries(analysis.general || {})
+      .filter(([key]) => allowedKeys.includes(key))
       .map(([key, info]) => {
         if (Array.isArray(info.found)) {
           if (!info.found.length) return false;


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

This change introduces an explicit whitelist of keys that `rdme inspect` will process from the data returned by `oas/analyzer`. By filtering on known keys, we ensure that any new fields added by the analyzer won’t be rendered until we’ve explicitly implemented their handling in `rdme`. 