### PR TITLE
fix(lib/fetchSchema): don't fetch OAS schemas from our API

### DIFF
--- a/__tests__/helpers/get-api-mock.ts
+++ b/__tests__/helpers/get-api-mock.ts
@@ -2,7 +2,6 @@ import nock from 'nock';
 
 import config from '../../src/lib/config.js';
 import { getUserAgent } from '../../src/lib/readmeAPIFetch.js';
-import readmeAPIv2Oas from '../../src/lib/types/openapiDoc.js';
 
 import { mockVersion } from './oclif.js';
 
@@ -43,8 +42,3 @@ export function getAPIv2MockForGHA(reqHeaders: nock.Options['reqheaders'] = {}) 
     ...reqHeaders,
   });
 }
-
-/**
- * Mocks the fetch call to ReadMe API v2's OpenAPI spec.
- */
-export const oasFetchMock = (status = 200) => getAPIv2Mock().get('/openapi.json').reply(status, readmeAPIv2Oas);

--- a/__tests__/lib/fetch.test.ts
+++ b/__tests__/lib/fetch.test.ts
@@ -4,7 +4,7 @@ import { describe, beforeEach, afterEach, it, expect, vi, type MockInstance } fr
 import pkg from '../../package.json' with { type: 'json' };
 import DocsUploadCommand from '../../src/commands/docs/upload.js';
 import { cleanAPIv1Headers, fetchSchema, handleAPIv1Res, readmeAPIv1Fetch } from '../../src/lib/readmeAPIFetch.js';
-import { getAPIv1Mock, oasFetchMock } from '../helpers/get-api-mock.js';
+import { getAPIv1Mock } from '../helpers/get-api-mock.js';
 import { githubActionsEnv } from '../helpers/git-mock.js';
 import { setupOclifConfig } from '../helpers/oclif.js';
 
@@ -378,26 +378,10 @@ describe('#cleanAPIv1Headers()', () => {
 
 describe('#fetchSchema', () => {
   it('should fetch the schema', async () => {
-    const mock = oasFetchMock();
-
     const oclifConfig = await setupOclifConfig();
     const command = new DocsUploadCommand([], oclifConfig);
-    const schema = await fetchSchema.call(command);
+    const schema = fetchSchema.call(command);
 
     expect(schema.type).toBe('object');
-
-    mock.done();
-  });
-
-  it('should have a fallback value in case fetch fails', async () => {
-    const mock = oasFetchMock(500);
-
-    const oclifConfig = await setupOclifConfig();
-    const command = new DocsUploadCommand([], oclifConfig);
-    const schema = await fetchSchema.call(command);
-
-    expect(schema.type).toBe('object');
-
-    mock.done();
   });
 });

--- a/__tests__/lib/frontmatter.test.ts
+++ b/__tests__/lib/frontmatter.test.ts
@@ -1,5 +1,4 @@
 import type { PageMetadata } from '../../src/lib/readPage.js';
-import type nock from 'nock';
 import type { SchemaObject } from 'oas/types';
 
 import fs from 'node:fs';
@@ -9,23 +8,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import DocsUploadCommand from '../../src/commands/docs/upload.js';
 import { fix, writeFixes } from '../../src/lib/frontmatter.js';
 import { emptyMappings, fetchSchema } from '../../src/lib/readmeAPIFetch.js';
-import { oasFetchMock } from '../helpers/get-api-mock.js';
 import { setupOclifConfig } from '../helpers/oclif.js';
 
 describe('#fix', () => {
   let command: DocsUploadCommand;
-  let mock: nock.Scope;
   let schema: SchemaObject;
 
   beforeEach(async () => {
     const oclifConfig = await setupOclifConfig();
     command = new DocsUploadCommand([], oclifConfig);
-    mock = oasFetchMock();
-    schema = await fetchSchema.call(command);
-  });
-
-  afterEach(() => {
-    mock.done();
+    schema = fetchSchema.call(command);
   });
 
   it('should do nothing for an empty object', () => {

--- a/src/lib/readmeAPIFetch.ts
+++ b/src/lib/readmeAPIFetch.ts
@@ -481,28 +481,7 @@ export async function fetchMappings(this: CommandClass['prototype']): Promise<Ma
 /**
  * Fetches the schema for the current route from the OpenAPI description for ReadMe API v2.
  */
-export async function fetchSchema(this: APIv2PageCommands) {
-  const oas = await this.readmeAPIFetch('/openapi.json')
-    .then(res => {
-      if (!res.ok) {
-        this.debug(`received the following error when attempting to fetch the readme OAS: ${res.status}`);
-        return readmeAPIv2Oas;
-      }
-      this.debug('received a successful response when fetching schema');
-      return res.json() as Promise<typeof readmeAPIv2Oas>;
-    })
-    .catch(e => {
-      this.debug(`error fetching readme OAS: ${e}`);
-      return readmeAPIv2Oas;
-    });
-
-  const requestBody = oas.paths?.[`/branches/{branch}/${this.route}/{slug}`]?.patch?.requestBody;
-
-  if (requestBody && 'content' in requestBody) {
-    return requestBody.content['application/json'].schema;
-  }
-
-  this.debug(`unable to find parse out schema for ${JSON.stringify(oas)}`);
+export function fetchSchema(this: APIv2PageCommands) {
   return readmeAPIv2Oas.paths[`/branches/{branch}/${this.route}/{slug}`].patch.requestBody.content['application/json']
     .schema satisfies SchemaObject;
 }

--- a/src/lib/validateFrontmatter.ts
+++ b/src/lib/validateFrontmatter.ts
@@ -25,7 +25,7 @@ export async function validateFrontmatter(
 
   const validationSpinner = ora({ ...oraOptions() }).start('🔬 Validating frontmatter data...');
 
-  const schema = await fetchSchema.call(this);
+  const schema = fetchSchema.call(this);
   const mappings = await fetchMappings.call(this);
 
   // validate the files, prompt user to fix if necessary


### PR DESCRIPTION
## 🧰 Changes

the endpoint for fetching OAS most likely isn't happening any time soon so this removes that in favor of relying on our git-tracked openapi file.

## 🧬 QA & Testing

do tests still pass?
