### PR TITLE
fix(openapi/upload): custom slugs for URL uploads

### DIFF
--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -65,6 +65,21 @@ exports[`rdme openapi upload > given that the "--legacy-id" flag is passed > sho
 }
 `;
 
+exports[`rdme openapi upload > given that the API definition is a URL > and the \`--slug\` flag is passed > should create a new API definition in ReadMe with the specified slug 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/branches/1.0.0/apis/custom-slug.json",
+  },
+  "stderr": "- Validating the API definition located at https://example.com/openapi.json...
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... done!
+",
+  "stdout": "🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
+",
+}
+`;
+
 exports[`rdme openapi upload > given that the API definition is a URL > should create a new API definition in ReadMe 1`] = `
 {
   "result": {

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -595,7 +595,9 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, {})
-          .post(`/branches/${branch}/apis`, body => body.match(`form-data; name="schema"; filename="${customFilename}.json"`))
+          .post(`/branches/${branch}/apis`, body =>
+            body.match(`form-data; name="schema"; filename="${customFilename}.json"`),
+          )
           .reply(200, {
             data: {
               upload: { status: 'done' },

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -528,12 +528,13 @@ describe('rdme openapi upload', () => {
 
   describe('given that the API definition is a URL', () => {
     it('should create a new API definition in ReadMe', async () => {
-      const fileMock = nock('https://example.com').get('/openapi.json').reply(200, petstore);
+      const filename = 'openapi.json';
+      const fileMock = nock('https://example.com').get(`/${filename}`).reply(200, petstore);
 
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, {})
-        .post(`/branches/${branch}/apis`, body => body.match(`form-data; name="url"\r\n\r\n${fileUrl}`))
+        .post(`/branches/${branch}/apis`, body => body.match(`form-data; name="schema"; filename="${filename}"`))
         .reply(200, {
           data: {
             upload: { status: 'done' },
@@ -552,12 +553,15 @@ describe('rdme openapi upload', () => {
     it('should update an existing API definition in ReadMe', async () => {
       prompts.inject([true]);
 
-      const fileMock = nock('https://example.com').get('/openapi.json').reply(200, petstore);
+      const filename = 'openapi.json';
+      const fileMock = nock('https://example.com').get(`/${filename}`).reply(200, petstore);
 
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, { data: [{ filename: 'openapi.json' }] })
-        .put('/branches/1.0.0/apis/openapi.json', body => body.match(`form-data; name="url"\r\n\r\n${fileUrl}`))
+        .put('/branches/1.0.0/apis/openapi.json', body =>
+          body.match(`form-data; name="schema"; filename="${filename}"`),
+        )
         .reply(200, {
           data: {
             upload: { status: 'done' },

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -586,6 +586,31 @@ describe('rdme openapi upload', () => {
 
       fileMock.done();
     });
+
+    describe('and the `--slug` flag is passed', () => {
+      it('should create a new API definition in ReadMe with the specified slug', async () => {
+        const customFilename = 'custom-slug';
+        const fileMock = nock('https://example.com').get('/openapi.json').reply(200, petstore);
+
+        const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
+          .get(`/branches/${branch}/apis`)
+          .reply(200, {})
+          .post(`/branches/${branch}/apis`, body => body.match(`form-data; name="schema"; filename="${customFilename}.json"`))
+          .reply(200, {
+            data: {
+              upload: { status: 'done' },
+              uri: `/branches/${branch}/apis/${customFilename}.json`,
+            },
+          });
+
+        const result = await run(['--branch', branch, fileUrl, '--key', key, '--slug', 'custom-slug']);
+
+        expect(result).toMatchSnapshot();
+
+        fileMock.done();
+        mock.done();
+      });
+    });
   });
 
   describe('given that the confirm overwrite flag is passed', () => {

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -528,13 +528,13 @@ describe('rdme openapi upload', () => {
 
   describe('given that the API definition is a URL', () => {
     it('should create a new API definition in ReadMe', async () => {
-      const filename = 'openapi.json';
-      const fileMock = nock('https://example.com').get(`/${filename}`).reply(200, petstore);
+      const urlFilename = 'openapi.json';
+      const fileMock = nock('https://example.com').get(`/${urlFilename}`).reply(200, petstore);
 
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, {})
-        .post(`/branches/${branch}/apis`, body => body.match(`form-data; name="schema"; filename="${filename}"`))
+        .post(`/branches/${branch}/apis`, body => body.match(`form-data; name="schema"; filename="${urlFilename}"`))
         .reply(200, {
           data: {
             upload: { status: 'done' },
@@ -553,14 +553,14 @@ describe('rdme openapi upload', () => {
     it('should update an existing API definition in ReadMe', async () => {
       prompts.inject([true]);
 
-      const filename = 'openapi.json';
-      const fileMock = nock('https://example.com').get(`/${filename}`).reply(200, petstore);
+      const urlFilename = 'openapi.json';
+      const fileMock = nock('https://example.com').get(`/${urlFilename}`).reply(200, petstore);
 
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, { data: [{ filename: 'openapi.json' }] })
         .put('/branches/1.0.0/apis/openapi.json', body =>
-          body.match(`form-data; name="schema"; filename="${filename}"`),
+          body.match(`form-data; name="schema"; filename="${urlFilename}"`),
         )
         .reply(200, {
           data: {

--- a/documentation/commands/openapi.md
+++ b/documentation/commands/openapi.md
@@ -143,7 +143,7 @@ Resolves circular and recursive references in OpenAPI by replacing them with obj
 
 ```
 USAGE
-  $ rdme openapi resolve [SPEC] [--out <value>] [--workingDirectory <value>]
+  $ rdme openapi resolve [SPEC] [--out <value>] [--title <value>] [--workingDirectory <value>]
 
 ARGUMENTS
   SPEC  A path to your API definition — either a local file path or a URL. If your working directory and all
@@ -151,6 +151,7 @@ ARGUMENTS
 
 FLAGS
   --out=<value>               Output file path to write resolved file to
+  --title=<value>             An override value for the `info.title` field in the API definition
   --workingDirectory=<value>  Working directory (for usage with relative external references)
 
 DESCRIPTION
@@ -184,7 +185,7 @@ Upload (or re-upload) your API definition to ReadMe.
 
 ```
 USAGE
-  $ rdme openapi upload [SPEC] --key <value> [--slug <value>] [--useSpecVersion | --branch <value>]
+  $ rdme openapi upload [SPEC] --key <value> [--slug <value>] [--title <value>] [--useSpecVersion | --branch <value>]
 
 ARGUMENTS
   SPEC  A path to your API definition — either a local file path or a URL. If your working directory and all
@@ -194,6 +195,7 @@ FLAGS
   --key=<value>     (required) ReadMe project API key
   --branch=<value>  [default: stable] ReadMe project version
   --slug=<value>    Override the slug (i.e., the unique identifier) for your API definition.
+  --title=<value>   An override value for the `info.title` field in the API definition
   --useSpecVersion  Use the OpenAPI `info.version` field for your ReadMe project version
 
 DESCRIPTION

--- a/src/commands/openapi/convert.ts
+++ b/src/commands/openapi/convert.ts
@@ -14,6 +14,8 @@ import promptTerminal from '../../lib/promptWrapper.js';
 import { validateFilePath } from '../../lib/validatePromptInput.js';
 
 export default class OpenAPIConvertCommand extends BaseCommand<typeof OpenAPIConvertCommand> {
+  id = 'openapi convert' as const;
+
   static summary = 'Converts an API definition to OpenAPI and bundles any external references.';
 
   static description =
@@ -51,7 +53,7 @@ export default class OpenAPIConvertCommand extends BaseCommand<typeof OpenAPICon
       this.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
-    const { preparedSpec, specPath, specType } = await prepareOas.call(this, 'openapi convert');
+    const { preparedSpec, specPath, specType } = await prepareOas.call(this);
     const parsedPreparedSpec: OASDocument = JSON.parse(preparedSpec);
 
     if (specType === 'OpenAPI') {

--- a/src/commands/openapi/convert.ts
+++ b/src/commands/openapi/convert.ts
@@ -43,8 +43,7 @@ export default class OpenAPIConvertCommand extends BaseCommand<typeof OpenAPICon
   ];
 
   async run() {
-    const { spec } = this.args;
-    const { out, title, workingDirectory } = this.flags;
+    const { out, workingDirectory } = this.flags;
 
     if (workingDirectory) {
       const previousWorkingDirectory = process.cwd();
@@ -52,9 +51,7 @@ export default class OpenAPIConvertCommand extends BaseCommand<typeof OpenAPICon
       this.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
-    const { preparedSpec, specPath, specType } = await prepareOas(spec, 'openapi convert', {
-      title,
-    });
+    const { preparedSpec, specPath, specType } = await prepareOas.call(this, 'openapi convert');
     const parsedPreparedSpec: OASDocument = JSON.parse(preparedSpec);
 
     if (specType === 'OpenAPI') {

--- a/src/commands/openapi/inspect.ts
+++ b/src/commands/openapi/inspect.ts
@@ -251,7 +251,7 @@ export default class OpenAPIInspectCommand extends BaseCommand<typeof OpenAPIIns
       this.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
-    const { preparedSpec, definitionVersion } = await prepareOas(spec, 'openapi inspect');
+    const { preparedSpec, definitionVersion } = await prepareOas.call(this, 'openapi inspect');
     const parsedPreparedSpec: OASDocument = JSON.parse(preparedSpec);
 
     const spinner = ora({ ...oraOptions() });

--- a/src/commands/openapi/inspect.ts
+++ b/src/commands/openapi/inspect.ts
@@ -198,6 +198,8 @@ function buildFullReport(analysis: Analysis, definitionVersion: string, tableBor
 }
 
 export default class OpenAPIInspectCommand extends BaseCommand<typeof OpenAPIInspectCommand> {
+  id = 'openapi inspect' as const;
+
   static summary = 'Analyze an OpenAPI/Swagger definition for various OpenAPI and ReadMe feature usage.';
 
   static description =
@@ -251,7 +253,7 @@ export default class OpenAPIInspectCommand extends BaseCommand<typeof OpenAPIIns
       this.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
-    const { preparedSpec, definitionVersion } = await prepareOas.call(this, 'openapi inspect');
+    const { preparedSpec, definitionVersion } = await prepareOas.call(this);
     const parsedPreparedSpec: OASDocument = JSON.parse(preparedSpec);
 
     const spinner = ora({ ...oraOptions() });

--- a/src/commands/openapi/reduce.ts
+++ b/src/commands/openapi/reduce.ts
@@ -58,9 +58,8 @@ export default class OpenAPIReduceCommand extends BaseCommand<typeof OpenAPIRedu
   ];
 
   async run() {
-    const { spec } = this.args;
     const opts = this.flags;
-    const { title, workingDirectory } = opts;
+    const { workingDirectory } = opts;
 
     if (workingDirectory) {
       const previousWorkingDirectory = process.cwd();
@@ -68,7 +67,7 @@ export default class OpenAPIReduceCommand extends BaseCommand<typeof OpenAPIRedu
       this.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
-    const { preparedSpec, specPath, specType } = await prepareOas(spec, 'openapi reduce', { title });
+    const { preparedSpec, specPath, specType } = await prepareOas.call(this, 'openapi reduce');
     const parsedPreparedSpec: OASDocument = JSON.parse(preparedSpec);
 
     if (specType !== 'OpenAPI') {

--- a/src/commands/openapi/reduce.ts
+++ b/src/commands/openapi/reduce.ts
@@ -18,6 +18,8 @@ import promptTerminal from '../../lib/promptWrapper.js';
 import { validateFilePath } from '../../lib/validatePromptInput.js';
 
 export default class OpenAPIReduceCommand extends BaseCommand<typeof OpenAPIReduceCommand> {
+  id = 'openapi reduce' as const;
+
   static summary = 'Reduce an OpenAPI definition into a smaller subset.';
 
   static description =
@@ -67,7 +69,7 @@ export default class OpenAPIReduceCommand extends BaseCommand<typeof OpenAPIRedu
       this.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
-    const { preparedSpec, specPath, specType } = await prepareOas.call(this, 'openapi reduce');
+    const { preparedSpec, specPath, specType } = await prepareOas.call(this);
     const parsedPreparedSpec: OASDocument = JSON.parse(preparedSpec);
 
     if (specType !== 'OpenAPI') {

--- a/src/commands/openapi/resolve.ts
+++ b/src/commands/openapi/resolve.ts
@@ -22,6 +22,8 @@ type Schema = OpenAPIV31.ReferenceObject | OpenAPIV31.SchemaObject;
 type SchemaCollection = Record<string, Schema>;
 
 export default class OpenAPIResolveCommand extends BaseCommand<typeof OpenAPIResolveCommand> {
+  id = 'openapi resolve' as const;
+
   static summary = 'Resolves circular and recursive references in OpenAPI by replacing them with object schemas.';
 
   static description =
@@ -350,7 +352,7 @@ export default class OpenAPIResolveCommand extends BaseCommand<typeof OpenAPIRes
       this.debug(`Switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
-    const { preparedSpec, specPath, specType } = await prepareOas.call(this, 'openapi resolve');
+    const { preparedSpec, specPath, specType } = await prepareOas.call(this);
     if (specType !== 'OpenAPI') {
       throw new Error('Sorry, this command only supports OpenAPI 3.0+ definitions.');
     }

--- a/src/commands/openapi/resolve.ts
+++ b/src/commands/openapi/resolve.ts
@@ -11,7 +11,7 @@ import prompts from 'prompts';
 
 import analyzeOas from '../../lib/analyzeOas.js';
 import BaseCommand from '../../lib/baseCommand.js';
-import { specArg, workingDirectoryFlag } from '../../lib/flags.js';
+import { specArg, titleFlag, workingDirectoryFlag } from '../../lib/flags.js';
 import { oraOptions } from '../../lib/logger.js';
 import prepareOas from '../../lib/prepareOas.js';
 import promptTerminal from '../../lib/promptWrapper.js';
@@ -50,6 +50,7 @@ export default class OpenAPIResolveCommand extends BaseCommand<typeof OpenAPIRes
 
   static flags = {
     out: Flags.string({ description: 'Output file path to write resolved file to' }),
+    title: titleFlag,
     workingDirectory: workingDirectoryFlag,
   };
 
@@ -349,7 +350,7 @@ export default class OpenAPIResolveCommand extends BaseCommand<typeof OpenAPIRes
       this.debug(`Switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
-    const { preparedSpec, specPath, specType } = await prepareOas(spec, 'openapi resolve');
+    const { preparedSpec, specPath, specType } = await prepareOas.call(this, 'openapi resolve');
     if (specType !== 'OpenAPI') {
       throw new Error('Sorry, this command only supports OpenAPI 3.0+ definitions.');
     }

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -278,7 +278,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
       'schema',
       new File([specToUpload], filename, {
         type: isYaml ? 'application/x-yaml' : 'application/json',
-      })
+      }),
     );
 
     const options: RequestInit = { headers, method, body };

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -21,6 +21,8 @@ import prepareOas from '../../lib/prepareOas.js';
 import promptTerminal from '../../lib/promptWrapper.js';
 
 export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUploadCommand> {
+  id = 'openapi upload' as const;
+
   static summary = 'Upload (or re-upload) your API definition to ReadMe.';
 
   static description = [
@@ -120,10 +122,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
   }
 
   async run() {
-    const { preparedSpec, specFileType, specType, specPath, specVersion } = await prepareOas.call(
-      this,
-      'openapi upload',
-    );
+    const { preparedSpec, specFileType, specType, specPath, specVersion } = await prepareOas.call(this);
 
     const branch = this.flags.useSpecVersion ? specVersion : this.flags.branch;
 

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -14,7 +14,7 @@ import prompts from 'prompts';
 import slugify from 'slugify';
 
 import BaseCommand from '../../lib/baseCommand.js';
-import { branchFlag, keyFlag, specArg } from '../../lib/flags.js';
+import { branchFlag, keyFlag, specArg, titleFlag } from '../../lib/flags.js';
 import isCI, { isTest } from '../../lib/isCI.js';
 import { oraOptions } from '../../lib/logger.js';
 import prepareOas from '../../lib/prepareOas.js';
@@ -56,6 +56,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
         "You do not need to include a file extension (i.e., either `custom-slug.json` or `custom-slug` will work). If you do, it must match the file extension of the file you're uploading.",
       ].join('\n\n'),
     }),
+    title: titleFlag,
     useSpecVersion: Flags.boolean({
       summary: 'Use the OpenAPI `info.version` field for your ReadMe project version',
       description:
@@ -119,9 +120,10 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
   }
 
   async run() {
-    const { spec } = this.args;
-
-    const { preparedSpec, specFileType, specType, specPath, specVersion } = await prepareOas(spec, 'openapi upload');
+    const { preparedSpec, specFileType, specType, specPath, specVersion } = await prepareOas.call(
+      this,
+      'openapi upload',
+    );
 
     const branch = this.flags.useSpecVersion ? specVersion : this.flags.branch;
 

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -266,26 +266,20 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
 
     const body = new FormData();
 
-    if (specFileType === 'url') {
-      this.debug('attaching URL to form data payload');
-      body.append('url', specPath);
-    } else {
-      const isYaml = fileExtension === '.yaml' || fileExtension === '.yml';
-      // Convert YAML files back to YAML before uploading
-      let specToUpload = preparedSpec;
-      if (isYaml) {
-        specToUpload = yaml.dump(JSON.parse(preparedSpec));
-      }
-
-      this.debug('processing file into form data payload');
-      body.append(
-        'schema',
-        new File([specToUpload], filename, {
-          type: isYaml ? 'application/x-yaml' : 'application/json',
-        }),
-        filename,
-      );
+    const isYaml = fileExtension === '.yaml' || fileExtension === '.yml';
+    // Convert YAML files back to YAML before uploading
+    let specToUpload = preparedSpec;
+    if (isYaml) {
+      specToUpload = yaml.dump(JSON.parse(preparedSpec));
     }
+
+    this.debug('processing file into form data payload');
+    body.append(
+      'schema',
+      new File([specToUpload], filename, {
+        type: isYaml ? 'application/x-yaml' : 'application/json',
+      })
+    );
 
     const options: RequestInit = { headers, method, body };
 

--- a/src/commands/openapi/validate.ts
+++ b/src/commands/openapi/validate.ts
@@ -41,7 +41,7 @@ export default class OpenAPIValidateCommand extends BaseCommand<typeof OpenAPIVa
       this.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
-    const { specPath, specType } = await prepareOas(this.args.spec, OpenAPIValidateCommand.id);
+    const { specPath, specType } = await prepareOas.call(this, OpenAPIValidateCommand.id);
 
     return this.runCreateGHAHook({
       parsedOpts: { ...this.flags, spec: specPath },

--- a/src/commands/openapi/validate.ts
+++ b/src/commands/openapi/validate.ts
@@ -5,6 +5,8 @@ import { githubFlag, specArg, workingDirectoryFlag } from '../../lib/flags.js';
 import prepareOas from '../../lib/prepareOas.js';
 
 export default class OpenAPIValidateCommand extends BaseCommand<typeof OpenAPIValidateCommand> {
+  id = 'openapi validate' as const;
+
   static summary = 'Validate your OpenAPI/Swagger definition.';
 
   static description =
@@ -41,7 +43,7 @@ export default class OpenAPIValidateCommand extends BaseCommand<typeof OpenAPIVa
       this.debug(`switching working directory from ${previousWorkingDirectory} to ${process.cwd()}`);
     }
 
-    const { specPath, specType } = await prepareOas.call(this, OpenAPIValidateCommand.id);
+    const { specPath, specType } = await prepareOas.call(this);
 
     return this.runCreateGHAHook({
       parsedOpts: { ...this.flags, spec: specPath },

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,3 +92,14 @@ export type APIv2PageUploadCommands =
  * These commands can do more than just upload pages, but they are all backed by the APIv2 representations.
  */
 export type APIv2PageCommands = APIv2PageUploadCommands | DocsMigrateCommand;
+
+/**
+ * Every command that deals with OpenAPI definitions.
+ */
+export type OpenAPICommands =
+  | OpenAPIConvertCommand
+  | OpenAPIInspectCommand
+  | OpenAPIReduceCommand
+  | OpenAPIResolveCommand
+  | OpenAPIUploadCommand
+  | OpenAPIValidateCommand;

--- a/src/lib/baseCommand.ts
+++ b/src/lib/baseCommand.ts
@@ -53,7 +53,7 @@ export default abstract class BaseCommand<T extends typeof OclifCommand> extends
   // protected property in the base oclif class
   declare debug: (...args: unknown[]) => void;
 
-  protected info(input: Parameters<typeof info>[0], opts: Parameters<typeof info>[1]): void {
+  public info(input: Parameters<typeof info>[0], opts?: Parameters<typeof info>[1]): void {
     if (!this.jsonEnabled()) {
       info(input, opts);
     }

--- a/src/lib/prepareOas.ts
+++ b/src/lib/prepareOas.ts
@@ -49,15 +49,9 @@ function capitalizeSpecType<T extends 'openapi' | 'postman' | 'swagger' | 'unkno
 /**
  * Normalizes, validates, and (optionally) bundles an OpenAPI definition.
  */
-export default async function prepareOas(
-  this: OpenAPICommands,
-  /**
-   * The command context in which this is being run within (uploading a spec,
-   * validation, or reducing one).
-   */
-  command: `openapi ${OpenAPIAction}`,
-) {
+export default async function prepareOas(this: OpenAPICommands) {
   let specPath = this.args.spec;
+  const command = this.id satisfies `openapi ${OpenAPIAction}`;
 
   if (!specPath) {
     /**


### PR DESCRIPTION
| 🚥 Resolves CX-1881 |
| :------------------- |

## 🧰 Changes

- [x] fixes an issue where the `--slug` flag wasn't able to be set with URL uploads
- [x] refactors `prepareOas` to accept `this` from the `openapi` family of commands
  - [x] backfills `--title` flag for a few commands that don't have it (and updates docs accordingly)

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
