### PR TITLE
feat(logger): improved warnings for GHA users

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Sync docs to ReadMe (dry run)
         uses: ./
         with:
-          rdme: docs upload ./documentation/synced --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ vars.README_DEVELOPERS_MAIN_VERSION }} --dryRun
+          rdme: docs upload ./documentation/synced --key=${{ secrets.README_DEVELOPERS_API_KEY }} --branch=${{ vars.README_DEVELOPERS_MAIN_VERSION }} --dry-run
 
       - name: Sync docs to ReadMe
         # And finally, we perform an actual sync to ReadMe if we're on the main branch

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Sync docs to ReadMe (dry run)
         uses: ./
         with:
-          rdme: docs upload ./documentation/synced --key=${{ secrets.README_DEVELOPERS_API_KEY }} --branch=${{ vars.README_DEVELOPERS_MAIN_VERSION }} --dry-run
+          rdme: docs upload ./documentation/synced --key=${{ secrets.README_DEVELOPERS_API_KEY }} --version=${{ vars.README_DEVELOPERS_MAIN_VERSION }} --dryRun
 
       - name: Sync docs to ReadMe
         # And finally, we perform an actual sync to ReadMe if we're on the main branch

--- a/__tests__/commands/changelog/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/changelog/__snapshots__/upload.test.ts.snap
@@ -343,12 +343,11 @@ exports[`rdme changelog upload > given that the file path is a single file > and
     ],
     "updated": [],
   },
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-- 🔬 Validating frontmatter data...
+  "stderr": "- 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
 ",
-  "stdout": "Automatically fixing issues in 1 file(s)...
+  "stdout": "::warning::This command is in an experimental alpha and is likely to change. Use at your own risk!
+Automatically fixing issues in 1 file(s)...
 === BEGIN writeFileSync to file: __tests__/__fixtures__/changelog/legacy-docs/autofixable.md ===
 ---
 type: added
@@ -383,14 +382,13 @@ exports[`rdme changelog upload > given that the file path is a single file > and
     "skipped": [],
     "updated": [],
   },
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-- 🔬 Validating frontmatter data...
+  "stderr": "- 🔬 Validating frontmatter data...
 ✔ 🔬 Validating frontmatter data... no issues found!
 - 🚀 Uploading files to ReadMe...
 ✔ 🚀 Uploading files to ReadMe... done!
 ",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
+  "stdout": "::warning::This command is in an experimental alpha and is likely to change. Use at your own risk!
+🌱 Successfully created 1 page(s) in ReadMe:
    - new-doc (__tests__/__fixtures__/changelog/new-docs/new-doc.md)
 ",
 }
