### PR TITLE
docs: use major node version in placeholders

### DIFF
--- a/__tests__/lib/getPkgVersion.test.ts
+++ b/__tests__/lib/getPkgVersion.test.ts
@@ -5,7 +5,6 @@ import pkg from '../../package.json' with { type: 'json' };
 import { getNodeVersion, getPkgVersion, getPkgVersionFromNPM } from '../../src/lib/getPkg.js';
 
 describe('#getNodeVersion()', () => {
-
   it('should return a major version', () => {
     const version = getNodeVersion();
 

--- a/__tests__/lib/getPkgVersion.test.ts
+++ b/__tests__/lib/getPkgVersion.test.ts
@@ -1,16 +1,15 @@
 import nock from 'nock';
-import semver from 'semver';
 import { describe, beforeEach, afterEach, it, expect, vi, type MockInstance } from 'vitest';
 
 import pkg from '../../package.json' with { type: 'json' };
 import { getNodeVersion, getPkgVersion, getPkgVersionFromNPM } from '../../src/lib/getPkg.js';
 
 describe('#getNodeVersion()', () => {
-  it('should extract version that matches range in package.json', () => {
-    const version = getNodeVersion();
-    const cleanedVersion = semver.valid(semver.coerce(version));
 
-    expect(semver.satisfies(cleanedVersion as string, pkg.engines.node)).toBe(true);
+  it('should return a major version', () => {
+    const version = getNodeVersion();
+
+    expect(version).toHaveLength(2);
   });
 });
 

--- a/src/lib/getPkg.ts
+++ b/src/lib/getPkg.ts
@@ -24,7 +24,7 @@ export function getNodeVersion(): string {
   if (!parsedVersion) {
     throw new Error('`version` value in package.json is invalid');
   }
-  return parsedVersion.version;
+  return parsedVersion.major.toString();
 }
 
 /**


### PR DESCRIPTION
## 🧰 Changes

i noticed that our docs are displaying an improper node.js version range on the docker image examples — i fixed it up here: https://github.com/readmeio/docs-developers/compare/5b0fe7c01d74d5732070cd731eb42b6b92bcb17d...8f77f008b62555178ab1f405429dddb88ee69dd4

this PR ensures this remains correct.
