### PR TITLE
chore: update the frontmatter fixing solution to support custom pages

### DIFF
--- a/__tests__/lib/frontmatter.test.ts
+++ b/__tests__/lib/frontmatter.test.ts
@@ -377,6 +377,7 @@ describe('#fix', () => {
       order: 7,
       hidden: true,
       slug: 'some-slug',
+      htmlmode: false,
     };
 
     const result = fix.call(command, data, schema, {
@@ -393,6 +394,7 @@ describe('#fix', () => {
         "content": {
           "body": "This is the body",
           "excerpt": "This is an excerpt",
+          "type": "markdown",
         },
         "parent": {
           "uri": "some-parent-slug",

--- a/__tests__/lib/frontmatter.test.ts
+++ b/__tests__/lib/frontmatter.test.ts
@@ -302,6 +302,63 @@ describe('#fix', () => {
     `);
   });
 
+  it('should fix htmlmode (true)', () => {
+    const data = {
+      title: 'Hello, world!',
+      htmlmode: true,
+    };
+
+    const result = fix.call(command, data, schema, emptyMappings);
+
+    expect(result.hasIssues).toBe(true);
+    expect(result.updatedData).toMatchInlineSnapshot(`
+      {
+        "content": {
+          "type": "html",
+        },
+        "title": "Hello, world!",
+      }
+    `);
+  });
+
+  it('should fix htmlmode (false)', () => {
+    const data = {
+      title: 'Hello, world!',
+      htmlmode: false,
+    };
+
+    const result = fix.call(command, data, schema, emptyMappings);
+
+    expect(result.hasIssues).toBe(true);
+    expect(result.updatedData).toMatchInlineSnapshot(`
+      {
+        "content": {
+          "type": "markdown",
+        },
+        "title": "Hello, world!",
+      }
+    `);
+  });
+
+  it('should fix fullscreen', () => {
+    const data = {
+      title: 'Hello, world!',
+      fullscreen: true,
+    };
+
+    const result = fix.call(command, data, schema, emptyMappings);
+
+    expect(result.hasIssues).toBe(true);
+    expect(result.updatedData).toMatchInlineSnapshot(`
+      {
+        "appearance": {
+          "fullscreen": true,
+        },
+        "title": "Hello, world!",
+      }
+    `);
+  });
+
   it.todo('should fix metadata object');
 
   it.todo('should fix content.link object');

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -127,6 +127,10 @@ export function fix(
           updatedData.privacy = { view: hidden ? 'anyone_with_link' : 'public' };
         } else if (badKey === 'order') {
           updatedData.position = extractedValue;
+        } else if (badKey === 'htmlmode') {
+          updatedData.content = { type: extractedValue ? 'html' : 'markdown' };
+        } else if (badKey === 'fullscreen') {
+          updatedData.appearance = { fullscreen: extractedValue };
         }
       } else {
         unfixableErrors.push(error);

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -128,7 +128,12 @@ export function fix(
         } else if (badKey === 'order') {
           updatedData.position = extractedValue;
         } else if (badKey === 'htmlmode') {
-          updatedData.content = { type: extractedValue ? 'html' : 'markdown' };
+          // if the `content` object exists, add to it. otherwise, create it
+          if (typeof updatedData.content === 'object' && updatedData.content) {
+            (updatedData.content as Record<string, unknown>).type = extractedValue ? 'html' : 'markdown';
+          } else {
+            updatedData.content = { type: extractedValue ? 'html' : 'markdown' };
+          }
         } else if (badKey === 'fullscreen') {
           updatedData.appearance = { fullscreen: extractedValue };
         }


### PR DESCRIPTION
| 🚥 Resolves RM-12971 |
| :------------------- |

## 🧰 Changes

Adding support for custom page specific frontmatter fixes so that we can add a `custom pages upload` command

## 🧬 QA & Testing

Added tests for the additional `badKeys`
