### PR TITLE
docs: initial docs for all page upload commands, property DRY

### DIFF
--- a/documentation/commands/changelog.md
+++ b/documentation/commands/changelog.md
@@ -1,0 +1,53 @@
+`rdme changelog`
+================
+
+Upload Markdown files to the Changelog section of your ReadMe project.
+
+NOTE: This command is in an experimental alpha and is likely to change. Use at your own risk!
+
+* [`rdme changelog upload PATH`](#rdme-changelog-upload-path)
+
+## `rdme changelog upload PATH`
+
+Upload Markdown files to the Changelog section of your ReadMe project.
+
+```
+USAGE
+  $ rdme changelog upload PATH --key <value> [--dry-run]
+
+ARGUMENTS
+  PATH  Path to a local Markdown file or folder of Markdown files.
+
+FLAGS
+  --key=<value>  (required) ReadMe project API key
+  --dry-run      Runs the command without creating nor updating any Changelog entries in ReadMe. Useful for debugging.
+
+DESCRIPTION
+  Upload Markdown files to the Changelog section of your ReadMe project.
+
+  NOTE: This command is in an experimental alpha and is likely to change. Use at your own risk!
+
+  The path can either be a directory or a single Markdown file. The Markdown files will require YAML frontmatter with
+  certain ReadMe documentation attributes. Check out our docs for more info on setting up your frontmatter:
+  https://docs.readme.com/main/docs/rdme#markdown-file-setup
+
+EXAMPLES
+  The path input can be a directory. This will also upload any Markdown files that are located in subdirectories:
+
+    $ rdme changelog upload documentation/
+
+  The path input can also be individual Markdown files:
+
+    $ rdme changelog upload documentation/about.md
+
+  This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about
+  dry run mode in our docs: https://docs.readme.com/main/docs/rdme#dry-run-mode
+
+    $ rdme changelog upload [path] --dry-run
+
+FLAG DESCRIPTIONS
+  --key=<value>  ReadMe project API key
+
+    An API key for your ReadMe project. Note that API authentication is required despite being omitted from the example
+    usage. See our docs for more information: https://github.com/readmeio/rdme/tree/v10#authentication
+```

--- a/documentation/commands/changelog.md
+++ b/documentation/commands/changelog.md
@@ -3,11 +3,17 @@
 
 Upload Markdown files to the Changelog section of your ReadMe project.
 
-NOTE: This command is in an experimental alpha and is likely to change. Use at your own risk!
-
 * [`rdme changelog upload PATH`](#rdme-changelog-upload-path)
 
 ## `rdme changelog upload PATH`
+
+> [!WARNING]
+> This command is in an experimental alpha and is likely to change. Use at your own risk!
+
+<details>
+
+
+<summary>I understand the risks — let's see the docs!</summary>
 
 Upload Markdown files to the Changelog section of your ReadMe project.
 
@@ -51,3 +57,6 @@ FLAG DESCRIPTIONS
     An API key for your ReadMe project. Note that API authentication is required despite being omitted from the example
     usage. See our docs for more information: https://github.com/readmeio/rdme/tree/v10#authentication
 ```
+
+
+</details>

--- a/documentation/commands/custompages.md
+++ b/documentation/commands/custompages.md
@@ -1,0 +1,62 @@
+`rdme custompages`
+==================
+
+Upload Markdown or HTML files to the Custom Pages section of your ReadMe project.
+
+NOTE: This command is in an experimental alpha and is likely to change. Use at your own risk!
+
+* [`rdme custompages upload PATH`](#rdme-custompages-upload-path)
+
+## `rdme custompages upload PATH`
+
+Upload Markdown or HTML files to the Custom Pages section of your ReadMe project.
+
+```
+USAGE
+  $ rdme custompages upload PATH --key <value> [--branch <value>] [--dry-run]
+
+ARGUMENTS
+  PATH  Path to a local Markdown/HTML file or folder of Markdown/HTML files.
+
+FLAGS
+  --key=<value>     (required) ReadMe project API key
+  --branch=<value>  [default: stable] ReadMe project version
+  --dry-run         Runs the command without creating nor updating any custom pages in ReadMe. Useful for debugging.
+
+DESCRIPTION
+  Upload Markdown or HTML files to the Custom Pages section of your ReadMe project.
+
+  NOTE: This command is in an experimental alpha and is likely to change. Use at your own risk!
+
+  The path can either be a directory or a single Markdown or HTML file. The files will require YAML frontmatter with
+  certain ReadMe documentation attributes. Check out our docs for more info on setting up your frontmatter:
+  https://docs.readme.com/main/docs/rdme#markdown-file-setup
+
+EXAMPLES
+  The path input can be a directory. This will also upload any Markdown/HTML files that are located in subdirectories:
+
+    $ rdme custompages upload documentation/ --branch={project-branch}
+
+  The path input can also be individual Markdown/HTML files:
+
+    $ rdme custompages upload documentation/about.md --branch={project-branch}
+
+  You can omit the `--branch` flag to default to the `stable` branch of your project:
+
+    $ rdme custompages upload [path]
+
+  This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about
+  dry run mode in our docs: https://docs.readme.com/main/docs/rdme#dry-run-mode
+
+    $ rdme custompages upload [path] --dry-run
+
+FLAG DESCRIPTIONS
+  --key=<value>  ReadMe project API key
+
+    An API key for your ReadMe project. Note that API authentication is required despite being omitted from the example
+    usage. See our docs for more information: https://github.com/readmeio/rdme/tree/v10#authentication
+
+  --branch=<value>  ReadMe project version
+
+    Defaults to `stable` (i.e., your main project version).
+```

--- a/documentation/commands/custompages.md
+++ b/documentation/commands/custompages.md
@@ -34,9 +34,9 @@ DESCRIPTION
 
   NOTE: This command is in an experimental alpha and is likely to change. Use at your own risk!
 
-  The path can either be a directory or a single Markdown or HTML file. The files will require YAML frontmatter with
-  certain ReadMe documentation attributes. Check out our docs for more info on setting up your frontmatter:
-  https://docs.readme.com/main/docs/rdme#markdown-file-setup
+  The path can either be a directory or a single Markdown/HTML file. The Markdown/HTML files will require YAML
+  frontmatter with certain ReadMe documentation attributes. Check out our docs for more info on setting up your
+  frontmatter: https://docs.readme.com/main/docs/rdme#markdown-file-setup
 
 EXAMPLES
   The path input can be a directory. This will also upload any Markdown/HTML files that are located in subdirectories:

--- a/documentation/commands/custompages.md
+++ b/documentation/commands/custompages.md
@@ -3,11 +3,17 @@
 
 Upload Markdown or HTML files to the Custom Pages section of your ReadMe project.
 
-NOTE: This command is in an experimental alpha and is likely to change. Use at your own risk!
-
 * [`rdme custompages upload PATH`](#rdme-custompages-upload-path)
 
 ## `rdme custompages upload PATH`
+
+> [!WARNING]
+> This command is in an experimental alpha and is likely to change. Use at your own risk!
+
+<details>
+
+
+<summary>I understand the risks — let's see the docs!</summary>
 
 Upload Markdown or HTML files to the Custom Pages section of your ReadMe project.
 
@@ -60,3 +66,6 @@ FLAG DESCRIPTIONS
 
     Defaults to `stable` (i.e., your main project version).
 ```
+
+
+</details>

--- a/documentation/commands/docs.md
+++ b/documentation/commands/docs.md
@@ -27,7 +27,7 @@ ARGUMENTS
 FLAGS
   --key=<value>     (required) ReadMe project API key
   --branch=<value>  [default: stable] ReadMe project version
-  --dry-run         Runs the command without creating nor updating any Guides in ReadMe. Useful for debugging.
+  --dry-run         Runs the command without creating nor updating any guides in ReadMe. Useful for debugging.
 
 DESCRIPTION
   Upload Markdown files to the Guides section of your ReadMe project.

--- a/documentation/commands/reference.md
+++ b/documentation/commands/reference.md
@@ -1,0 +1,60 @@
+`rdme reference`
+================
+
+Upload Markdown files to the Reference section of your ReadMe project.
+
+* [`rdme reference upload PATH`](#rdme-reference-upload-path)
+
+## `rdme reference upload PATH`
+
+Upload Markdown files to the Reference section of your ReadMe project.
+
+```
+USAGE
+  $ rdme reference upload PATH --key <value> [--branch <value>] [--dry-run]
+
+ARGUMENTS
+  PATH  Path to a local Markdown file or folder of Markdown files.
+
+FLAGS
+  --key=<value>     (required) ReadMe project API key
+  --branch=<value>  [default: stable] ReadMe project version
+  --dry-run         Runs the command without creating nor updating any reference pages in ReadMe. Useful for debugging.
+
+DESCRIPTION
+  Upload Markdown files to the Reference section of your ReadMe project.
+
+  NOTE: This command is in an experimental alpha and is likely to change. Use at your own risk!
+
+  The path can either be a directory or a single Markdown file. The Markdown files will require YAML frontmatter with
+  certain ReadMe documentation attributes. Check out our docs for more info on setting up your frontmatter:
+  https://docs.readme.com/main/docs/rdme#markdown-file-setup
+
+EXAMPLES
+  The path input can be a directory. This will also upload any Markdown files that are located in subdirectories:
+
+    $ rdme reference upload documentation/ --branch={project-branch}
+
+  The path input can also be individual Markdown files:
+
+    $ rdme reference upload documentation/about.md --branch={project-branch}
+
+  You can omit the `--branch` flag to default to the `stable` branch of your project:
+
+    $ rdme reference upload [path]
+
+  This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about
+  dry run mode in our docs: https://docs.readme.com/main/docs/rdme#dry-run-mode
+
+    $ rdme reference upload [path] --dry-run
+
+FLAG DESCRIPTIONS
+  --key=<value>  ReadMe project API key
+
+    An API key for your ReadMe project. Note that API authentication is required despite being omitted from the example
+    usage. See our docs for more information: https://github.com/readmeio/rdme/tree/v10#authentication
+
+  --branch=<value>  ReadMe project version
+
+    Defaults to `stable` (i.e., your main project version).
+```

--- a/documentation/commands/reference.md
+++ b/documentation/commands/reference.md
@@ -7,6 +7,14 @@ Upload Markdown files to the Reference section of your ReadMe project.
 
 ## `rdme reference upload PATH`
 
+> [!WARNING]
+> This command is in an experimental alpha and is likely to change. Use at your own risk!
+
+<details>
+
+
+<summary>I understand the risks — let's see the docs!</summary>
+
 Upload Markdown files to the Reference section of your ReadMe project.
 
 ```
@@ -58,3 +66,6 @@ FLAG DESCRIPTIONS
 
     Defaults to `stable` (i.e., your main project version).
 ```
+
+
+</details>

--- a/src/commands/changelog/upload.ts
+++ b/src/commands/changelog/upload.ts
@@ -1,8 +1,7 @@
-import { Args, Flags } from '@oclif/core';
-
 import BaseCommand from '../../lib/baseCommand.js';
-import { confirmAutofixesFlag, keyFlag } from '../../lib/flags.js';
-import syncPagePath, { type FullUploadResults, } from '../../lib/syncPagePath.js';
+import { keyFlag } from '../../lib/flags.js';
+import { args, baseFlags, description, examples, summary } from '../../lib/pageCommandProperties.js';
+import syncPagePath, { type FullUploadResults } from '../../lib/syncPagePath.js';
 
 const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
 
@@ -11,60 +10,19 @@ export default class ChangelogUploadCommand extends BaseCommand<typeof Changelog
 
   route = 'changelogs' as const;
 
+  static section = 'Changelog' as const;
+
   static hidden = true;
 
-  static summary = `Upload Markdown files to the Changelog section of your ReadMe project.\n\nNOTE: ${alphaNotice}`;
+  static summary = summary(this.section);
 
-  static description =
-    'The path can either be a directory or a single Markdown file. The Markdown files will require YAML frontmatter with certain ReadMe documentation attributes. Check out our docs for more info on setting up your frontmatter: https://docs.readme.com/main/docs/rdme#markdown-file-setup';
+  static description = description(this.section);
 
-  static args = {
-    path: Args.string({ description: 'Path to a local Markdown file or folder of Markdown files.', required: true }),
-  };
+  static args = args(this.section);
 
-  static examples = [
-    {
-      description:
-        'The path input can be a directory. This will also upload any Markdown files that are located in subdirectories:',
-      command: '<%= config.bin %> <%= command.id %> documentation/',
-    },
-    {
-      description: 'The path input can also be individual Markdown files:',
-      command: '<%= config.bin %> <%= command.id %> documentation/about.md',
-    },
-    {
-      description:
-        'This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about dry run mode in our docs: https://docs.readme.com/main/docs/rdme#dry-run-mode',
-      command: '<%= config.bin %> <%= command.id %> [path] --dry-run',
-    },
-  ];
+  static examples = examples(this.section);
 
-  static flags = {
-    key: keyFlag,
-    'confirm-autofixes': confirmAutofixesFlag,
-    'dry-run': Flags.boolean({
-      description:
-        'Runs the command without creating nor updating any Changelog entries in ReadMe. Useful for debugging.',
-      aliases: ['dryRun'],
-      deprecateAliases: true,
-    }),
-    'hide-experimental-warning': Flags.boolean({
-      description: 'Hides the warning message about this command being in an experimental alpha.',
-      hidden: true,
-    }),
-    'max-errors': Flags.integer({
-      summary: 'Maximum number of page uploading errors before the command throws an error.',
-      description:
-        'By default, this command will respond with a 1 exit code if any number of the Markdown files fail to upload. This flag allows you to set a maximum number of errors before the command fails. For example, if you set this flag to `5`, the command will respond with an error if 5 or more errors are encountered. If you do not want the command to fail under any circumstances (this could be useful for plugins where you want to handle the error handling yourself), set this flag to `-1`.',
-      default: 0,
-      hidden: true,
-    }),
-    'skip-validation': Flags.boolean({
-      description:
-        'Skips the pre-upload validation of the Markdown files. This flag can be a useful escape hatch but its usage is not recommended.',
-      hidden: true,
-    }),
-  };
+  static flags = { key: keyFlag, ...baseFlags(this.section) };
 
   async run(): Promise<FullUploadResults> {
     if (!this.flags['hide-experimental-warning']) {

--- a/src/commands/changelog/upload.ts
+++ b/src/commands/changelog/upload.ts
@@ -2,12 +2,7 @@ import { Args, Flags } from '@oclif/core';
 
 import BaseCommand from '../../lib/baseCommand.js';
 import { confirmAutofixesFlag, keyFlag } from '../../lib/flags.js';
-import syncPagePath, {
-  type FailedPushResult,
-  type SkippedPushResult,
-  type CreatePushResult,
-  type UpdatePushResult,
-} from '../../lib/syncPagePath.js';
+import syncPagePath, { type FullUploadResults, } from '../../lib/syncPagePath.js';
 
 const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
 
@@ -71,12 +66,7 @@ export default class ChangelogUploadCommand extends BaseCommand<typeof Changelog
     }),
   };
 
-  async run(): Promise<{
-    created: CreatePushResult[];
-    failed: FailedPushResult[];
-    skipped: SkippedPushResult[];
-    updated: UpdatePushResult[];
-  }> {
+  async run(): Promise<FullUploadResults> {
     if (!this.flags['hide-experimental-warning']) {
       this.warn(alphaNotice);
     }

--- a/src/commands/custompages/upload.ts
+++ b/src/commands/custompages/upload.ts
@@ -1,7 +1,6 @@
-import { Args, Flags } from '@oclif/core';
-
 import BaseCommand from '../../lib/baseCommand.js';
-import { branchFlag, confirmAutofixesFlag, keyFlag } from '../../lib/flags.js';
+import { branchFlag, keyFlag } from '../../lib/flags.js';
+import { args, baseFlags, description, examples, summary } from '../../lib/pageCommandProperties.js';
 import syncPagePath, { type FullUploadResults } from '../../lib/syncPagePath.js';
 
 const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
@@ -11,67 +10,19 @@ export default class CustomPagesUploadCommand extends BaseCommand<typeof CustomP
 
   route = 'custom_pages' as const;
 
+  static section = 'Custom Pages' as const;
+
   static hidden = true;
 
-  static summary = `Upload Markdown or HTML files to the Custom Pages section of your ReadMe project.\n\nNOTE: ${alphaNotice}`;
+  static summary = summary(this.section);
 
-  static description =
-    'The path can either be a directory or a single Markdown or HTML file. The files will require YAML frontmatter with certain ReadMe documentation attributes. Check out our docs for more info on setting up your frontmatter: https://docs.readme.com/main/docs/rdme#markdown-file-setup';
+  static description = description(this.section);
 
-  static args = {
-    path: Args.string({
-      description: 'Path to a local Markdown/HTML file or folder of Markdown/HTML files.',
-      required: true,
-    }),
-  };
+  static args = args(this.section);
 
-  static examples = [
-    {
-      description:
-        'The path input can be a directory. This will also upload any Markdown/HTML files that are located in subdirectories:',
-      command: '<%= config.bin %> <%= command.id %> documentation/ --branch={project-branch}',
-    },
-    {
-      description: 'The path input can also be individual Markdown/HTML files:',
-      command: '<%= config.bin %> <%= command.id %> documentation/about.md --branch={project-branch}',
-    },
-    {
-      description: 'You can omit the `--branch` flag to default to the `stable` branch of your project:',
-      command: '<%= config.bin %> <%= command.id %> [path]',
-    },
-    {
-      description:
-        'This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about dry run mode in our docs: https://docs.readme.com/main/docs/rdme#dry-run-mode',
-      command: '<%= config.bin %> <%= command.id %> [path] --dry-run',
-    },
-  ];
+  static examples = examples(this.section);
 
-  static flags = {
-    key: keyFlag,
-    ...branchFlag(),
-    'confirm-autofixes': confirmAutofixesFlag,
-    'dry-run': Flags.boolean({
-      description: 'Runs the command without creating nor updating any custom pages in ReadMe. Useful for debugging.',
-      aliases: ['dryRun'],
-      deprecateAliases: true,
-    }),
-    'hide-experimental-warning': Flags.boolean({
-      description: 'Hides the warning message about this command being in an experimental alpha.',
-      hidden: true,
-    }),
-    'max-errors': Flags.integer({
-      summary: 'Maximum number of page uploading errors before the command throws an error.',
-      description:
-        'By default, this command will respond with a 1 exit code if any number of the Markdown files fail to upload. This flag allows you to set a maximum number of errors before the command fails. For example, if you set this flag to `5`, the command will respond with an error if 5 or more errors are encountered. If you do not want the command to fail under any circumstances (this could be useful for plugins where you want to handle the error handling yourself), set this flag to `-1`.',
-      default: 0,
-      hidden: true,
-    }),
-    'skip-validation': Flags.boolean({
-      description:
-        'Skips the pre-upload validation of the Markdown/HTML files. This flag can be a useful escape hatch but its usage is not recommended.',
-      hidden: true,
-    }),
-  };
+  static flags = { key: keyFlag, ...branchFlag(), ...baseFlags(this.section) };
 
   async run(): Promise<FullUploadResults> {
     if (!this.flags['hide-experimental-warning']) {

--- a/src/commands/custompages/upload.ts
+++ b/src/commands/custompages/upload.ts
@@ -2,12 +2,7 @@ import { Args, Flags } from '@oclif/core';
 
 import BaseCommand from '../../lib/baseCommand.js';
 import { branchFlag, confirmAutofixesFlag, keyFlag } from '../../lib/flags.js';
-import syncPagePath, {
-  type FailedPushResult,
-  type SkippedPushResult,
-  type CreatePushResult,
-  type UpdatePushResult,
-} from '../../lib/syncPagePath.js';
+import syncPagePath, { type FullUploadResults } from '../../lib/syncPagePath.js';
 
 const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
 
@@ -78,12 +73,7 @@ export default class CustomPagesUploadCommand extends BaseCommand<typeof CustomP
     }),
   };
 
-  async run(): Promise<{
-    created: CreatePushResult[];
-    failed: FailedPushResult[];
-    skipped: SkippedPushResult[];
-    updated: UpdatePushResult[];
-  }> {
+  async run(): Promise<FullUploadResults> {
     if (!this.flags['hide-experimental-warning']) {
       this.warn(alphaNotice);
     }

--- a/src/commands/docs/migrate.ts
+++ b/src/commands/docs/migrate.ts
@@ -6,9 +6,9 @@ import ora from 'ora';
 import { dir } from 'tmp-promise';
 
 import BaseCommand from '../../lib/baseCommand.js';
-import { confirmAutofixesFlag } from '../../lib/flags.js';
 import { writeFixes } from '../../lib/frontmatter.js';
 import { oraOptions } from '../../lib/logger.js';
+import { baseFlags } from '../../lib/pageCommandProperties.js';
 import { findPages } from '../../lib/readPage.js';
 import { attemptUnzip } from '../../lib/unzip.js';
 import { validateFrontmatter } from '../../lib/validateFrontmatter.js';
@@ -32,18 +32,13 @@ export default class DocsMigrateCommand extends BaseCommand<typeof DocsMigrateCo
   };
 
   static flags = {
-    'confirm-autofixes': confirmAutofixesFlag,
-    'hide-experimental-warning': Flags.boolean({
-      description: 'Hides the warning message about this command being in an experimental alpha.',
-      hidden: true,
-    }),
     out: Flags.string({
       summary: 'The directory to write the migration output to. Defaults to a temporary directory.',
     }),
-    'skip-validation': Flags.boolean({
-      description:
-        'Skips the validation of the Markdown files. Useful if this command is as part of a chain of commands that includes `docs upload`.',
-    }),
+    // NOTE: the `baseFlags` function contains a handful of properties (e.g., `dry-run`, `max-errors`)
+    // that aren't actually used in this command, but are included for consistency/simplicity
+    // since this command is purely for internal use.
+    ...baseFlags('Guides'),
   };
 
   async run(): Promise<{ outputDir: string; stats: MigrationStats }> {

--- a/src/commands/docs/upload.ts
+++ b/src/commands/docs/upload.ts
@@ -1,74 +1,26 @@
-import { Args, Flags } from '@oclif/core';
-
 import BaseCommand from '../../lib/baseCommand.js';
-import { branchFlag, confirmAutofixesFlag, keyFlag } from '../../lib/flags.js';
+import { branchFlag, keyFlag } from '../../lib/flags.js';
+import { args, description, examples, baseFlags, summary, alphaNotice } from '../../lib/pageCommandProperties.js';
 import syncPagePath, { type FullUploadResults } from '../../lib/syncPagePath.js';
-
-const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
 
 export default class DocsUploadCommand extends BaseCommand<typeof DocsUploadCommand> {
   id = 'docs upload' as const;
 
   route = 'guides' as const;
 
+  static section = 'Guides' as const;
+
   static hidden = true;
 
-  static summary = `Upload Markdown files to the Guides section of your ReadMe project.\n\nNOTE: ${alphaNotice}`;
+  static summary = summary(this.section);
 
-  static description =
-    'The path can either be a directory or a single Markdown file. The Markdown files will require YAML frontmatter with certain ReadMe documentation attributes. Check out our docs for more info on setting up your frontmatter: https://docs.readme.com/main/docs/rdme#markdown-file-setup';
+  static description = description(this.section);
 
-  static args = {
-    path: Args.string({ description: 'Path to a local Markdown file or folder of Markdown files.', required: true }),
-  };
+  static args = args(this.section);
 
-  static examples = [
-    {
-      description:
-        'The path input can be a directory. This will also upload any Markdown files that are located in subdirectories:',
-      command: '<%= config.bin %> <%= command.id %> documentation/ --branch={project-branch}',
-    },
-    {
-      description: 'The path input can also be individual Markdown files:',
-      command: '<%= config.bin %> <%= command.id %> documentation/about.md --branch={project-branch}',
-    },
-    {
-      description: 'You can omit the `--branch` flag to default to the `stable` branch of your project:',
-      command: '<%= config.bin %> <%= command.id %> [path]',
-    },
-    {
-      description:
-        'This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about dry run mode in our docs: https://docs.readme.com/main/docs/rdme#dry-run-mode',
-      command: '<%= config.bin %> <%= command.id %> [path] --dry-run',
-    },
-  ];
+  static examples = examples(this.section);
 
-  static flags = {
-    key: keyFlag,
-    ...branchFlag(),
-    'confirm-autofixes': confirmAutofixesFlag,
-    'dry-run': Flags.boolean({
-      description: 'Runs the command without creating nor updating any Guides in ReadMe. Useful for debugging.',
-      aliases: ['dryRun'],
-      deprecateAliases: true,
-    }),
-    'hide-experimental-warning': Flags.boolean({
-      description: 'Hides the warning message about this command being in an experimental alpha.',
-      hidden: true,
-    }),
-    'max-errors': Flags.integer({
-      summary: 'Maximum number of page uploading errors before the command throws an error.',
-      description:
-        'By default, this command will respond with a 1 exit code if any number of the Markdown files fail to upload. This flag allows you to set a maximum number of errors before the command fails. For example, if you set this flag to `5`, the command will respond with an error if 5 or more errors are encountered. If you do not want the command to fail under any circumstances (this could be useful for plugins where you want to handle the error handling yourself), set this flag to `-1`.',
-      default: 0,
-      hidden: true,
-    }),
-    'skip-validation': Flags.boolean({
-      description:
-        'Skips the pre-upload validation of the Markdown files. This flag can be a useful escape hatch but its usage is not recommended.',
-      hidden: true,
-    }),
-  };
+  static flags = { key: keyFlag, ...branchFlag(), ...baseFlags(this.section) };
 
   async run(): Promise<FullUploadResults> {
     if (!this.flags['hide-experimental-warning']) {

--- a/src/commands/docs/upload.ts
+++ b/src/commands/docs/upload.ts
@@ -2,12 +2,7 @@ import { Args, Flags } from '@oclif/core';
 
 import BaseCommand from '../../lib/baseCommand.js';
 import { branchFlag, confirmAutofixesFlag, keyFlag } from '../../lib/flags.js';
-import syncPagePath, {
-  type FailedPushResult,
-  type SkippedPushResult,
-  type CreatePushResult,
-  type UpdatePushResult,
-} from '../../lib/syncPagePath.js';
+import syncPagePath, { type FullUploadResults } from '../../lib/syncPagePath.js';
 
 const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
 
@@ -75,12 +70,7 @@ export default class DocsUploadCommand extends BaseCommand<typeof DocsUploadComm
     }),
   };
 
-  async run(): Promise<{
-    created: CreatePushResult[];
-    failed: FailedPushResult[];
-    skipped: SkippedPushResult[];
-    updated: UpdatePushResult[];
-  }> {
+  async run(): Promise<FullUploadResults> {
     if (!this.flags['hide-experimental-warning']) {
       this.warn(alphaNotice);
     }

--- a/src/commands/reference/upload.ts
+++ b/src/commands/reference/upload.ts
@@ -2,12 +2,7 @@ import { Args, Flags } from '@oclif/core';
 
 import BaseCommand from '../../lib/baseCommand.js';
 import { branchFlag, confirmAutofixesFlag, keyFlag } from '../../lib/flags.js';
-import syncPagePath, {
-  type FailedPushResult,
-  type SkippedPushResult,
-  type CreatePushResult,
-  type UpdatePushResult,
-} from '../../lib/syncPagePath.js';
+import syncPagePath, { type FullUploadResults } from '../../lib/syncPagePath.js';
 
 const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
 
@@ -76,12 +71,7 @@ export default class RefUploadCommand extends BaseCommand<typeof RefUploadComman
     }),
   };
 
-  async run(): Promise<{
-    created: CreatePushResult[];
-    failed: FailedPushResult[];
-    skipped: SkippedPushResult[];
-    updated: UpdatePushResult[];
-  }> {
+  async run(): Promise<FullUploadResults> {
     if (!this.flags['hide-experimental-warning']) {
       this.warn(alphaNotice);
     }

--- a/src/commands/reference/upload.ts
+++ b/src/commands/reference/upload.ts
@@ -1,7 +1,6 @@
-import { Args, Flags } from '@oclif/core';
-
 import BaseCommand from '../../lib/baseCommand.js';
-import { branchFlag, confirmAutofixesFlag, keyFlag } from '../../lib/flags.js';
+import { branchFlag, keyFlag } from '../../lib/flags.js';
+import { args, baseFlags, description, examples, summary } from '../../lib/pageCommandProperties.js';
 import syncPagePath, { type FullUploadResults } from '../../lib/syncPagePath.js';
 
 const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
@@ -11,65 +10,19 @@ export default class RefUploadCommand extends BaseCommand<typeof RefUploadComman
 
   route = 'reference' as const;
 
+  static section = 'Reference' as const;
+
   static hidden = true;
 
-  static summary = `Upload Markdown files to the Reference section of your ReadMe project.\n\nNOTE: ${alphaNotice}`;
+  static summary = summary(this.section);
 
-  static description =
-    'The path can either be a directory or a single Markdown file. The Markdown files will require YAML frontmatter with certain ReadMe documentation attributes. Check out our docs for more info on setting up your frontmatter: https://docs.readme.com/main/docs/rdme#markdown-file-setup';
+  static description = description(this.section);
 
-  static args = {
-    path: Args.string({ description: 'Path to a local Markdown file or folder of Markdown files.', required: true }),
-  };
+  static args = args(this.section);
 
-  static examples = [
-    {
-      description:
-        'The path input can be a directory. This will also upload any Markdown files that are located in subdirectories:',
-      command: '<%= config.bin %> <%= command.id %> documentation/ --branch={project-branch}',
-    },
-    {
-      description: 'The path input can also be individual Markdown files:',
-      command: '<%= config.bin %> <%= command.id %> documentation/about.md --branch={project-branch}',
-    },
-    {
-      description: 'You can omit the `--branch` flag to default to the `stable` branch of your project:',
-      command: '<%= config.bin %> <%= command.id %> [path]',
-    },
-    {
-      description:
-        'This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about dry run mode in our docs: https://docs.readme.com/main/docs/rdme#dry-run-mode',
-      command: '<%= config.bin %> <%= command.id %> [path] --dry-run',
-    },
-  ];
+  static examples = examples(this.section);
 
-  static flags = {
-    key: keyFlag,
-    ...branchFlag(),
-    'confirm-autofixes': confirmAutofixesFlag,
-    'dry-run': Flags.boolean({
-      description:
-        'Runs the command without creating nor updating any reference pages in ReadMe. Useful for debugging.',
-      aliases: ['dryRun'],
-      deprecateAliases: true,
-    }),
-    'hide-experimental-warning': Flags.boolean({
-      description: 'Hides the warning message about this command being in an experimental alpha.',
-      hidden: true,
-    }),
-    'max-errors': Flags.integer({
-      summary: 'Maximum number of page uploading errors before the command throws an error.',
-      description:
-        'By default, this command will respond with a 1 exit code if any number of the Markdown files fail to upload. This flag allows you to set a maximum number of errors before the command fails. For example, if you set this flag to `5`, the command will respond with an error if 5 or more errors are encountered. If you do not want the command to fail under any circumstances (this could be useful for plugins where you want to handle the error handling yourself), set this flag to `-1`.',
-      default: 0,
-      hidden: true,
-    }),
-    'skip-validation': Flags.boolean({
-      description:
-        'Skips the pre-upload validation of the Markdown files. This flag can be a useful escape hatch but its usage is not recommended.',
-      hidden: true,
-    }),
-  };
+  static flags = { key: keyFlag, ...branchFlag(), ...baseFlags(this.section) };
 
   async run(): Promise<FullUploadResults> {
     if (!this.flags['hide-experimental-warning']) {

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -10,14 +10,6 @@ export const branchFlag = (additionalDescription: string[] = []) => ({
   }),
 });
 
-export const confirmAutofixesFlag = Flags.boolean({
-  hidden: true,
-  summary:
-    'Bypasses the prompt and automatically fixes up any autofixable errors that are found in the Markdown files.',
-  description:
-    'This is useful if you are using this command in a CI/CD pipeline and want to ensure that the command does not prompt for user input.',
-});
-
 /**
  * Used in any command where `github` is a `flag.
  */

--- a/src/lib/pageCommandProperties.ts
+++ b/src/lib/pageCommandProperties.ts
@@ -1,0 +1,97 @@
+import { Args, Flags } from '@oclif/core';
+
+type Section = 'Changelog' | 'Custom Pages' | 'Guides' | 'Reference';
+
+export const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
+
+export function summary(section: Section): string {
+  return `Upload Markdown files to the ${section} section of your ReadMe project.\n\nNOTE: ${alphaNotice}`;
+}
+
+export function description(section: Section): string {
+  const fileType = section === 'Custom Pages' ? 'Markdown/HTML' : 'Markdown';
+  return `The path can either be a directory or a single ${fileType} file. The ${fileType} files will require YAML frontmatter with certain ReadMe documentation attributes. Check out our docs for more info on setting up your frontmatter: https://docs.readme.com/main/docs/rdme#markdown-file-setup`;
+}
+
+export function args(section: Section) {
+  const fileType = section === 'Custom Pages' ? 'Markdown/HTML' : 'Markdown';
+  return {
+    path: Args.string({
+      description: `Path to a local ${fileType} file or folder of ${fileType} files.`,
+      required: true,
+    }),
+  };
+}
+
+export function examples(section: Section) {
+  const fileType = section === 'Custom Pages' ? 'Markdown/HTML' : 'Markdown';
+  return [
+    {
+      description: `The path input can be a directory. This will also upload any ${fileType} files that are located in subdirectories:`,
+      command: '<%= config.bin %> <%= command.id %> documentation/ --branch={project-branch}',
+    },
+    {
+      description: `The path input can also be individual ${fileType} files:`,
+      command: '<%= config.bin %> <%= command.id %> documentation/about.md --branch={project-branch}',
+    },
+    {
+      description: 'You can omit the `--branch` flag to default to the `stable` branch of your project:',
+      command: '<%= config.bin %> <%= command.id %> [path]',
+    },
+    {
+      description:
+        'This command also has a dry run mode, which can be useful for initial setup and debugging. You can read more about dry run mode in our docs: https://docs.readme.com/main/docs/rdme#dry-run-mode',
+      command: '<%= config.bin %> <%= command.id %> [path] --dry-run',
+    },
+  ];
+}
+
+export function baseFlags(section: Section) {
+  const fileType = section === 'Custom Pages' ? 'Markdown/HTML' : 'Markdown';
+  let items;
+
+  switch (section) {
+    case 'Changelog':
+      items = 'Changelog entries' as const;
+      break;
+    case 'Custom Pages':
+      items = 'custom pages' as const;
+      break;
+    case 'Guides':
+      items = 'guides' as const;
+      break;
+    case 'Reference':
+      items = 'reference pages' as const;
+      break;
+    default:
+      throw new Error(`Unknown section: ${section}`);
+  }
+
+  return {
+    'confirm-autofixes': Flags.boolean({
+      hidden: true,
+      summary: `Bypasses the prompt and automatically fixes up any autofixable errors that are found in the ${fileType} files.`,
+      description:
+        'This is useful if you are using this command in a CI/CD pipeline and want to ensure that the command does not prompt for user input.',
+    }),
+    'dry-run': Flags.boolean({
+      description: `Runs the command without creating nor updating any ${items} in ReadMe. Useful for debugging.`,
+      aliases: ['dryRun'],
+      deprecateAliases: true,
+    }),
+    'hide-experimental-warning': Flags.boolean({
+      description: 'Hides the warning message about this command being in an experimental alpha.',
+      hidden: true,
+    }),
+    'max-errors': Flags.integer({
+      summary: 'Maximum number of page uploading errors before the command throws an error.',
+      description: `By default, this command will respond with a 1 exit code if any number of the ${fileType} files fail to upload. This flag allows you to set a maximum number of errors before the command fails. For example, if you set this flag to \`5\`, the command will respond with an error if 5 or more errors are encountered. If you do not want the command to fail under any circumstances (this could be useful for plugins where you want to handle the error handling yourself), set this flag to \`-1\`.`,
+      default: 0,
+      hidden: true,
+    }),
+    'skip-validation': Flags.boolean({
+      description: `Skips the pre-upload validation of the ${fileType} files. This flag can be a useful escape hatch but its usage is not recommended.`,
+      hidden: true,
+    }),
+  };
+}

--- a/src/lib/pageCommandProperties.ts
+++ b/src/lib/pageCommandProperties.ts
@@ -5,7 +5,8 @@ type Section = 'Changelog' | 'Custom Pages' | 'Guides' | 'Reference';
 export const alphaNotice = 'This command is in an experimental alpha and is likely to change. Use at your own risk!';
 
 export function summary(section: Section): string {
-  return `Upload Markdown files to the ${section} section of your ReadMe project.\n\nNOTE: ${alphaNotice}`;
+  const fileType = section === 'Custom Pages' ? 'Markdown or HTML' : 'Markdown';
+  return `Upload ${fileType} files to the ${section} section of your ReadMe project.\n\nNOTE: ${alphaNotice}`;
 }
 
 export function description(section: Section): string {
@@ -25,14 +26,16 @@ export function args(section: Section) {
 
 export function examples(section: Section) {
   const fileType = section === 'Custom Pages' ? 'Markdown/HTML' : 'Markdown';
-  return [
+  const usesBranch = section !== 'Changelog';
+  const branchFlag = usesBranch ? ' --branch={project-branch}' : '';
+  const allExamples = [
     {
       description: `The path input can be a directory. This will also upload any ${fileType} files that are located in subdirectories:`,
-      command: '<%= config.bin %> <%= command.id %> documentation/ --branch={project-branch}',
+      command: `<%= config.bin %> <%= command.id %> documentation/${branchFlag}`,
     },
     {
       description: `The path input can also be individual ${fileType} files:`,
-      command: '<%= config.bin %> <%= command.id %> documentation/about.md --branch={project-branch}',
+      command: `<%= config.bin %> <%= command.id %> documentation/about.md${branchFlag}`,
     },
     {
       description: 'You can omit the `--branch` flag to default to the `stable` branch of your project:',
@@ -44,6 +47,12 @@ export function examples(section: Section) {
       command: '<%= config.bin %> <%= command.id %> [path] --dry-run',
     },
   ];
+
+  if (!usesBranch) {
+    // remove the third example since it uses the branch flag
+    allExamples.splice(2, 1);
+  }
+  return allExamples;
 }
 
 export function baseFlags(section: Section) {


### PR DESCRIPTION
## 🧰 Changes

this PR creates the initial documentation for all of the page upload commands. the documentation follows the format of [the `docs upload` documentation](https://github.com/readmeio/rdme/blob/next/documentation/commands/docs.md#rdme-docs-upload-path).

as part of this, i created a helper file to consolidate all of the command properties for these four commands, which should help with future command + documentation updates.

## 🧬 QA & Testing

do the docs look good? and do all tests still pass?
