### PR TITLE
chore: remove bidi checks for page uploads

### DIFF
--- a/__tests__/commands/changelog/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/changelog/__snapshots__/upload.test.ts.snap
@@ -1,55 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`rdme changelog upload > given that ReadMe project has bidirection sync set up > should error if validation is not skipped 1`] = `
-{
-  "error": [Error: Bi-directional syncing is enabled for this project. Uploading these docs will overwrite what's currently synced from Git. To proceed with the upload, re-run this command with the \`--skip-validation\` flag.],
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-",
-  "stdout": "",
-}
-`;
-
-exports[`rdme changelog upload > given that ReadMe project has bidirection sync set up > should handle an error if /projects/me returns an error 1`] = `
-{
-  "error": [APIv2Error: ReadMe API error: The API key couldn't be located.
-
-The API key you passed in (bad-api-key) doesn't match any keys we have in our system. API keys must be passed in via Bearer token. You can get your API key in Configuration > API Key, or in the docs.],
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-",
-  "stdout": "",
-}
-`;
-
-exports[`rdme changelog upload > given that ReadMe project has bidirection sync set up > should upload if validation is skipped 1`] = `
-{
-  "result": {
-    "created": [
-      {
-        "filePath": "__tests__/__fixtures__/changelog/mixed-docs/invalid-attributes.md",
-        "response": {},
-        "result": "created",
-        "slug": "invalid-attributes",
-      },
-    ],
-    "failed": [],
-    "skipped": [],
-    "updated": [],
-  },
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
- ›   Warning: Bi-directional syncing is enabled for this project. Uploading 
- ›   these docs will overwrite what's currently synced from Git.
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
-",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
-   - invalid-attributes (__tests__/__fixtures__/changelog/mixed-docs/invalid-attributes.md)
-",
-}
-`;
-
 exports[`rdme changelog upload > given that the file path is a directory > should create a page in ReadMe for each file in the directory and its subdirectories 1`] = `
 {
   "result": {

--- a/__tests__/commands/custompages/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/custompages/__snapshots__/upload.test.ts.snap
@@ -1,55 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`custompages upload > given that ReadMe project has bidirection sync set up > should error if validation is not skipped 1`] = `
-{
-  "error": [Error: Bi-directional syncing is enabled for this project. Uploading these docs will overwrite what's currently synced from Git. To proceed with the upload, re-run this command with the \`--skip-validation\` flag.],
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-",
-  "stdout": "",
-}
-`;
-
-exports[`custompages upload > given that ReadMe project has bidirection sync set up > should handle an error if /projects/me returns an error 1`] = `
-{
-  "error": [APIv2Error: ReadMe API error: The API key couldn't be located.
-
-The API key you passed in (bad-api-key) doesn't match any keys we have in our system. API keys must be passed in via Bearer token. You can get your API key in Configuration > API Key, or in the docs.],
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-",
-  "stdout": "",
-}
-`;
-
-exports[`custompages upload > given that ReadMe project has bidirection sync set up > should upload if validation is skipped 1`] = `
-{
-  "result": {
-    "created": [
-      {
-        "filePath": "__tests__/__fixtures__/custompages/new-docs/new-doc.md",
-        "response": {},
-        "result": "created",
-        "slug": "new-doc",
-      },
-    ],
-    "failed": [],
-    "skipped": [],
-    "updated": [],
-  },
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
- ›   Warning: Bi-directional syncing is enabled for this project. Uploading 
- ›   these docs will overwrite what's currently synced from Git.
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
-",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
-   - new-doc (__tests__/__fixtures__/custompages/new-docs/new-doc.md)
-",
-}
-`;
-
 exports[`custompages upload > given that the file path is a directory > should create a page in ReadMe for each file in the directory and its subdirectories 1`] = `
 {
   "result": {

--- a/__tests__/commands/pages/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/pages/__snapshots__/upload.test.ts.snap
@@ -1,55 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`rdme docs upload > given that ReadMe project has bidirection sync set up > should error if validation is not skipped 1`] = `
-{
-  "error": [Error: Bi-directional syncing is enabled for this project. Uploading these docs will overwrite what's currently synced from Git. To proceed with the upload, re-run this command with the \`--skip-validation\` flag.],
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-",
-  "stdout": "",
-}
-`;
-
-exports[`rdme docs upload > given that ReadMe project has bidirection sync set up > should handle an error if /projects/me returns an error 1`] = `
-{
-  "error": [APIv2Error: ReadMe API error: The API key couldn't be located.
-
-The API key you passed in (bad-api-key) doesn't match any keys we have in our system. API keys must be passed in via Bearer token. You can get your API key in Configuration > API Key, or in the docs.],
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-",
-  "stdout": "",
-}
-`;
-
-exports[`rdme docs upload > given that ReadMe project has bidirection sync set up > should upload if validation is skipped 1`] = `
-{
-  "result": {
-    "created": [
-      {
-        "filePath": "__tests__/__fixtures__/docs/new-docs/new-doc.md",
-        "response": {},
-        "result": "created",
-        "slug": "new-doc",
-      },
-    ],
-    "failed": [],
-    "skipped": [],
-    "updated": [],
-  },
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
- ›   Warning: Bi-directional syncing is enabled for this project. Uploading 
- ›   these docs will overwrite what's currently synced from Git.
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
-",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
-   - new-doc (__tests__/__fixtures__/docs/new-docs/new-doc.md)
-",
-}
-`;
-
 exports[`rdme docs upload > given that the file path is a directory > given that the directory contains parent/child docs > should upload parents before children 1`] = `
 {
   "result": {
@@ -984,56 +934,6 @@ something went so so wrong],
 ",
   "stdout": "🚨 Received errors when attempting to upload 1 page(s):
    - __tests__/__fixtures__/docs/new-docs/new-doc.md: bad request
-",
-}
-`;
-
-exports[`rdme reference upload > given that ReadMe project has bidirection sync set up > should error if validation is not skipped 1`] = `
-{
-  "error": [Error: Bi-directional syncing is enabled for this project. Uploading these docs will overwrite what's currently synced from Git. To proceed with the upload, re-run this command with the \`--skip-validation\` flag.],
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-",
-  "stdout": "",
-}
-`;
-
-exports[`rdme reference upload > given that ReadMe project has bidirection sync set up > should handle an error if /projects/me returns an error 1`] = `
-{
-  "error": [APIv2Error: ReadMe API error: The API key couldn't be located.
-
-The API key you passed in (bad-api-key) doesn't match any keys we have in our system. API keys must be passed in via Bearer token. You can get your API key in Configuration > API Key, or in the docs.],
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-",
-  "stdout": "",
-}
-`;
-
-exports[`rdme reference upload > given that ReadMe project has bidirection sync set up > should upload if validation is skipped 1`] = `
-{
-  "result": {
-    "created": [
-      {
-        "filePath": "__tests__/__fixtures__/docs/new-docs/new-doc.md",
-        "response": {},
-        "result": "created",
-        "slug": "new-doc",
-      },
-    ],
-    "failed": [],
-    "skipped": [],
-    "updated": [],
-  },
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
- ›   Warning: Bi-directional syncing is enabled for this project. Uploading 
- ›   these docs will overwrite what's currently synced from Git.
-- 🚀 Uploading files to ReadMe...
-✔ 🚀 Uploading files to ReadMe... done!
-",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
-   - new-doc (__tests__/__fixtures__/docs/new-docs/new-doc.md)
 ",
 }
 `;

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -1,5 +1,5 @@
 import type { APIv2PageUploadCommands } from '../index.js';
-import type { PageRequestSchema, PageResponseSchema, ProjectRepresentation } from './types/index.js';
+import type { PageRequestSchema, PageResponseSchema } from './types/index.js';
 
 import path from 'node:path';
 

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -234,20 +234,7 @@ function sortFiles(
  */
 export default async function syncPagePath(this: APIv2PageUploadCommands): Promise<FullUploadResults> {
   const { path: pathInput } = this.args;
-  const { key, 'dry-run': dryRun, 'max-errors': maxErrors, 'skip-validation': skipValidation } = this.flags;
-
-  // check whether or not the project has bidirection syncing enabled
-  // if it is, validations must be skipped to prevent frontmatter from being overwritten
-  const headers = new Headers({ authorization: `Bearer ${key}` });
-  const projectMetadata: ProjectRepresentation = await this.readmeAPIFetch('/projects/me', {
-    method: 'GET',
-    headers,
-  }).then(res => {
-    return this.handleAPIRes(res);
-  });
-
-  const biDiConnection = projectMetadata?.data?.git?.connection?.status === 'active';
-  this.debug(`bi-directional syncing is ${biDiConnection ? 'enabled' : 'disabled'}`);
+  const { 'dry-run': dryRun, 'max-errors': maxErrors, 'skip-validation': skipValidation } = this.flags;
 
   const validFileExtensions = [...allowedMarkdownExtensions];
   if (this.route === 'custom_pages') {

--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -247,11 +247,7 @@ export default async function syncPagePath(this: APIv2PageUploadCommands): Promi
   });
 
   const biDiConnection = projectMetadata?.data?.git?.connection?.status === 'active';
-  if (biDiConnection && !skipValidation) {
-    throw new Error(
-      "Bi-directional syncing is enabled for this project. Uploading these docs will overwrite what's currently synced from Git. To proceed with the upload, re-run this command with the `--skip-validation` flag.",
-    );
-  }
+  this.debug(`bi-directional syncing is ${biDiConnection ? 'enabled' : 'disabled'}`);
 
   const validFileExtensions = [...allowedMarkdownExtensions];
   if (this.route === 'custom_pages') {
@@ -261,13 +257,7 @@ export default async function syncPagePath(this: APIv2PageUploadCommands): Promi
   let unsortedFiles = await findPages.call(this, pathInput, validFileExtensions);
 
   if (skipValidation) {
-    if (biDiConnection) {
-      this.warn(
-        "Bi-directional syncing is enabled for this project. Uploading these docs will overwrite what's currently synced from Git.",
-      );
-    } else {
-      this.warn('Skipping pre-upload validation of the Markdown file(s). This is not recommended.');
-    }
+    this.warn('Skipping pre-upload validation of the Markdown file(s). This is not recommended.');
   } else {
     const validationResults = await validateFrontmatter.call(this, unsortedFiles);
 


### PR DESCRIPTION
| 🚥 Resolves RM-13222 |
| :------------------- |

## 🧰 Changes

We had added in a check for projects with bidi connections, and required them to use the `--skip-validation` flag if it was enabled in order to use rdme to upload pages. This was maybe a bit overly prescriptive and we would actually want that validation to happen, even if bidi is enabled. We haven't fully ironed out what the behavior should be for customers using both rdme and bidi to sync docs, but for now, we're gonna remove all guardrails and checks. Once customers start really using these flows, we can see if we need to make updates.

## 🧬 QA & Testing

Updated tests & they're still passing
