### PR TITLE
ci: expanding unit tests to run on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   build:
     name: Test Suite
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -22,6 +21,11 @@ jobs:
           - lts/-1
           - lts/*
           - latest
+        os-version:
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os-version }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 🧰 Changes

There can be a number of weird quirks with file paths on Windows with regard to OpenAPI `$ref` resolutions so we should expand rdme's testing scope to include it.