@@ -399,12 +397,11 @@ exports[`rdme changelog upload > given that the file path is a single file > and
 exports[`rdme changelog upload > given that the file path is a single file > and the command is being run in a CI environment > should error out if the file has validation errors 1`] = `
 {
   "error": [Error: 1 file(s) have issues that should be fixed before uploading to ReadMe. Please run \`rdme changelog upload __tests__/__fixtures__/changelog/legacy-docs/autofixable.md --dry-run\` in a non-CI environment to fix them.],
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-- 🔬 Validating frontmatter data...
+  "stderr": "- 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
 ",
-  "stdout": "",
+  "stdout": "::warning::This command is in an experimental alpha and is likely to change. Use at your own risk!
+",
 }
 `;
 

--- a/__tests__/commands/custompages/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/custompages/__snapshots__/upload.test.ts.snap
@@ -360,12 +360,11 @@ exports[`custompages upload > given that the file path is a single file > and th
     ],
     "updated": [],
   },
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-- 🔬 Validating frontmatter data...
+  "stderr": "- 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
 ",
-  "stdout": "Automatically fixing issues in 1 file(s)...
+  "stdout": "::warning::This command is in an experimental alpha and is likely to change. Use at your own risk!
+Automatically fixing issues in 1 file(s)...
 === BEGIN writeFileSync to file: __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md ===
 ---
 title: This is the document title
@@ -401,14 +400,13 @@ exports[`custompages upload > given that the file path is a single file > and th
     "skipped": [],
     "updated": [],
   },
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-- 🔬 Validating frontmatter data...
+  "stderr": "- 🔬 Validating frontmatter data...
 ✔ 🔬 Validating frontmatter data... no issues found!
 - 🚀 Uploading files to ReadMe...
 ✔ 🚀 Uploading files to ReadMe... done!
 ",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
+  "stdout": "::warning::This command is in an experimental alpha and is likely to change. Use at your own risk!
+🌱 Successfully created 1 page(s) in ReadMe:
    - new-doc (__tests__/__fixtures__/custompages/new-docs/new-doc.md)
 ",
 }
@@ -417,12 +415,11 @@ exports[`custompages upload > given that the file path is a single file > and th
 exports[`custompages upload > given that the file path is a single file > and the command is being run in a CI environment > should error out if the file has validation errors 1`] = `
 {
   "error": [Error: 1 file(s) have issues that should be fixed before uploading to ReadMe. Please run \`rdme custompages upload __tests__/__fixtures__/custompages/mixed-docs/legacy-page.md --dry-run\` in a non-CI environment to fix them.],
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-- 🔬 Validating frontmatter data...
+  "stderr": "- 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
 ",
-  "stdout": "",
+  "stdout": "::warning::This command is in an experimental alpha and is likely to change. Use at your own risk!
+",
 }
 `;
 

--- a/__tests__/commands/openapi/__snapshots__/convert.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/convert.test.ts.snap
@@ -4,7 +4,8 @@ exports[`rdme openapi convert > error handling > should warn if given an OpenAPI
 {
   "result": "Your API definition has been converted and bundled and saved to output.json!",
   "stderr": "- Validating the API definition located at petstore.json...
-⚠️  Warning! The input file is already OpenAPI, so no conversion is necessary. Any external references will be bundled.
+ ›   Warning: The input file is already OpenAPI, so no conversion is necessary.
+ ›    Any external references will be bundled.
 ",
   "stdout": "",
 }
@@ -14,7 +15,8 @@ exports[`rdme openapi convert > error handling > should warn if given an OpenAPI
 {
   "result": "Your API definition has been converted and bundled and saved to output.json!",
   "stderr": "- Validating the API definition located at petstore.yaml...
-⚠️  Warning! The input file is already OpenAPI, so no conversion is necessary. Any external references will be bundled.
+ ›   Warning: The input file is already OpenAPI, so no conversion is necessary.
+ ›    Any external references will be bundled.
 ",
   "stdout": "",
 }

--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -141,14 +141,11 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
     "uri": "/branches/1.0.0/apis/__tests____fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This 
- ›   slug is not visible to your end users. To set this slug to something else,
- ›    use the \`--slug\` flag.
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",
-  "stdout": "🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
+  "stdout": "::warning::The slug of your API Definition will be set to __tests____fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
+🚀 Your API definition (__tests____fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
 ",
 }
 `;

--- a/__tests__/commands/pages/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/pages/__snapshots__/upload.test.ts.snap
@@ -398,12 +398,11 @@ exports[`rdme docs upload > given that the file path is a single file > and the 
     ],
     "updated": [],
   },
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-- 🔬 Validating frontmatter data...
+  "stderr": "- 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
 ",
-  "stdout": "Automatically fixing issues in 1 file(s)...
+  "stdout": "::warning::This command is in an experimental alpha and is likely to change. Use at your own risk!
+Automatically fixing issues in 1 file(s)...
 === BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
 ---
 category:
@@ -437,14 +436,13 @@ exports[`rdme docs upload > given that the file path is a single file > and the 
     "skipped": [],
     "updated": [],
   },
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-- 🔬 Validating frontmatter data...
+  "stderr": "- 🔬 Validating frontmatter data...
 ✔ 🔬 Validating frontmatter data... no issues found!
 - 🚀 Uploading files to ReadMe...
 ✔ 🚀 Uploading files to ReadMe... done!
 ",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
+  "stdout": "::warning::This command is in an experimental alpha and is likely to change. Use at your own risk!
+🌱 Successfully created 1 page(s) in ReadMe:
    - new-doc (__tests__/__fixtures__/docs/new-docs/new-doc.md)
 ",
 }
@@ -453,12 +451,11 @@ exports[`rdme docs upload > given that the file path is a single file > and the 
 exports[`rdme docs upload > given that the file path is a single file > and the command is being run in a CI environment > should error out if the file has validation errors 1`] = `
 {
   "error": [Error: 1 file(s) have issues that should be fixed before uploading to ReadMe. Please run \`rdme docs upload __tests__/__fixtures__/docs/mixed-docs/legacy-category.md --dry-run\` in a non-CI environment to fix them.],
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-- 🔬 Validating frontmatter data...
+  "stderr": "- 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
 ",
-  "stdout": "",
+  "stdout": "::warning::This command is in an experimental alpha and is likely to change. Use at your own risk!
+",
 }
 `;
 
@@ -1336,12 +1333,11 @@ exports[`rdme reference upload > given that the file path is a single file > and
     ],
     "updated": [],
   },
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-- 🔬 Validating frontmatter data...
+  "stderr": "- 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
 ",
-  "stdout": "Automatically fixing issues in 1 file(s)...
+  "stdout": "::warning::This command is in an experimental alpha and is likely to change. Use at your own risk!
+Automatically fixing issues in 1 file(s)...
 === BEGIN writeFileSync to file: __tests__/__fixtures__/docs/mixed-docs/legacy-category.md ===
 ---
 category:
@@ -1375,14 +1371,13 @@ exports[`rdme reference upload > given that the file path is a single file > and
     "skipped": [],
     "updated": [],
   },
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-- 🔬 Validating frontmatter data...
+  "stderr": "- 🔬 Validating frontmatter data...
 ✔ 🔬 Validating frontmatter data... no issues found!
 - 🚀 Uploading files to ReadMe...
 ✔ 🚀 Uploading files to ReadMe... done!
 ",
-  "stdout": "🌱 Successfully created 1 page(s) in ReadMe:
+  "stdout": "::warning::This command is in an experimental alpha and is likely to change. Use at your own risk!
+🌱 Successfully created 1 page(s) in ReadMe:
    - new-doc (__tests__/__fixtures__/docs/new-docs/new-doc.md)
 ",
 }
@@ -1391,12 +1386,11 @@ exports[`rdme reference upload > given that the file path is a single file > and
 exports[`rdme reference upload > given that the file path is a single file > and the command is being run in a CI environment > should error out if the file has validation errors 1`] = `
 {
   "error": [Error: 1 file(s) have issues that should be fixed before uploading to ReadMe. Please run \`rdme reference upload __tests__/__fixtures__/docs/mixed-docs/legacy-category.md --dry-run\` in a non-CI environment to fix them.],
-  "stderr": " ›   Warning: This command is in an experimental alpha and is likely to change.
- ›    Use at your own risk!
-- 🔬 Validating frontmatter data...
+  "stderr": "- 🔬 Validating frontmatter data...
 ⚠ 🔬 Validating frontmatter data... issues found in 1 file(s).
 ",
-  "stdout": "",
+  "stdout": "::warning::This command is in an experimental alpha and is likely to change. Use at your own risk!
+",
 }
 `;
 

--- a/src/commands/openapi/convert.ts
+++ b/src/commands/openapi/convert.ts
@@ -9,7 +9,6 @@ import prompts from 'prompts';
 
 import BaseCommand from '../../lib/baseCommand.js';
 import { specArg, titleFlag, workingDirectoryFlag } from '../../lib/flags.js';
-import { warn } from '../../lib/logger.js';
 import prepareOas from '../../lib/prepareOas.js';
 import promptTerminal from '../../lib/promptWrapper.js';
 import { validateFilePath } from '../../lib/validatePromptInput.js';
@@ -59,7 +58,7 @@ export default class OpenAPIConvertCommand extends BaseCommand<typeof OpenAPICon
     const parsedPreparedSpec: OASDocument = JSON.parse(preparedSpec);
 
     if (specType === 'OpenAPI') {
-      warn(
+      this.warn(
         'The input file is already OpenAPI, so no conversion is necessary. Any external references will be bundled.',
       );
     }

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -4,7 +4,7 @@ import type { Config, Hook, Interfaces } from '@oclif/core';
 import { format } from 'node:util';
 
 import * as core from '@actions/core';
-import { Command as OclifCommand } from '@oclif/core';
+import { Errors, Command as OclifCommand } from '@oclif/core';
 import chalk from 'chalk';
 import debugPkg from 'debug';
 
@@ -57,6 +57,17 @@ export default abstract class BaseCommand<T extends typeof OclifCommand> extends
     if (!this.jsonEnabled()) {
       info(input, opts);
     }
+  }
+
+  public warn(input: Error | string): Error | string {
+    if (!this.jsonEnabled()) {
+      if (isGHA()) {
+        core.warning(input);
+      } else {
+        Errors.warn(input);
+      }
+    }
+    return input;
   }
 
   protected async catch(err: Error & { exitCode?: number }) {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -37,7 +37,8 @@ function error(input: string) {
 
 /**
  * Wrapper for info/notice statements.
-
+ *
+ * @deprecated use the base command's `this.info` method instead.
  */
 function info(
   input: string,
@@ -65,6 +66,8 @@ function oraOptions() {
 
 /**
  * Wrapper for warn statements.
+ *
+ * @deprecated use the base command's `this.warn` method instead.
  */
 function warn(
   /**

--- a/src/lib/readmeAPIFetch.ts
+++ b/src/lib/readmeAPIFetch.ts
@@ -317,7 +317,7 @@ export async function readmeAPIv2Fetch<T extends Hook.Context = Hook.Context>(
         this.debug(`received warning header: ${warningHeader}`);
         const warnings = parseWarningHeader(warningHeader);
         warnings.forEach(warning => {
-          warn(warning.message, 'ReadMe API Warning:');
+          this.warn(`⚠️ ReadMe API Warning: ${warning.message}`);
         });
       }
       return res;


### PR DESCRIPTION
| 🚥 Resolves RM-13246 |
| :------------------- |

## 🧰 Changes

updates the formatting for our `this.warn()` statements so they're surfaced properly in github actions annotations.

- [x] make sure everything else is merged in and refresh this branch afterwards
- [x] do a dry run with the CI changes in https://github.com/readmeio/rdme/pull/1284 to ensure that warnings are surfaced properly

## 🧬 QA & Testing

i confirmed that these are showing up properly: https://github.com/readmeio/rdme/actions/runs/16131074838/job/45518517159
