### PR TITLE
docs: tweak YAML comments to fix TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ rdme login
 `rdme` has a thin wrapper that allows the CLI to be used as a proper action in a GitHub Actions workflow. For example, say you wanted to run `rdme openapi validate petstore.json` in a GitHub Actions environment. Here's what the corresponding steps would look like in a GitHub Actions workflow file:
 
 ```yml
-## Required in order for the GitHub Action to access your repo's contents ##
+## Required in order for the GitHub Action to access your repo's contents
 - uses: actions/checkout@v4
 
-## Runs the `rdme openapi validate petstore.json` command with the root directory being your repo ##
+## Runs the `rdme openapi validate petstore.json` command with the root directory being your repo
 - uses: readmeio/rdme@v10
   with:
     rdme: openapi validate petstore.json


### PR DESCRIPTION
## 🧰 Changes

noticed our TOC looks a lil off at the moment:

<img width="1656" height="572" alt="CleanShot 2025-08-12 at 11 30 00@2x" src="https://github.com/user-attachments/assets/eef159df-1845-42ea-a77a-fca10ebfe485" />

turns out `oclif`'s autogenerated TOC generation was incorrectly thinking a YAML comment was a header. this fixes that!

