### PR TITLE
chore(deps-dev): upgrading biome and our standards package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,13 +45,13 @@
         "rdme": "bin/run.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.1.1",
+        "@biomejs/biome": "^2.1.4",
         "@commitlint/cli": "^19.0.3",
         "@commitlint/config-conventional": "^19.0.3",
         "@oclif/test": "^4.1.0",
         "@readme/better-ajv-errors": "^2.3.2",
         "@readme/oas-examples": "^6.1.2",
-        "@readme/standards": "^1.0.0",
+        "@readme/standards": "^1.4.0",
         "@rollup/plugin-commonjs": "^28.0.0",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
@@ -1192,9 +1192,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.1.3.tgz",
-      "integrity": "sha512-KE/tegvJIxTkl7gJbGWSgun7G6X/n2M6C35COT6ctYrAy7SiPyNvi6JtoQERVK/VRbttZfgGq96j2bFmhmnH4w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.1.4.tgz",
+      "integrity": "sha512-QWlrqyxsU0FCebuMnkvBIkxvPqH89afiJzjMl+z67ybutse590jgeaFdDurE9XYtzpjRGTI1tlUZPGWmbKsElA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -1208,20 +1208,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.1.3",
-        "@biomejs/cli-darwin-x64": "2.1.3",
-        "@biomejs/cli-linux-arm64": "2.1.3",
-        "@biomejs/cli-linux-arm64-musl": "2.1.3",
-        "@biomejs/cli-linux-x64": "2.1.3",
-        "@biomejs/cli-linux-x64-musl": "2.1.3",
-        "@biomejs/cli-win32-arm64": "2.1.3",
-        "@biomejs/cli-win32-x64": "2.1.3"
+        "@biomejs/cli-darwin-arm64": "2.1.4",
+        "@biomejs/cli-darwin-x64": "2.1.4",
+        "@biomejs/cli-linux-arm64": "2.1.4",
+        "@biomejs/cli-linux-arm64-musl": "2.1.4",
+        "@biomejs/cli-linux-x64": "2.1.4",
+        "@biomejs/cli-linux-x64-musl": "2.1.4",
+        "@biomejs/cli-win32-arm64": "2.1.4",
+        "@biomejs/cli-win32-x64": "2.1.4"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.1.3.tgz",
-      "integrity": "sha512-LFLkSWRoSGS1wVUD/BE6Nlt2dSn0ulH3XImzg2O/36BoToJHKXjSxzPEMAqT9QvwVtk7/9AQhZpTneERU9qaXA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.1.4.tgz",
+      "integrity": "sha512-sCrNENE74I9MV090Wq/9Dg7EhPudx3+5OiSoQOkIe3DLPzFARuL1dOwCWhKCpA3I5RHmbrsbNSRfZwCabwd8Qg==",
       "cpu": [
         "arm64"
       ],
@@ -1236,9 +1236,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.1.3.tgz",
-      "integrity": "sha512-Q/4OTw8P9No9QeowyxswcWdm0n2MsdCwWcc5NcKQQvzwPjwuPdf8dpPPf4r+x0RWKBtl1FLiAUtJvBlri6DnYw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.1.4.tgz",
+      "integrity": "sha512-gOEICJbTCy6iruBywBDcG4X5rHMbqCPs3clh3UQ+hRKlgvJTk4NHWQAyHOXvaLe+AxD1/TNX1jbZeffBJzcrOw==",
       "cpu": [
         "x64"
       ],
@@ -1253,9 +1253,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.1.3.tgz",
-      "integrity": "sha512-2hS6LgylRqMFmAZCOFwYrf77QMdUwJp49oe8PX/O8+P2yKZMSpyQTf3Eo5ewnsMFUEmYbPOskafdV1ds1MZMJA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.1.4.tgz",
+      "integrity": "sha512-juhEkdkKR4nbUi5k/KRp1ocGPNWLgFRD4NrHZSveYrD6i98pyvuzmS9yFYgOZa5JhaVqo0HPnci0+YuzSwT2fw==",
       "cpu": [
         "arm64"
       ],
@@ -1270,9 +1270,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.1.3.tgz",
-      "integrity": "sha512-KXouFSBnoxAWZYDQrnNRzZBbt5s9UJkIm40hdvSL9mBxSSoxRFQJbtg1hP3aa8A2SnXyQHxQfpiVeJlczZt76w==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.1.4.tgz",
+      "integrity": "sha512-nYr7H0CyAJPaLupFE2cH16KZmRC5Z9PEftiA2vWxk+CsFkPZQ6dBRdcC6RuS+zJlPc/JOd8xw3uCCt9Pv41WvQ==",
       "cpu": [
         "arm64"
       ],
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.1.3.tgz",
-      "integrity": "sha512-NxlSCBhLvQtWGagEztfAZ4WcE1AkMTntZV65ZvR+J9jp06+EtOYEBPQndA70ZGhHbEDG57bR6uNvqkd1WrEYVA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.1.4.tgz",
+      "integrity": "sha512-Eoy9ycbhpJVYuR+LskV9s3uyaIkp89+qqgqhGQsWnp/I02Uqg2fXFblHJOpGZR8AxdB9ADy87oFVxn9MpFKUrw==",
       "cpu": [
         "x64"
       ],
