### PR TITLE
fix(pages/upload): decouple autofixing and uploads

### DIFF
--- a/__tests__/commands/changelog/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/changelog/__snapshots__/upload.test.ts.snap
@@ -300,7 +300,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/changelog/mixed-docs/legacy-flag.md (1 issue)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme changelog upload\` to upload these files to ReadMe.
 ",
 }
 `;
@@ -413,7 +413,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/changelog/legacy-docs/autofixable.md (1 issue)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme changelog upload\` to upload these files to ReadMe.
 ",
 }
 `;
@@ -593,7 +593,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/changelog/legacy-docs/autofixable.md (1 issue)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme changelog upload\` to upload these files to ReadMe.
 ",
 }
 `;

--- a/__tests__/commands/changelog/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/changelog/__snapshots__/upload.test.ts.snap
@@ -106,11 +106,8 @@ exports[`rdme changelog upload > given that the file path is a directory > shoul
  ›    Use at your own risk!
 - 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/changelog/mixed-docs\` directory...
 ✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/changelog/mixed-docs\` directory... 5 file(s) found!
-- 🔬 Validating frontmatter data...
-⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
- ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
- ›   upload will proceed but we recommend addressing these issues. Please get 
- ›   in touch with us at support@readme.io if you need a hand.
+ ›   Warning: Skipping pre-upload validation of the Markdown file(s). This is 
+ ›   not recommended.
 - 🎭 Uploading files to ReadMe (but not really because it's a dry run)...
 ✖ 🎭 Uploading files to ReadMe (but not really because it's a dry run)... 2 file(s) failed.
 ",
@@ -134,11 +131,8 @@ exports[`rdme changelog upload > given that the file path is a directory > shoul
  ›    Use at your own risk!
 - 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/changelog/mixed-docs\` directory...
 ✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/changelog/mixed-docs\` directory... 5 file(s) found!
-- 🔬 Validating frontmatter data...
-⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
- ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
- ›   upload will proceed but we recommend addressing these issues. Please get 
- ›   in touch with us at support@readme.io if you need a hand.
+ ›   Warning: Skipping pre-upload validation of the Markdown file(s). This is 
+ ›   not recommended.
 - 🚀 Uploading files to ReadMe...
 ✖ 🚀 Uploading files to ReadMe... 2 file(s) failed.
 ",
@@ -200,11 +194,8 @@ exports[`rdme changelog upload > given that the file path is a directory > shoul
  ›    Use at your own risk!
 - 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/changelog/mixed-docs\` directory...
 ✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/changelog/mixed-docs\` directory... 5 file(s) found!
-- 🔬 Validating frontmatter data...
-⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
- ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
- ›   upload will proceed but we recommend addressing these issues. Please get 
- ›   in touch with us at support@readme.io if you need a hand.
+ ›   Warning: Skipping pre-upload validation of the Markdown file(s). This is 
+ ›   not recommended.
 - 🚀 Uploading files to ReadMe...
 ✖ 🚀 Uploading files to ReadMe... 2 file(s) failed.
 ",
@@ -217,6 +208,99 @@ exports[`rdme changelog upload > given that the file path is a directory > shoul
 🚨 Received errors when attempting to upload 2 page(s):
    - __tests__/__fixtures__/changelog/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
    - __tests__/__fixtures__/changelog/mixed-docs/simple-doc.md: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
+",
+}
+`;
+
+exports[`rdme changelog upload > given that the file path is a directory > should handle a mix of valid and invalid and autofixable files 1`] = `
+{
+  "result": {
+    "created": [],
+    "failed": [],
+    "skipped": [
+      {
+        "filePath": "__tests__/__fixtures__/changelog/mixed-docs/doc-sans-attributes.md",
+        "result": "skipped",
+        "slug": "doc-sans-attributes",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/changelog/mixed-docs/invalid-attributes.md",
+        "result": "skipped",
+        "slug": "invalid-attributes",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/changelog/mixed-docs/legacy-flag.md",
+        "result": "skipped",
+        "slug": "legacy-flag",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/changelog/mixed-docs/new-doc-slug.mdx",
+        "result": "skipped",
+        "slug": "some-slug",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/changelog/mixed-docs/simple-doc.md",
+        "result": "skipped",
+        "slug": "simple-doc",
+      },
+    ],
+    "updated": [],
+  },
+  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
+ ›    Use at your own risk!
+- 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/changelog/mixed-docs\` directory...
+✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/changelog/mixed-docs\` directory... 5 file(s) found!
+- 🔬 Validating frontmatter data...
+⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
+ ›   Warning: 1 file(s) have issues that cannot be fixed automatically. 
+ ›   Autofixable issues have been addressed but we also recommend addressing 
+ ›   these issues as well. Please get in touch with us at support@readme.io if 
+ ›   you need a hand.
+",
+  "stdout": "=== BEGIN writeFileSync to file: __tests__/__fixtures__/changelog/mixed-docs/doc-sans-attributes.md ===
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/changelog/mixed-docs/doc-sans-attributes.md ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/changelog/mixed-docs/invalid-attributes.md ===
+---
+type: false
+title: This is the changelog title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/changelog/mixed-docs/invalid-attributes.md ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/changelog/mixed-docs/legacy-flag.md ===
+---
+title: This is the changelog title
+privacy:
+  view: public
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/changelog/mixed-docs/legacy-flag.md ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/changelog/mixed-docs/new-doc-slug.mdx ===
+---
+title: This is the changelog title
+slug: some-slug
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/changelog/mixed-docs/new-doc-slug.mdx ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/changelog/mixed-docs/simple-doc.md ===
+---
+title: This is the changelog title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/changelog/mixed-docs/simple-doc.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/changelog/mixed-docs/legacy-flag.md (1 issue)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;
@@ -298,28 +382,38 @@ exports[`rdme changelog upload > given that the file path is a directory > shoul
 exports[`rdme changelog upload > given that the file path is a single file > and the command is being run in a CI environment > should bypass prompt if \`--confirm-autofixes\` flag is passed 1`] = `
 {
   "result": {
-    "created": [
+    "created": [],
+    "failed": [],
+    "skipped": [
       {
         "filePath": "__tests__/__fixtures__/changelog/legacy-docs/autofixable.md",
-        "response": {},
-        "result": "created",
+        "result": "skipped",
         "slug": "autofixable",
       },
     ],
-    "failed": [],
-    "skipped": [],
     "updated": [],
   },
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
  ›    Use at your own risk!
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
 ",
   "stdout": "Automatically fixing issues in 1 file(s)...
-🌱 Successfully created 1 page(s) in ReadMe:
-   - autofixable (__tests__/__fixtures__/changelog/legacy-docs/autofixable.md)
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/changelog/legacy-docs/autofixable.md ===
+---
+type: added
+title: This is the changelog title
+privacy:
+  view: anyone_with_link
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/changelog/legacy-docs/autofixable.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/changelog/legacy-docs/autofixable.md (1 issue)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;
@@ -466,30 +560,40 @@ exports[`rdme changelog upload > given that the file path is a single file > giv
 }
 `;
 
-exports[`rdme changelog upload > given that the file path is a single file > given that the file has frontmatter issues > should fix the frontmatter issues in the file and create the corrected file in ReadMe 1`] = `
+exports[`rdme changelog upload > given that the file path is a single file > given that the file has frontmatter issues > should fix the frontmatter issues in the file 1`] = `
 {
   "result": {
-    "created": [
+    "created": [],
+    "failed": [],
+    "skipped": [
       {
         "filePath": "__tests__/__fixtures__/changelog/legacy-docs/autofixable.md",
-        "response": {},
-        "result": "created",
+        "result": "skipped",
         "slug": "autofixable",
       },
     ],
-    "failed": [],
-    "skipped": [],
     "updated": [],
   },
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
  ›    Use at your own risk!
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
 ",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
-   - autofixable (__tests__/__fixtures__/changelog/legacy-docs/autofixable.md)
+  "stdout": "=== BEGIN writeFileSync to file: __tests__/__fixtures__/changelog/legacy-docs/autofixable.md ===
+---
+type: added
+title: This is the changelog title
+privacy:
+  view: anyone_with_link
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/changelog/legacy-docs/autofixable.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/changelog/legacy-docs/autofixable.md (1 issue)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;

--- a/__tests__/commands/changelog/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/changelog/__snapshots__/upload.test.ts.snap
@@ -253,7 +253,7 @@ exports[`rdme changelog upload > given that the file path is a directory > shoul
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
  ›   Warning: 1 file(s) have issues that cannot be fixed automatically. 
