### PR TITLE
chore: knip config cleanup

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -1,7 +1,7 @@
 import type { KnipConfig } from 'knip';
 
 const config: KnipConfig = {
-  entry: ['src/index.ts', 'src/types.ts', 'src/utils.ts', 'src/lib/help.ts', 'bin/*.js'],
+  entry: ['bin/dev.js', 'bin/set-major-version-tag.js', 'src/lib/help.ts'],
   ignore: ['dist-gha/**'],
   // we're choosing not to include semantic release deps in our main dev-deps
   // since we're only using it in CI


### PR DESCRIPTION
## 🧰 Changes

[knip](https://knip.dev/) (a super powerful tool that we use in our lint step for catching dead code) pointed out a few bits of superfluous config (since these file are already defined [as entry points in the `package.json` file's `exports` property](https://github.com/readmeio/rdme/blob/013a2ea66c638f044720b1b975597d3c65e49390/package.json#L35-L39):

![CleanShot 2025-06-24 at 14 17 17@2x](https://github.com/user-attachments/assets/129b2f26-118d-4144-8e14-c023762bb424)

this PR cleans that up a bit!

## 🧬 QA & Testing

the knip warnings are now gone:

![CleanShot 2025-06-24 at 14 19 58@2x](https://github.com/user-attachments/assets/5aee7a02-799f-436e-990d-871761cdc667)