@@ -1304,9 +1304,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.1.3.tgz",
-      "integrity": "sha512-KaLAxnROouzIWtl6a0Y88r/4hW5oDUJTIqQorOTVQITaKQsKjZX4XCUmHIhdEk8zMnaiLZzRTAwk1yIAl+mIew==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.1.4.tgz",
+      "integrity": "sha512-lvwvb2SQQHctHUKvBKptR6PLFCM7JfRjpCCrDaTmvB7EeZ5/dQJPhTYBf36BE/B4CRWR2ZiBLRYhK7hhXBCZAg==",
       "cpu": [
         "x64"
       ],
@@ -1321,9 +1321,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.1.3.tgz",
-      "integrity": "sha512-V9CUZCtWH4u0YwyCYbQ3W5F4ZGPWp2C2TYcsiWFNNyRfmOW1j/TY/jAurl33SaRjgZPO5UUhGyr9m6BN9t84NQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.1.4.tgz",
+      "integrity": "sha512-3WRYte7orvyi6TRfIZkDN9Jzoogbv+gSvR+b9VOXUg1We1XrjBg6WljADeVEaKTvOcpVdH0a90TwyOQ6ue4fGw==",
       "cpu": [
         "arm64"
       ],
@@ -1338,9 +1338,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.1.3.tgz",
-      "integrity": "sha512-dxy599q6lgp8ANPpR8sDMscwdp9oOumEsVXuVCVT9N2vAho8uYXlCz53JhxX6LtJOXaE73qzgkGQ7QqvFlMC0g==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.1.4.tgz",
+      "integrity": "sha512-tBc+W7anBPSFXGAoQW+f/+svkpt8/uXfRwDzN1DvnatkRMt16KIYpEi/iw8u9GahJlFv98kgHcIrSsZHZTR0sw==",
       "cpu": [
         "x64"
       ],
@@ -3955,13 +3955,13 @@
       }
     },
     "node_modules/@readme/standards": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/standards/-/standards-1.2.0.tgz",
-      "integrity": "sha512-9OjODr3DRlpbpDglpHSjScUEWoFC5pqRrsnz0+OGH7glA8YvADJgRBreeI4FHwrUwGKCb7jxdv7B2/p0qX9QuQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@readme/standards/-/standards-1.4.0.tgz",
+      "integrity": "sha512-MKW4qS1GE9ni8aeCr2kHmgyFFUqSgJoE9BI+vKDHeaOGhr59KpcmG086QjCCJRH5z1pEXleuGYr3z0AexYC3+g==",
       "dev": true,
       "license": "ISC",
       "optionalDependencies": {
-        "@biomejs/biome": "^2.1.1",
+        "@biomejs/biome": "^2.1.4",
         "prettier": "^3.6.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -79,13 +79,13 @@
     "validator": "^13.7.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.1.1",
+    "@biomejs/biome": "^2.1.4",
     "@commitlint/cli": "^19.0.3",
     "@commitlint/config-conventional": "^19.0.3",
     "@oclif/test": "^4.1.0",
     "@readme/better-ajv-errors": "^2.3.2",
     "@readme/oas-examples": "^6.1.2",
-    "@readme/standards": "^1.0.0",
+    "@readme/standards": "^1.4.0",
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^16.0.0",

--- a/src/commands/openapi/inspect.ts
+++ b/src/commands/openapi/inspect.ts
@@ -239,7 +239,6 @@ export default class OpenAPIInspectCommand extends BaseCommand<typeof OpenAPIIns
   ];
 
   async run() {
-    const { spec } = this.args;
     const { workingDirectory, feature: features } = this.flags;
 
     const tableBorder = Object.entries(getBorderCharacters('norc'))

--- a/src/commands/openapi/resolve.ts
+++ b/src/commands/openapi/resolve.ts
@@ -345,7 +345,6 @@ export default class OpenAPIResolveCommand extends BaseCommand<typeof OpenAPIRes
   }
 
   async run() {
-    const { spec } = this.args;
     const { out, workingDirectory } = this.flags;
 
     if (workingDirectory) {


### PR DESCRIPTION
## 🧰 Changes

Upgrades Biome and our `@readme/standards` package in order to flip on following rules:

* [x] https://biomejs.dev/linter/rules/no-console/
* [x] https://biomejs.dev/linter/rules/no-unused-variables/
* [x] https://biomejs.dev/linter/rules/use-import-extensions/
  * Our preference continues to be that types be written as interfaces.

All of these rules were/are a part of our ESLint config and just hadn't been ported into our Biome standards yet.