- ›   Autofixable issues have been addressed but we also recommend addressing 
+ ›   Autofixable issues have been corrected but we also recommend addressing 
  ›   these issues as well. Please get in touch with us at support@readme.io if 
  ›   you need a hand.
 ",

--- a/__tests__/commands/changelog/upload.test.ts
+++ b/__tests__/commands/changelog/upload.test.ts
@@ -535,8 +535,6 @@ describe(`rdme ${topic} upload`, () => {
         })
         .reply(500, {});
 
-      prompts.inject([true]);
-
       const result = await run(['__tests__/__fixtures__/changelog/mixed-docs', '--key', key, '--skip-validation']);
 
       expect(result).toMatchSnapshot();
@@ -581,8 +579,6 @@ describe(`rdme ${topic} upload`, () => {
         })
         .reply(500, {});
 
-      prompts.inject([true]);
-
       const result = await run([
         '__tests__/__fixtures__/changelog/mixed-docs',
         '--key',
@@ -608,8 +604,6 @@ describe(`rdme ${topic} upload`, () => {
         .reply(500)
         .get(`/${route}/simple-doc`)
         .reply(500);
-
-      prompts.inject([true]);
 
       const result = await run([
         '__tests__/__fixtures__/changelog/mixed-docs',

--- a/__tests__/commands/changelog/upload.test.ts
+++ b/__tests__/commands/changelog/upload.test.ts
@@ -30,7 +30,14 @@ describe(`rdme ${topic} upload`, () => {
     getAPIv2Mock({ authorization }).get('/projects/me').reply(200, {
       data: {},
     });
-    vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    vi.spyOn(fs, 'writeFileSync').mockImplementation((file, data) => {
+      // eslint-disable-next-line no-console
+      console.log(`=== BEGIN writeFileSync to file: ${file} ===`);
+      // eslint-disable-next-line no-console
+      console.log(data);
+      // eslint-disable-next-line no-console
+      console.log(`=== END writeFileSync to file: ${file} ===`);
+    });
   });
 
   afterEach(() => {
@@ -191,19 +198,7 @@ describe(`rdme ${topic} upload`, () => {
     });
 
     describe('given that the file has frontmatter issues', () => {
-      it('should fix the frontmatter issues in the file and create the corrected file in ReadMe', async () => {
-        const mock = getAPIv2Mock({ authorization })
-          .get(`/${route}/autofixable`)
-          .reply(404)
-          .post(`/${route}`, {
-            type: 'added',
-            slug: 'autofixable',
-            privacy: { view: 'anyone_with_link' },
-            title: 'This is the changelog title',
-            content: { body: '\nBody\n' },
-          })
-          .reply(201, {});
-
+      it('should fix the frontmatter issues in the file', async () => {
         prompts.inject([true]);
 
         const result = await run(['__tests__/__fixtures__/changelog/legacy-docs/autofixable.md', '--key', key]);
@@ -214,8 +209,6 @@ describe(`rdme ${topic} upload`, () => {
           expect.stringContaining('view: anyone_with_link'),
           { encoding: 'utf-8' },
         );
-
-        mock.done();
       });
 
       it('should exit if the user declines to fix the issues', async () => {
@@ -321,22 +314,6 @@ describe(`rdme ${topic} upload`, () => {
       });
 
       it('should bypass prompt if `--confirm-autofixes` flag is passed', async () => {
-        const getMock = getAPIv2MockForGHA({ authorization }).get(`/${route}/autofixable`).reply(404);
-
-        const postMock = getAPIv2MockForGHA({
-          authorization,
-          'x-readme-source-url':
-            'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/__tests__/__fixtures__/changelog/legacy-docs/autofixable.md',
-        })
-          .post(`/${route}`, {
-            type: 'added',
-            slug: 'autofixable',
-            title: 'This is the changelog title',
-            content: { body: '\nBody\n' },
-            privacy: { view: 'anyone_with_link' },
-          })
-          .reply(201, {});
-
         const projectsMeMock = getAPIv2MockForGHA({ authorization }).get('/projects/me').reply(200, {
           data: {},
         });
@@ -354,8 +331,7 @@ describe(`rdme ${topic} upload`, () => {
           expect.stringContaining('view: anyone_with_link'),
           { encoding: 'utf-8' },
         );
-        getMock.done();
-        postMock.done();
+
         projectsMeMock.done();
       });
     });
@@ -514,6 +490,15 @@ describe(`rdme ${topic} upload`, () => {
       expect(result).toMatchSnapshot();
     });
 
+    it('should handle a mix of valid and invalid and autofixable files', async () => {
+      prompts.inject([true]);
+
+      const result = await run(['__tests__/__fixtures__/changelog/mixed-docs', '--key', key]);
+
+      expect(result).toMatchSnapshot();
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
+    });
+
     it('should handle a mix of creates and updates and failures and skipped files', async () => {
       const mock = getAPIv2Mock({ authorization })
         .get(`/${route}/invalid-attributes`)
@@ -530,7 +515,7 @@ describe(`rdme ${topic} upload`, () => {
         .patch(`/${route}/legacy-flag`, {
           title: 'This is the changelog title',
           content: { body: '\nBody\n' },
-          privacy: { view: 'public' },
+          hidden: false,
         })
         .reply(201, {})
         .get(`/${route}/some-slug`)
@@ -552,10 +537,10 @@ describe(`rdme ${topic} upload`, () => {
 
       prompts.inject([true]);
 
-      const result = await run(['__tests__/__fixtures__/changelog/mixed-docs', '--key', key]);
+      const result = await run(['__tests__/__fixtures__/changelog/mixed-docs', '--key', key, '--skip-validation']);
 
       expect(result).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
 
       mock.done();
     });
@@ -576,7 +561,7 @@ describe(`rdme ${topic} upload`, () => {
         .patch(`/${route}/legacy-flag`, {
           title: 'This is the changelog title',
           content: { body: '\nBody\n' },
-          privacy: { view: 'public' },
+          hidden: false,
         })
         .reply(201, {})
         .get(`/${route}/some-slug`)
@@ -598,10 +583,17 @@ describe(`rdme ${topic} upload`, () => {
 
       prompts.inject([true]);
 
-      const result = await run(['__tests__/__fixtures__/changelog/mixed-docs', '--key', key, '--max-errors', '10']);
+      const result = await run([
+        '__tests__/__fixtures__/changelog/mixed-docs',
+        '--key',
+        key,
+        '--max-errors',
+        '10',
+        '--skip-validation',
+      ]);
 
       expect(result).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
 
       mock.done();
     });
@@ -619,10 +611,16 @@ describe(`rdme ${topic} upload`, () => {
 
       prompts.inject([true]);
 
-      const result = await run(['__tests__/__fixtures__/changelog/mixed-docs', '--key', key, '--dry-run']);
+      const result = await run([
+        '__tests__/__fixtures__/changelog/mixed-docs',
+        '--key',
+        key,
+        '--dry-run',
+        '--skip-validation',
+      ]);
 
       expect(result).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
 
       mock.done();
     });

--- a/__tests__/commands/custompages/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/custompages/__snapshots__/upload.test.ts.snap
@@ -310,7 +310,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md (2 issues)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme custompages upload\` to upload these files to ReadMe.
 ",
 }
 `;
@@ -431,7 +431,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md (2 issues)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme custompages upload\` to upload these files to ReadMe.
 ",
 }
 `;
@@ -612,7 +612,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md (2 issues)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme custompages upload\` to upload these files to ReadMe.
 ",
 }
 `;

--- a/__tests__/commands/custompages/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/custompages/__snapshots__/upload.test.ts.snap
@@ -260,7 +260,7 @@ exports[`custompages upload > given that the file path is a directory > should h
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
  ›   Warning: 1 file(s) have issues that cannot be fixed automatically. 
- ›   Autofixable issues have been addressed but we also recommend addressing 
+ ›   Autofixable issues have been corrected but we also recommend addressing 
  ›   these issues as well. Please get in touch with us at support@readme.io if 
  ›   you need a hand.
 ",

--- a/__tests__/commands/custompages/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/custompages/__snapshots__/upload.test.ts.snap
@@ -113,11 +113,8 @@ exports[`custompages upload > given that the file path is a directory > should h
  ›    Use at your own risk!
 - 🔍 Looking for Markdown and/or HTML files in the \`__tests__/__fixtures__/custompages/mixed-docs\` directory...
 ✔ 🔍 Looking for Markdown and/or HTML files in the \`__tests__/__fixtures__/custompages/mixed-docs\` directory... 5 file(s) found!
-- 🔬 Validating frontmatter data...
-⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
- ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
- ›   upload will proceed but we recommend addressing these issues. Please get 
- ›   in touch with us at support@readme.io if you need a hand.
+ ›   Warning: Skipping pre-upload validation of the Markdown file(s). This is 
+ ›   not recommended.
 - 🎭 Uploading files to ReadMe (but not really because it's a dry run)...
 ✖ 🎭 Uploading files to ReadMe (but not really because it's a dry run)... 2 file(s) failed.
 ",
@@ -141,11 +138,8 @@ exports[`custompages upload > given that the file path is a directory > should h
  ›    Use at your own risk!
 - 🔍 Looking for Markdown and/or HTML files in the \`__tests__/__fixtures__/custompages/mixed-docs\` directory...
 ✔ 🔍 Looking for Markdown and/or HTML files in the \`__tests__/__fixtures__/custompages/mixed-docs\` directory... 5 file(s) found!
-- 🔬 Validating frontmatter data...
-⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
- ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
- ›   upload will proceed but we recommend addressing these issues. Please get 
- ›   in touch with us at support@readme.io if you need a hand.
+ ›   Warning: Skipping pre-upload validation of the Markdown file(s). This is 
+ ›   not recommended.
 - 🚀 Uploading files to ReadMe...
 ✖ 🚀 Uploading files to ReadMe... 2 file(s) failed.
 ",
@@ -207,11 +201,8 @@ exports[`custompages upload > given that the file path is a directory > should h
  ›    Use at your own risk!
 - 🔍 Looking for Markdown and/or HTML files in the \`__tests__/__fixtures__/custompages/mixed-docs\` directory...
 ✔ 🔍 Looking for Markdown and/or HTML files in the \`__tests__/__fixtures__/custompages/mixed-docs\` directory... 5 file(s) found!
-- 🔬 Validating frontmatter data...
-⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
- ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
- ›   upload will proceed but we recommend addressing these issues. Please get 
- ›   in touch with us at support@readme.io if you need a hand.
+ ›   Warning: Skipping pre-upload validation of the Markdown file(s). This is 
+ ›   not recommended.
 - 🚀 Uploading files to ReadMe...
 ✖ 🚀 Uploading files to ReadMe... 2 file(s) failed.
 ",
@@ -224,6 +215,102 @@ exports[`custompages upload > given that the file path is a directory > should h
 🚨 Received errors when attempting to upload 2 page(s):
    - __tests__/__fixtures__/custompages/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
    - __tests__/__fixtures__/custompages/mixed-docs/simple-doc.md: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
+",
+}
+`;
+
+exports[`custompages upload > given that the file path is a directory > should handle a mix of valid and invalid and autofixable files 1`] = `
+{
+  "result": {
+    "created": [],
+    "failed": [],
+    "skipped": [
+      {
+        "filePath": "__tests__/__fixtures__/custompages/mixed-docs/doc-sans-attributes.md",
+        "result": "skipped",
+        "slug": "doc-sans-attributes",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/custompages/mixed-docs/invalid-attributes.md",
+        "result": "skipped",
+        "slug": "invalid-attributes",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/custompages/mixed-docs/legacy-page.md",
+        "result": "skipped",
+        "slug": "legacy-page",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/custompages/mixed-docs/new-doc-slug.mdx",
+        "result": "skipped",
+        "slug": "some-slug",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/custompages/mixed-docs/simple-doc.md",
+        "result": "skipped",
+        "slug": "simple-doc",
+      },
+    ],
+    "updated": [],
+  },
+  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
+ ›    Use at your own risk!
+- 🔍 Looking for Markdown and/or HTML files in the \`__tests__/__fixtures__/custompages/mixed-docs\` directory...
+✔ 🔍 Looking for Markdown and/or HTML files in the \`__tests__/__fixtures__/custompages/mixed-docs\` directory... 5 file(s) found!
+- 🔬 Validating frontmatter data...
+⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
+ ›   Warning: 1 file(s) have issues that cannot be fixed automatically. 
+ ›   Autofixable issues have been addressed but we also recommend addressing 
+ ›   these issues as well. Please get in touch with us at support@readme.io if 
+ ›   you need a hand.
+",
+  "stdout": "=== BEGIN writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/doc-sans-attributes.md ===
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/doc-sans-attributes.md ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/invalid-attributes.md ===
+---
+title: This is the document title
+appearance:
+  is-this-a-valid-property: nope
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/invalid-attributes.md ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md ===
+---
+title: This is the document title
+privacy:
+  view: anyone_with_link
+appearance:
+  fullscreen: true
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/new-doc-slug.mdx ===
+---
+title: This is the document title
+slug: some-slug
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/new-doc-slug.mdx ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/simple-doc.md ===
+---
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/simple-doc.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md (2 issues)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;
@@ -312,28 +399,39 @@ exports[`custompages upload > given that the file path is a directory > should u
 exports[`custompages upload > given that the file path is a single file > and the command is being run in a CI environment > should bypass prompt if \`--confirm-autofixes\` flag is passed 1`] = `
 {
   "result": {
-    "created": [
+    "created": [],
+    "failed": [],
+    "skipped": [
       {
         "filePath": "__tests__/__fixtures__/custompages/mixed-docs/legacy-page.md",
-        "response": {},
-        "result": "created",
+        "result": "skipped",
         "slug": "legacy-page",
       },
     ],
-    "failed": [],
-    "skipped": [],
     "updated": [],
   },
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
  ›    Use at your own risk!
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
 ",
   "stdout": "Automatically fixing issues in 1 file(s)...
-🌱 Successfully created 1 page(s) in ReadMe:
-   - legacy-page (__tests__/__fixtures__/custompages/mixed-docs/legacy-page.md)
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md ===
+---
+title: This is the document title
+privacy:
+  view: anyone_with_link
+appearance:
+  fullscreen: true
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md (2 issues)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;
@@ -480,30 +578,41 @@ exports[`custompages upload > given that the file path is a single file > given 
 }
 `;
 
-exports[`custompages upload > given that the file path is a single file > given that the file has frontmatter issues > should fix the frontmatter issues in the file and create the corrected file in ReadMe 1`] = `
+exports[`custompages upload > given that the file path is a single file > given that the file has frontmatter issues > should fix the frontmatter issues in the file 1`] = `
 {
   "result": {
-    "created": [
+    "created": [],
+    "failed": [],
+    "skipped": [
       {
         "filePath": "__tests__/__fixtures__/custompages/mixed-docs/legacy-page.md",
-        "response": {},
-        "result": "created",
+        "result": "skipped",
         "slug": "legacy-page",
       },
     ],
-    "failed": [],
-    "skipped": [],
     "updated": [],
   },
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
  ›    Use at your own risk!
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
 ",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
-   - legacy-page (__tests__/__fixtures__/custompages/mixed-docs/legacy-page.md)
+  "stdout": "=== BEGIN writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md ===
+---
+title: This is the document title
+privacy:
+  view: anyone_with_link
+appearance:
+  fullscreen: true
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md (2 issues)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;

--- a/__tests__/commands/custompages/upload.test.ts
+++ b/__tests__/commands/custompages/upload.test.ts
@@ -603,8 +603,6 @@ describe('custompages upload', () => {
         })
         .reply(500, {});
 
-      prompts.inject([true]);
-
       const result = await run(['__tests__/__fixtures__/custompages/mixed-docs', '--key', key, '--skip-validation']);
 
       expect(result).toMatchSnapshot();
@@ -650,8 +648,6 @@ describe('custompages upload', () => {
         })
         .reply(500, {});
 
-      prompts.inject([true]);
-
       const result = await run([
         '__tests__/__fixtures__/custompages/mixed-docs',
         '--key',
@@ -677,8 +673,6 @@ describe('custompages upload', () => {
         .reply(500)
         .get('/branches/stable/custom_pages/simple-doc')
         .reply(500);
-
-      prompts.inject([true]);
 
       const result = await run([
         '__tests__/__fixtures__/custompages/mixed-docs',

--- a/__tests__/commands/custompages/upload.test.ts
+++ b/__tests__/commands/custompages/upload.test.ts
@@ -27,7 +27,14 @@ describe('custompages upload', () => {
     getAPIv2Mock({ authorization }).get('/projects/me').reply(200, {
       data: {},
     });
-    vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    vi.spyOn(fs, 'writeFileSync').mockImplementation((file, data) => {
+      // eslint-disable-next-line no-console
+      console.log(`=== BEGIN writeFileSync to file: ${file} ===`);
+      // eslint-disable-next-line no-console
+      console.log(data);
+      // eslint-disable-next-line no-console
+      console.log(`=== END writeFileSync to file: ${file} ===`);
+    });
   });
 
   afterEach(() => {
@@ -234,19 +241,7 @@ describe('custompages upload', () => {
     });
 
     describe('given that the file has frontmatter issues', () => {
-      it('should fix the frontmatter issues in the file and create the corrected file in ReadMe', async () => {
-        const mock = getAPIv2Mock({ authorization })
-          .get('/branches/stable/custom_pages/legacy-page')
-          .reply(404)
-          .post('/branches/stable/custom_pages', {
-            slug: 'legacy-page',
-            title: 'This is the document title',
-            content: { body: '\nBody\n', type: 'markdown' },
-            privacy: { view: 'anyone_with_link' },
-            appearance: { fullscreen: true },
-          })
-          .reply(201, {});
-
+      it('should fix the frontmatter issues in the file', async () => {
         prompts.inject([true]);
 
         const result = await run(['__tests__/__fixtures__/custompages/mixed-docs/legacy-page.md', '--key', key]);
@@ -257,8 +252,6 @@ describe('custompages upload', () => {
           expect.stringContaining('view: anyone_with_link'),
           { encoding: 'utf-8' },
         );
-
-        mock.done();
       });
 
       it('should exit if the user declines to fix the issues', async () => {
@@ -363,24 +356,6 @@ describe('custompages upload', () => {
       });
 
       it('should bypass prompt if `--confirm-autofixes` flag is passed', async () => {
-        const getMock = getAPIv2MockForGHA({ authorization })
-          .get('/branches/stable/custom_pages/legacy-page')
-          .reply(404);
-
-        const postMock = getAPIv2MockForGHA({
-          authorization,
-          'x-readme-source-url':
-            'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/__tests__/__fixtures__/custompages/mixed-docs/legacy-page.md',
-        })
-          .post('/branches/stable/custom_pages', {
-            privacy: { view: 'anyone_with_link' },
-            appearance: { fullscreen: true },
-            slug: 'legacy-page',
-            title: 'This is the document title',
-            content: { body: '\nBody\n', type: 'markdown' },
-          })
-          .reply(201, {});
-
         const projectsMeMock = getAPIv2MockForGHA({ authorization }).get('/projects/me').reply(200, {
           data: {},
         });
@@ -398,8 +373,7 @@ describe('custompages upload', () => {
           expect.stringContaining('view: anyone_with_link'),
           { encoding: 'utf-8' },
         );
-        getMock.done();
-        postMock.done();
+
         projectsMeMock.done();
       });
     });
@@ -583,6 +557,15 @@ describe('custompages upload', () => {
       expect(result).toMatchSnapshot();
     });
 
+    it('should handle a mix of valid and invalid and autofixable files', async () => {
+      prompts.inject([true]);
+
+      const result = await run(['__tests__/__fixtures__/custompages/mixed-docs', '--key', key]);
+
+      expect(result).toMatchSnapshot();
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
+    });
+
     it('should handle a mix of creates and updates and failures and skipped files', async () => {
       const mock = getAPIv2Mock({ authorization })
         .get('/branches/stable/custom_pages/invalid-attributes')
@@ -599,8 +582,8 @@ describe('custompages upload', () => {
         .patch('/branches/stable/custom_pages/legacy-page', {
           title: 'This is the document title',
           content: { body: '\nBody\n', type: 'markdown' },
-          privacy: { view: 'anyone_with_link' },
-          appearance: { fullscreen: true },
+          hidden: true,
+          fullscreen: true,
         })
         .reply(201, {})
         .get('/branches/stable/custom_pages/some-slug')
@@ -622,10 +605,10 @@ describe('custompages upload', () => {
 
       prompts.inject([true]);
 
-      const result = await run(['__tests__/__fixtures__/custompages/mixed-docs', '--key', key]);
+      const result = await run(['__tests__/__fixtures__/custompages/mixed-docs', '--key', key, '--skip-validation']);
 
       expect(result).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
 
       mock.done();
     });
@@ -646,8 +629,8 @@ describe('custompages upload', () => {
         .patch('/branches/stable/custom_pages/legacy-page', {
           title: 'This is the document title',
           content: { body: '\nBody\n', type: 'markdown' },
-          privacy: { view: 'anyone_with_link' },
-          appearance: { fullscreen: true },
+          hidden: true,
+          fullscreen: true,
         })
         .reply(201, {})
         .get('/branches/stable/custom_pages/some-slug')
@@ -669,10 +652,17 @@ describe('custompages upload', () => {
 
       prompts.inject([true]);
 
-      const result = await run(['__tests__/__fixtures__/custompages/mixed-docs', '--key', key, '--max-errors', '10']);
+      const result = await run([
+        '__tests__/__fixtures__/custompages/mixed-docs',
+        '--key',
+        key,
+        '--max-errors',
+        '10',
+        '--skip-validation',
+      ]);
 
       expect(result).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
 
       mock.done();
     });
@@ -690,10 +680,16 @@ describe('custompages upload', () => {
 
       prompts.inject([true]);
 
-      const result = await run(['__tests__/__fixtures__/custompages/mixed-docs', '--key', key, '--dry-run']);
+      const result = await run([
+        '__tests__/__fixtures__/custompages/mixed-docs',
+        '--key',
+        key,
+        '--dry-run',
+        '--skip-validation',
+      ]);
 
       expect(result).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
 
       mock.done();
     });

--- a/__tests__/commands/pages/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/pages/__snapshots__/upload.test.ts.snap
@@ -157,11 +157,8 @@ exports[`rdme docs upload > given that the file path is a directory > should han
  ›    Use at your own risk!
 - 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory...
 ✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory... 5 file(s) found!
-- 🔬 Validating frontmatter data...
-⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
- ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
- ›   upload will proceed but we recommend addressing these issues. Please get 
- ›   in touch with us at support@readme.io if you need a hand.
+ ›   Warning: Skipping pre-upload validation of the Markdown file(s). This is 
+ ›   not recommended.
 - 🎭 Uploading files to ReadMe (but not really because it's a dry run)...
 ✖ 🎭 Uploading files to ReadMe (but not really because it's a dry run)... 2 file(s) failed.
 ",
@@ -185,11 +182,8 @@ exports[`rdme docs upload > given that the file path is a directory > should han
  ›    Use at your own risk!
 - 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory...
 ✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory... 5 file(s) found!
-- 🔬 Validating frontmatter data...
-⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
- ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
- ›   upload will proceed but we recommend addressing these issues. Please get 
- ›   in touch with us at support@readme.io if you need a hand.
+ ›   Warning: Skipping pre-upload validation of the Markdown file(s). This is 
+ ›   not recommended.
 - 🚀 Uploading files to ReadMe...
 ✖ 🚀 Uploading files to ReadMe... 2 file(s) failed.
 ",
@@ -251,11 +245,8 @@ exports[`rdme docs upload > given that the file path is a directory > should han
  ›    Use at your own risk!
 - 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory...
 ✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory... 5 file(s) found!
-- 🔬 Validating frontmatter data...
-⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
- ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
- ›   upload will proceed but we recommend addressing these issues. Please get 
- ›   in touch with us at support@readme.io if you need a hand.
+ ›   Warning: Skipping pre-upload validation of the Markdown file(s). This is 
+ ›   not recommended.
 - 🚀 Uploading files to ReadMe...
 ✖ 🚀 Uploading files to ReadMe... 2 file(s) failed.
 ",
@@ -268,6 +259,103 @@ exports[`rdme docs upload > given that the file path is a directory > should han
 🚨 Received errors when attempting to upload 2 page(s):
    - __tests__/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
    - __tests__/__fixtures__/docs/mixed-docs/simple-doc.md: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
+",
+}
+`;
+
+exports[`rdme docs upload > given that the file path is a directory > should handle a mix of valid and invalid and autofixable files 1`] = `
+{
+  "result": {
+    "created": [],
+    "failed": [],
+    "skipped": [
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/doc-sans-attributes.md",
+        "result": "skipped",
+        "slug": "doc-sans-attributes",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/invalid-attributes.md",
+        "result": "skipped",
+        "slug": "invalid-attributes",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/legacy-category.md",
+        "result": "skipped",
+        "slug": "legacy-category",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/new-doc-slug.mdx",
+        "result": "skipped",
+        "slug": "some-slug",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/simple-doc.md",
+        "result": "skipped",
+        "slug": "simple-doc",
+      },
+    ],
+    "updated": [],
+  },
+  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
+ ›    Use at your own risk!
+- 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory...
+✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory... 5 file(s) found!
+- 🔬 Validating frontmatter data...
+⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
+ ›   Warning: 1 file(s) have issues that cannot be fixed automatically. 
+ ›   Autofixable issues have been addressed but we also recommend addressing 
+ ›   these issues as well. Please get in touch with us at support@readme.io if 
+ ›   you need a hand.
+",
+  "stdout": "=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/doc-sans-attributes.md ===
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/doc-sans-attributes.md ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/invalid-attributes.md ===
+---
+category:
+  uri: some-category-uri
+  is-this-a-valid-property: nope
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/invalid-attributes.md ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+---
+category:
+  uri: uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/new-doc-slug.mdx ===
+---
+category:
+  uri: some-category-uri
+title: This is the document title
+slug: some-slug
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/new-doc-slug.mdx ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/simple-doc.md ===
+---
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/simple-doc.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;
@@ -349,28 +437,37 @@ exports[`rdme docs upload > given that the file path is a directory > should upd
 exports[`rdme docs upload > given that the file path is a single file > and the command is being run in a CI environment > should bypass prompt if \`--confirm-autofixes\` flag is passed 1`] = `
 {
   "result": {
-    "created": [
+    "created": [],
+    "failed": [],
+    "skipped": [
       {
         "filePath": "__tests__/__fixtures__/docs/mixed-docs/legacy-category.md",
-        "response": {},
-        "result": "created",
+        "result": "skipped",
         "slug": "legacy-category",
       },
     ],
-    "failed": [],
-    "skipped": [],
     "updated": [],
   },
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
  ›    Use at your own risk!
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
 ",
   "stdout": "Automatically fixing issues in 1 file(s)...
-🌱 Successfully created 1 page(s) in ReadMe:
-   - legacy-category (__tests__/__fixtures__/docs/mixed-docs/legacy-category.md)
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+---
+category:
+  uri: uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;
@@ -517,30 +614,39 @@ exports[`rdme docs upload > given that the file path is a single file > given th
 }
 `;
 
-exports[`rdme docs upload > given that the file path is a single file > given that the file has frontmatter issues > should fix the frontmatter issues in the file and create the corrected file in ReadMe 1`] = `
+exports[`rdme docs upload > given that the file path is a single file > given that the file has frontmatter issues > should fix the frontmatter issues in the file 1`] = `
 {
   "result": {
-    "created": [
+    "created": [],
+    "failed": [],
+    "skipped": [
       {
         "filePath": "__tests__/__fixtures__/docs/mixed-docs/legacy-category.md",
-        "response": {},
-        "result": "created",
+        "result": "skipped",
         "slug": "legacy-category",
       },
     ],
-    "failed": [],
-    "skipped": [],
     "updated": [],
   },
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
  ›    Use at your own risk!
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
 ",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
-   - legacy-category (__tests__/__fixtures__/docs/mixed-docs/legacy-category.md)
+  "stdout": "=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+---
+category:
+  uri: uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;
@@ -548,27 +654,36 @@ exports[`rdme docs upload > given that the file path is a single file > given th
 exports[`rdme docs upload > given that the file path is a single file > given that the file has frontmatter issues > should fix the frontmatter issues in the file and insert the proper category mapping 1`] = `
 {
   "result": {
-    "created": [
+    "created": [],
+    "failed": [],
+    "skipped": [
       {
         "filePath": "__tests__/__fixtures__/docs/mixed-docs/legacy-category.md",
-        "response": {},
-        "result": "created",
+        "result": "skipped",
         "slug": "legacy-category",
       },
     ],
-    "failed": [],
-    "skipped": [],
     "updated": [],
   },
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
  ›    Use at your own risk!
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
 ",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
-   - legacy-category (__tests__/__fixtures__/docs/mixed-docs/legacy-category.md)
+  "stdout": "=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+---
+category:
+  uri: mapped-uri
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;
@@ -1030,11 +1145,8 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
  ›    Use at your own risk!
 - 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory...
 ✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory... 5 file(s) found!
-- 🔬 Validating frontmatter data...
-⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
- ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
- ›   upload will proceed but we recommend addressing these issues. Please get 
- ›   in touch with us at support@readme.io if you need a hand.
+ ›   Warning: Skipping pre-upload validation of the Markdown file(s). This is 
+ ›   not recommended.
 - 🎭 Uploading files to ReadMe (but not really because it's a dry run)...
 ✖ 🎭 Uploading files to ReadMe (but not really because it's a dry run)... 2 file(s) failed.
 ",
@@ -1058,11 +1170,8 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
  ›    Use at your own risk!
 - 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory...
 ✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory... 5 file(s) found!
-- 🔬 Validating frontmatter data...
-⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
- ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
- ›   upload will proceed but we recommend addressing these issues. Please get 
- ›   in touch with us at support@readme.io if you need a hand.
+ ›   Warning: Skipping pre-upload validation of the Markdown file(s). This is 
+ ›   not recommended.
 - 🚀 Uploading files to ReadMe...
 ✖ 🚀 Uploading files to ReadMe... 2 file(s) failed.
 ",
@@ -1124,11 +1233,8 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
  ›    Use at your own risk!
 - 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory...
 ✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory... 5 file(s) found!
-- 🔬 Validating frontmatter data...
-⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
- ›   Warning: 1 file(s) have issues that cannot be fixed automatically. The 
- ›   upload will proceed but we recommend addressing these issues. Please get 
- ›   in touch with us at support@readme.io if you need a hand.
+ ›   Warning: Skipping pre-upload validation of the Markdown file(s). This is 
+ ›   not recommended.
 - 🚀 Uploading files to ReadMe...
 ✖ 🚀 Uploading files to ReadMe... 2 file(s) failed.
 ",
@@ -1141,6 +1247,103 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
 🚨 Received errors when attempting to upload 2 page(s):
    - __tests__/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
    - __tests__/__fixtures__/docs/mixed-docs/simple-doc.md: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
+",
+}
+`;
+
+exports[`rdme reference upload > given that the file path is a directory > should handle a mix of valid and invalid and autofixable files 1`] = `
+{
+  "result": {
+    "created": [],
+    "failed": [],
+    "skipped": [
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/doc-sans-attributes.md",
+        "result": "skipped",
+        "slug": "doc-sans-attributes",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/invalid-attributes.md",
+        "result": "skipped",
+        "slug": "invalid-attributes",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/legacy-category.md",
+        "result": "skipped",
+        "slug": "legacy-category",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/new-doc-slug.mdx",
+        "result": "skipped",
+        "slug": "some-slug",
+      },
+      {
+        "filePath": "__tests__/__fixtures__/docs/mixed-docs/simple-doc.md",
+        "result": "skipped",
+        "slug": "simple-doc",
+      },
+    ],
+    "updated": [],
+  },
+  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
+ ›    Use at your own risk!
+- 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory...
+✔ 🔍 Looking for Markdown files in the \`__tests__/__fixtures__/docs/mixed-docs\` directory... 5 file(s) found!
+- 🔬 Validating frontmatter data...
+⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
+ ›   Warning: 1 file(s) have issues that cannot be fixed automatically. 
+ ›   Autofixable issues have been addressed but we also recommend addressing 
+ ›   these issues as well. Please get in touch with us at support@readme.io if 
+ ›   you need a hand.
+",
+  "stdout": "=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/doc-sans-attributes.md ===
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/doc-sans-attributes.md ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/invalid-attributes.md ===
+---
+category:
+  uri: some-category-uri
+  is-this-a-valid-property: nope
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/invalid-attributes.md ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+---
+category:
+  uri: uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/new-doc-slug.mdx ===
+---
+category:
+  uri: some-category-uri
+title: This is the document title
+slug: some-slug
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/new-doc-slug.mdx ===
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/simple-doc.md ===
+---
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/simple-doc.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;
@@ -1222,28 +1425,37 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
 exports[`rdme reference upload > given that the file path is a single file > and the command is being run in a CI environment > should bypass prompt if \`--confirm-autofixes\` flag is passed 1`] = `
 {
   "result": {
-    "created": [
+    "created": [],
+    "failed": [],
+    "skipped": [
       {
         "filePath": "__tests__/__fixtures__/docs/mixed-docs/legacy-category.md",
-        "response": {},
-        "result": "created",
+        "result": "skipped",
         "slug": "legacy-category",
       },
     ],
-    "failed": [],
-    "skipped": [],
     "updated": [],
   },
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
  ›    Use at your own risk!
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
 ",
   "stdout": "Automatically fixing issues in 1 file(s)...
-🌱 Successfully created 1 page(s) in ReadMe:
-   - legacy-category (__tests__/__fixtures__/docs/mixed-docs/legacy-category.md)
+=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+---
+category:
+  uri: uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;
@@ -1390,30 +1602,39 @@ exports[`rdme reference upload > given that the file path is a single file > giv
 }
 `;
 
-exports[`rdme reference upload > given that the file path is a single file > given that the file has frontmatter issues > should fix the frontmatter issues in the file and create the corrected file in ReadMe 1`] = `
+exports[`rdme reference upload > given that the file path is a single file > given that the file has frontmatter issues > should fix the frontmatter issues in the file 1`] = `
 {
   "result": {
-    "created": [
+    "created": [],
+    "failed": [],
+    "skipped": [
       {
         "filePath": "__tests__/__fixtures__/docs/mixed-docs/legacy-category.md",
-        "response": {},
-        "result": "created",
+        "result": "skipped",
         "slug": "legacy-category",
       },
     ],
-    "failed": [],
-    "skipped": [],
     "updated": [],
   },
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
  ›    Use at your own risk!
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
 ",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
-   - legacy-category (__tests__/__fixtures__/docs/mixed-docs/legacy-category.md)
+  "stdout": "=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+---
+category:
+  uri: uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;
@@ -1421,27 +1642,36 @@ exports[`rdme reference upload > given that the file path is a single file > giv
 exports[`rdme reference upload > given that the file path is a single file > given that the file has frontmatter issues > should fix the frontmatter issues in the file and insert the proper category mapping 1`] = `
 {
   "result": {
-    "created": [
+    "created": [],
+    "failed": [],
+    "skipped": [
       {
         "filePath": "__tests__/__fixtures__/docs/mixed-docs/legacy-category.md",
-        "response": {},
-        "result": "created",
+        "result": "skipped",
         "slug": "legacy-category",
       },
     ],
-    "failed": [],
-    "skipped": [],
     "updated": [],
   },
   "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
  ›    Use at your own risk!
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
 ",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
-   - legacy-category (__tests__/__fixtures__/docs/mixed-docs/legacy-category.md)
+  "stdout": "=== BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+---
+category:
+  uri: mapped-uri
+title: This is the document title
+---
+
+Body
+
+=== END writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
+✅ The following files have been automatically fixed:
+- __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
+
+Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
 ",
 }
 `;

--- a/__tests__/commands/pages/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/pages/__snapshots__/upload.test.ts.snap
@@ -304,7 +304,7 @@ exports[`rdme docs upload > given that the file path is a directory > should han
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
  ›   Warning: 1 file(s) have issues that cannot be fixed automatically. 
- ›   Autofixable issues have been addressed but we also recommend addressing 
+ ›   Autofixable issues have been corrected but we also recommend addressing 
  ›   these issues as well. Please get in touch with us at support@readme.io if 
  ›   you need a hand.
 ",
@@ -1292,7 +1292,7 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
 - 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 2 file(s).
  ›   Warning: 1 file(s) have issues that cannot be fixed automatically. 
- ›   Autofixable issues have been addressed but we also recommend addressing 
+ ›   Autofixable issues have been corrected but we also recommend addressing 
  ›   these issues as well. Please get in touch with us at support@readme.io if 
  ›   you need a hand.
 ",

--- a/__tests__/commands/pages/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/pages/__snapshots__/upload.test.ts.snap
@@ -355,7 +355,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme docs upload\` to upload these files to ReadMe.
 ",
 }
 `;
@@ -467,7 +467,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme docs upload\` to upload these files to ReadMe.
 ",
 }
 `;
@@ -646,7 +646,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme docs upload\` to upload these files to ReadMe.
 ",
 }
 `;
@@ -683,7 +683,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme docs upload\` to upload these files to ReadMe.
 ",
 }
 `;
@@ -1343,7 +1343,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme reference upload\` to upload these files to ReadMe.
 ",
 }
 `;
@@ -1455,7 +1455,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme reference upload\` to upload these files to ReadMe.
 ",
 }
 `;
@@ -1634,7 +1634,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme reference upload\` to upload these files to ReadMe.
 ",
 }
 `;
@@ -1671,7 +1671,7 @@ Body
 ✅ The following files have been automatically fixed:
 - __tests__/__fixtures__/docs/mixed-docs/legacy-category.md (1 issue)
 
-Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.
+Please review the changes. Once everything looks good, re-run \`rdme reference upload\` to upload these files to ReadMe.
 ",
 }
 `;

--- a/__tests__/commands/pages/upload.test.ts
+++ b/__tests__/commands/pages/upload.test.ts
@@ -265,7 +265,7 @@ describe.each([
         projectsMeMock.done();
       });
 
-      it.skip('should exit if the user declines to fix the issues', async () => {
+      it('should exit if the user declines to fix the issues', async () => {
         prompts.inject([false]);
 
         const result = await run(['__tests__/__fixtures__/docs/mixed-docs/legacy-category.md', '--key', key]);
@@ -638,8 +638,6 @@ describe.each([
         })
         .reply(500, {});
 
-      prompts.inject([true]);
-
       const result = await run(['__tests__/__fixtures__/docs/mixed-docs', '--key', key, '--skip-validation']);
 
       expect(result).toMatchSnapshot();
@@ -688,8 +686,6 @@ describe.each([
         })
         .reply(500, {});
 
-      prompts.inject([true]);
-
       const result = await run([
         '__tests__/__fixtures__/docs/mixed-docs',
         '--key',
@@ -715,8 +711,6 @@ describe.each([
         .reply(500)
         .get(`/branches/stable/${route}/simple-doc`)
         .reply(500);
-
-      prompts.inject([true]);
 
       const result = await run([
         '__tests__/__fixtures__/docs/mixed-docs',

--- a/__tests__/commands/pages/upload.test.ts
+++ b/__tests__/commands/pages/upload.test.ts
@@ -31,7 +31,14 @@ describe.each([
     getAPIv2Mock({ authorization }).get('/projects/me').reply(200, {
       data: {},
     });
-    vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    vi.spyOn(fs, 'writeFileSync').mockImplementation((file, data) => {
+      // eslint-disable-next-line no-console
+      console.log(`=== BEGIN writeFileSync to file: ${file} ===`);
+      // eslint-disable-next-line no-console
+      console.log(data);
+      // eslint-disable-next-line no-console
+      console.log(`=== END writeFileSync to file: ${file} ===`);
+    });
   });
 
   afterEach(() => {
@@ -217,18 +224,7 @@ describe.each([
     });
 
     describe('given that the file has frontmatter issues', () => {
-      it('should fix the frontmatter issues in the file and create the corrected file in ReadMe', async () => {
-        const mock = getAPIv2Mock({ authorization })
-          .get(`/branches/stable/${route}/legacy-category`)
-          .reply(404)
-          .post(`/branches/stable/${route}`, {
-            category: { uri: `/branches/stable/categories/${route}/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f` },
-            slug: 'legacy-category',
-            title: 'This is the document title',
-            content: { body: '\nBody\n' },
-          })
-          .reply(201, {});
-
+      it('should fix the frontmatter issues in the file', async () => {
         prompts.inject([true]);
 
         const result = await run(['__tests__/__fixtures__/docs/mixed-docs/legacy-category.md', '--key', key]);
@@ -239,8 +235,6 @@ describe.each([
           expect.stringContaining('uri: uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f'),
           { encoding: 'utf-8' },
         );
-
-        mock.done();
       });
 
       it('should fix the frontmatter issues in the file and insert the proper category mapping', async () => {
@@ -251,17 +245,6 @@ describe.each([
           .reply(201, {
             categories: { '5ae122e10fdf4e39bb34db6f': 'mapped-uri' },
           });
-
-        const mock = getAPIv2Mock({ authorization })
-          .get(`/branches/stable/${route}/legacy-category`)
-          .reply(404)
-          .post(`/branches/stable/${route}`, {
-            category: { uri: `/branches/stable/categories/${route}/mapped-uri` },
-            slug: 'legacy-category',
-            title: 'This is the document title',
-            content: { body: '\nBody\n' },
-          })
-          .reply(201, {});
 
         const projectsMeMock = getAPIv2Mock({ authorization }).get('/projects/me').reply(200, {
           data: {},
@@ -279,11 +262,10 @@ describe.each([
         );
 
         mappingsMock.done();
-        mock.done();
         projectsMeMock.done();
       });
 
-      it('should exit if the user declines to fix the issues', async () => {
+      it.skip('should exit if the user declines to fix the issues', async () => {
         prompts.inject([false]);
 
         const result = await run(['__tests__/__fixtures__/docs/mixed-docs/legacy-category.md', '--key', key]);
@@ -388,23 +370,6 @@ describe.each([
       });
 
       it('should bypass prompt if `--confirm-autofixes` flag is passed', async () => {
-        const getMock = getAPIv2MockForGHA({ authorization })
-          .get(`/branches/stable/${route}/legacy-category`)
-          .reply(404);
-
-        const postMock = getAPIv2MockForGHA({
-          authorization,
-          'x-readme-source-url':
-            'https://github.com/octocat/Hello-World/blob/ffac537e6cbbf934b08745a378932722df287a53/__tests__/__fixtures__/docs/mixed-docs/legacy-category.md',
-        })
-          .post(`/branches/stable/${route}`, {
-            category: { uri: `/branches/stable/categories/${route}/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f` },
-            slug: 'legacy-category',
-            title: 'This is the document title',
-            content: { body: '\nBody\n' },
-          })
-          .reply(201, {});
-
         const projectsMeMock = getAPIv2MockForGHA({ authorization }).get('/projects/me').reply(200, {
           data: {},
         });
@@ -422,8 +387,7 @@ describe.each([
           expect.stringContaining('uri: uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f'),
           { encoding: 'utf-8' },
         );
-        getMock.done();
-        postMock.done();
+
         projectsMeMock.done();
       });
     });
@@ -625,6 +589,15 @@ describe.each([
       expect(result).toMatchSnapshot();
     });
 
+    it('should handle a mix of valid and invalid and autofixable files', async () => {
+      prompts.inject([true]);
+
+      const result = await run(['__tests__/__fixtures__/docs/mixed-docs', '--key', key]);
+
+      expect(result).toMatchSnapshot();
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
+    });
+
     it('should handle a mix of creates and updates and failures and skipped files', async () => {
       const mock = getAPIv2Mock({ authorization })
         .get(`/branches/stable/${route}/invalid-attributes`)
@@ -642,7 +615,7 @@ describe.each([
         .get(`/branches/stable/${route}/legacy-category`)
         .reply(200)
         .patch(`/branches/stable/${route}/legacy-category`, {
-          category: { uri: `/branches/stable/categories/${route}/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f` },
+          category: '5ae122e10fdf4e39bb34db6f',
           title: 'This is the document title',
           content: { body: '\nBody\n' },
         })
@@ -667,10 +640,10 @@ describe.each([
 
       prompts.inject([true]);
 
-      const result = await run(['__tests__/__fixtures__/docs/mixed-docs', '--key', key]);
+      const result = await run(['__tests__/__fixtures__/docs/mixed-docs', '--key', key, '--skip-validation']);
 
       expect(result).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
 
       mock.done();
     });
@@ -692,7 +665,7 @@ describe.each([
         .get(`/branches/stable/${route}/legacy-category`)
         .reply(200)
         .patch(`/branches/stable/${route}/legacy-category`, {
-          category: { uri: `/branches/stable/categories/${route}/uri-that-does-not-map-to-5ae122e10fdf4e39bb34db6f` },
+          category: '5ae122e10fdf4e39bb34db6f',
           title: 'This is the document title',
           content: { body: '\nBody\n' },
         })
@@ -717,10 +690,17 @@ describe.each([
 
       prompts.inject([true]);
 
-      const result = await run(['__tests__/__fixtures__/docs/mixed-docs', '--key', key, '--max-errors', '10']);
+      const result = await run([
+        '__tests__/__fixtures__/docs/mixed-docs',
+        '--key',
+        key,
+        '--max-errors',
+        '10',
+        '--skip-validation',
+      ]);
 
       expect(result).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
 
       mock.done();
     });
@@ -738,10 +718,16 @@ describe.each([
 
       prompts.inject([true]);
 
-      const result = await run(['__tests__/__fixtures__/docs/mixed-docs', '--key', key, '--dry-run']);
+      const result = await run([
+        '__tests__/__fixtures__/docs/mixed-docs',
+        '--key',
+        key,
+        '--dry-run',
+        '--skip-validation',
+      ]);
 
       expect(result).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(5);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
 
       mock.done();
     });

--- a/src/commands/docs/migrate.ts
+++ b/src/commands/docs/migrate.ts
@@ -111,9 +111,7 @@ export default class DocsMigrateCommand extends BaseCommand<typeof DocsMigrateCo
     if (skipValidation) {
       this.debug('skipping validation');
     } else {
-      unsortedFiles = (
-        await validateFrontmatter.call(this, unsortedFiles, 'Would you like to make these changes?', outputDir)
-      ).pages;
+      unsortedFiles = (await validateFrontmatter.call(this, unsortedFiles, outputDir)).pages;
     }
 
     if (transformedByHooks) {

--- a/src/commands/docs/migrate.ts
+++ b/src/commands/docs/migrate.ts
@@ -111,12 +111,9 @@ export default class DocsMigrateCommand extends BaseCommand<typeof DocsMigrateCo
     if (skipValidation) {
       this.debug('skipping validation');
     } else {
-      unsortedFiles = await validateFrontmatter.call(
-        this,
-        unsortedFiles,
-        'Would you like to make these changes?',
-        outputDir,
-      );
+      unsortedFiles = (
+        await validateFrontmatter.call(this, unsortedFiles, 'Would you like to make these changes?', outputDir)
+      ).pages;
     }
 
     if (transformedByHooks) {

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -269,11 +269,7 @@ export default async function syncPagePath(this: APIv2PageUploadCommands): Promi
       this.warn('Skipping pre-upload validation of the Markdown file(s). This is not recommended.');
     }
   } else {
-    const validationResults = await validateFrontmatter.call(
-      this,
-      unsortedFiles,
-      'Would you like to make these changes and continue with the upload to ReadMe?',
-    );
+    const validationResults = await validateFrontmatter.call(this, unsortedFiles);
 
     // if autofixes were applied, we return the results immediately
     if (validationResults.status.includes('autofixed')) {

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -269,11 +269,27 @@ export default async function syncPagePath(this: APIv2PageUploadCommands): Promi
       this.warn('Skipping pre-upload validation of the Markdown file(s). This is not recommended.');
     }
   } else {
-    unsortedFiles = await validateFrontmatter.call(
+    const validationResults = await validateFrontmatter.call(
       this,
       unsortedFiles,
       'Would you like to make these changes and continue with the upload to ReadMe?',
     );
+
+    // if autofixes were applied, we return the results immediately
+    if (validationResults.status.includes('autofixed')) {
+      return {
+        created: [],
+        updated: [],
+        skipped: validationResults.pages.map(page => ({
+          filePath: page.filePath,
+          result: 'skipped',
+          slug: page.slug,
+        })),
+        failed: [],
+      };
+    }
+
+    unsortedFiles = validationResults.pages;
   }
 
   const uploadSpinner = ora({ ...oraOptions() }).start(

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -27,7 +27,7 @@ type apiDefinitionsSchema =
   (typeof readmeAPIv2Oas)['paths']['/branches/{branch}/apis']['get']['responses']['200']['content']['application/json']['schema'];
 
 /** Page schemas */
-type PageRoute = APIv2PageUploadCommands['route'];
+export type PageRoute = APIv2PageUploadCommands['route'];
 
 type PageRequestSchemaRaw<T extends PageRoute> = T extends 'custom_pages' | 'guides' | 'reference'
   ? (typeof readmeAPIv2Oas)['paths'][`/branches/{branch}/${T}/{slug}`]['patch']['requestBody']['content']['application/json']['schema']

--- a/src/lib/validateFrontmatter.ts
+++ b/src/lib/validateFrontmatter.ts
@@ -16,7 +16,6 @@ type ValidationStatus = 'autofixed-with-issues' | 'autofixed' | 'has-issues' | '
 export async function validateFrontmatter(
   this: APIv2PageCommands,
   pages: PageMetadata[],
-  promptQuestion: string,
   outputDir?: string,
 ): Promise<{ pages: PageMetadata<PageRequestSchema<PageRoute>>[]; status: ValidationStatus }> {
   const { path: pathInput } = this.args;
@@ -59,7 +58,7 @@ export async function validateFrontmatter(
         {
           type: 'confirm',
           name: 'confirm',
-          message: `${filesWithFixableIssues.length} file(s) have issues that can be fixed automatically. ${promptQuestion}`,
+          message: `${filesWithFixableIssues.length} file(s) have issues that can be fixed automatically. Would you like to make these changes`,
         },
       ]);
 

--- a/src/lib/validateFrontmatter.ts
+++ b/src/lib/validateFrontmatter.ts
@@ -10,6 +10,7 @@ import isCI from './isCI.js';
 import { oraOptions } from './logger.js';
 import promptTerminal from './promptWrapper.js';
 import { fetchMappings, fetchSchema } from './readmeAPIFetch.js';
+import chalk from 'chalk';
 
 type ValidationStatus = 'autofixed-with-issues' | 'autofixed' | 'has-issues' | 'valid';
 
@@ -84,7 +85,7 @@ export async function validateFrontmatter(
 
       this.log();
       this.log(
-        'Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.',
+        `Please review the changes. Once everything looks good, re-run \`${chalk.blue(`${this.config.bin} ${this.id}`)}\` to upload these files to ReadMe.`,
       );
     }
 

--- a/src/lib/validateFrontmatter.ts
+++ b/src/lib/validateFrontmatter.ts
@@ -58,7 +58,7 @@ export async function validateFrontmatter(
         {
           type: 'confirm',
           name: 'confirm',
-          message: `${filesWithFixableIssues.length} file(s) have issues that can be fixed automatically. Would you like to make these changes`,
+          message: `${filesWithFixableIssues.length} file(s) have issues that can be fixed automatically. Would you like to make these changes?`,
         },
       ]);
 

--- a/src/lib/validateFrontmatter.ts
+++ b/src/lib/validateFrontmatter.ts
@@ -82,6 +82,7 @@ export async function validateFrontmatter(
           );
         }
       });
+
       this.log();
       this.log(
         'Please review the changes. Once everything looks good, run the command again to upload these files to ReadMe.',

--- a/src/lib/validateFrontmatter.ts
+++ b/src/lib/validateFrontmatter.ts
@@ -2,6 +2,7 @@ import type { PageMetadata } from './readPage.js';
 import type { APIv2PageCommands } from '../index.js';
 import type { PageRequestSchema, PageRoute } from './types/index.js';
 
+import chalk from 'chalk';
 import ora from 'ora';
 import prompts from 'prompts';
 
@@ -10,7 +11,6 @@ import isCI from './isCI.js';
 import { oraOptions } from './logger.js';
 import promptTerminal from './promptWrapper.js';
 import { fetchMappings, fetchSchema } from './readmeAPIFetch.js';
-import chalk from 'chalk';
 
 type ValidationStatus = 'autofixed-with-issues' | 'autofixed' | 'has-issues' | 'valid';
 

--- a/src/lib/validateFrontmatter.ts
+++ b/src/lib/validateFrontmatter.ts
@@ -98,7 +98,7 @@ export async function validateFrontmatter(
       } else {
         status = 'autofixed-with-issues';
         this.warn(
-          `${filesWithUnfixableIssues.length} file(s) have issues that cannot be fixed automatically. Autofixable issues have been addressed but we also recommend addressing these issues as well. Please get in touch with us at support@readme.io if you need a hand.`,
+          `${filesWithUnfixableIssues.length} file(s) have issues that cannot be fixed automatically. Autofixable issues have been corrected but we also recommend addressing these issues as well. Please get in touch with us at support@readme.io if you need a hand.`,
         );
       }
     }


### PR DESCRIPTION
| 🚥 Resolves RM-12355 |
| :------------------- |

## 🧰 Changes

with the way our `docs upload` / `reference upload` / etc. commands are set up, this is how a command workflow might go with what’s in `next`:

1. user runs command
2. `rdme` detects autofixable frontmatter, prompts user to fix it
3. user says yes
4. frontmatter is autofixed
5. pages are then uploaded to ReadMe

based on internal feedback, that flow contains too _**little**_ friction (e.g., the idea of doing steps 4 and 5 above in one fell swoop is a little heavy-handed and is throwing folks off).

this PR tweaks this a bit so this is the new flow:

1. user runs command
2. `rdme` detects autofixable frontmatter, prompts user to fix it
3. user says yes
4. frontmatter is autofixed
5. `rdme` displays frontmatter autofixing results, prompts user to run the command again in order to upload files, and then exits.
6. user runs `rdme` again, per instructions
7. pages are then uploaded to ReadMe

## 🧬 QA & Testing

i still need to QA this against a local project (will mark this as officially ready for review when that's done), but the tests around this are pretty airtight.

**edit**: QA is done! here's what the new flow looks like:

![CleanShot 2025-07-02 at 14 08 37@2x](https://github.com/user-attachments/assets/d71e0f20-d8be-464f-825e-88358b76b480)

