### PR TITLE
refactor: add `runRdmeCommand` helper

### DIFF
--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -1,3 +1,4 @@
+import type { COMMANDS } from '../index.js';
 import type { CreateGHAHook, CreateGHAHookOptsInClass } from './hooks/createGHA.js';
 import type { Config, Hook, Interfaces } from '@oclif/core';
 
@@ -57,6 +58,18 @@ export default abstract class BaseCommand<T extends typeof OclifCommand> extends
     if (!this.jsonEnabled()) {
       info(input, opts);
     }
+  }
+
+  /**
+   * A typesafe handler for running another `rdme` command.
+   *
+   * @example
+   * ```ts
+   * await this.runRdmeCommand('docs:upload', [this.flags.dir, '--skip-validation', '--key', this.flags.key]);
+   * ```
+   */
+  async runRdmeCommand<C extends keyof typeof COMMANDS>(command: C, argv?: string[]) {
+    return this.config.runCommand<Awaited<ReturnType<(typeof COMMANDS)[C]['prototype']['run']>>>(command, argv);
   }
 
   public warn(input: Error | string): Error | string {


### PR DESCRIPTION
## 🧰 Changes

as part of the experimental plugin work we did a few months ago, i wrote up this little helper method to have a typesafe way to invoke `rdme` commands. this PR adds that method in.

## 🧬 QA & Testing

i confirmed that this method works as expected locally! might add a unit test before marking this for review.
