### PR TITLE
feat: new `rage` command for printing out environment data for debugging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "simple-git": "^3.19.1",
         "slugify": "^1.6.6",
         "string-argv": "^0.3.2",
+        "supports-color": "^10.0.0",
         "table": "^6.8.1",
         "tmp-promise": "^3.0.3",
         "toposort": "^2.0.2",
@@ -3428,6 +3429,21 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/@oclif/plugin-autocomplete": {
@@ -15951,15 +15967,12 @@
       "integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g=="
     },
     "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.0.0.tgz",
+      "integrity": "sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==",
       "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "simple-git": "^3.19.1",
     "slugify": "^1.6.6",
     "string-argv": "^0.3.2",
+    "supports-color": "^10.0.0",
     "table": "^6.8.1",
     "tmp-promise": "^3.0.3",
     "toposort": "^2.0.2",

--- a/src/commands/rage.ts
+++ b/src/commands/rage.ts
@@ -1,0 +1,55 @@
+import supportsColor from 'supports-color';
+import { getBorderCharacters, table } from 'table';
+
+import BaseCommand from '../lib/baseCommand.js';
+import configstore from '../lib/configstore.js';
+import getCurrentConfig from '../lib/getCurrentConfig.js';
+import isCI, { ciName, isGHA } from '../lib/isCI.js';
+
+export default class RageCommand extends BaseCommand<typeof RageCommand> {
+  static description = 'Prints information for debugging.';
+
+  static hidden = true;
+
+  async run() {
+    const { apiKey, email, project } = getCurrentConfig.call(this);
+
+    const rage = Object.entries({
+      CLI: {
+        Version: this.config.version,
+        // This `supports-color` logic is the same that `@oclif/core/ux` uses for `colorize` they
+        // just don't expose their internal `supportsColor` library.
+        'Color support': Boolean(supportsColor.stdout) && Boolean(supportsColor.stderr),
+      },
+      Platform: {
+        'CPU Architecture': process.arch,
+        OS: process.platform,
+      },
+      Environment: {
+        CI: isCI() ? ciName() : false,
+        'GitHub Actions': isGHA(),
+      },
+      Configuration: {
+        // If we didn't find any data in their config file then it's either empty or doens't exist
+        // so it seems reasonable to ascertain if we were able to successfully load it or not by
+        // that.
+        'Loaded successfully': Boolean(apiKey || email || project),
+        Path: configstore.path,
+      },
+    }).flatMap(([section, values]) => {
+      const sectionData = Object.entries(values).map(([key, value]) => [`  ${key}:`, value]);
+      return [[`${section}:`, ''], ...sectionData, ['', '']];
+    });
+
+    const output = table(rage, {
+      border: getBorderCharacters('void'),
+      drawHorizontalLine: () => false,
+      columnDefault: {
+        paddingLeft: 0,
+        paddingRight: 1,
+      },
+    });
+
+    return Promise.resolve(output);
+  }
+}

--- a/src/commands/rage.ts
+++ b/src/commands/rage.ts
@@ -14,7 +14,7 @@ export default class RageCommand extends BaseCommand<typeof RageCommand> {
   async run() {
     const { apiKey, email, project } = getCurrentConfig.call(this);
 
-    const rage = Object.entries({
+    const rage = {
       CLI: {
         Version: this.config.version,
         // This `supports-color` logic is the same that `@oclif/core/ux` uses for `colorize` they
@@ -36,12 +36,20 @@ export default class RageCommand extends BaseCommand<typeof RageCommand> {
         'Loaded successfully': Boolean(apiKey || email || project),
         Path: configstore.path,
       },
-    }).flatMap(([section, values]) => {
-      const sectionData = Object.entries(values).map(([key, value]) => [`  ${key}:`, value]);
-      return [[`${section}:`, ''], ...sectionData, ['', '']];
-    });
+    };
 
-    const output = table(rage, {
+    const data = Object.entries(rage).flatMap(([section, values], idx) => {
+      const sectionData = Object.entries(values).map(([key, value]) => [`  ${key}:`, value]);
+      return [
+        [`${section}:`, ''],
+        ...sectionData,
+
+        // Only add a group separator if this isn't the last section.
+        idx !== (Object.keys(rage).length - 1) ? ['', ''] : false
+      ];
+    }).filter(Boolean) as [string, string][];
+
+    const output = table(data, {
       border: getBorderCharacters('void'),
       drawHorizontalLine: () => false,
       columnDefault: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import OpenAPIReduceCommand from './commands/openapi/reduce.js';
 import OpenAPIResolveCommand from './commands/openapi/resolve.js';
 import OpenAPIUploadCommand from './commands/openapi/upload.js';
 import OpenAPIValidateCommand from './commands/openapi/validate.js';
+import RageCommand from './commands/rage.js';
 import RefUploadCommand from './commands/reference/upload.js';
 import WhoAmICommand from './commands/whoami.js';
 
@@ -51,6 +52,8 @@ export const COMMANDS = {
   'openapi:resolve': OpenAPIResolveCommand,
   'openapi:upload': OpenAPIUploadCommand,
   'openapi:validate': OpenAPIValidateCommand,
+
+  'rage': RageCommand,
 
   'reference:upload': RefUploadCommand,
 


### PR DESCRIPTION
## 🧰 Changes

I've been kind of amused by Biome's `rage` command for printing out environment data for debugging:

```
$ npx biome rage
CLI:
  Version:                      2.1.2
  Color support:                true

Platform:
  CPU Architecture:             aarch64
  OS:                           macos

Environment:
  BIOME_LOG_PATH:               unset
  BIOME_LOG_PREFIX_NAME:        unset
  BIOME_CONFIG_PATH:            unset
  BIOME_THREADS:                unset
  NO_COLOR:                     unset
  TERM:                         xterm-256color
  JS_RUNTIME_VERSION:           v20.19.0
  JS_RUNTIME_NAME:              node
  NODE_PACKAGE_MANAGER:         npm/10.8.2

Biome Configuration:
  Status:                       Loaded successfully
  Path:                         biome.jsonc
  Formatter enabled:            false
  Linter enabled:               true
  Assist enabled:               true
  VCS enabled:                  false

Workspace:
  Open Documents:               0
```

Given that rdme supports a number of different environments it might be nice for us to have something similar that isn't just a `rdme --version` call so I've created `rdme rage`. This is what it looks like:

```
$ ./bin/dev.js rage
CLI:                                                                            
  Version:             10.5.0-next.1                                            
  Color support:       true                                                     
                                                                                
Platform:                                                                       
  CPU Architecture:    arm64                                                    
  OS:                  darwin                                                   
                                                                                
Environment:                                                                    
  CI:                  false                                                    
  GitHub Actions:      false                                                    
                                                                                
Configuration:                                                                  
  Loaded successfully: false                                                    
  Path:                /Users/erunion/.config/configstore/rdme-development.json 
```
