### PR TITLE
fix(openapi/upload): handle funky URLs

### DIFF
--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -80,6 +80,36 @@ exports[`rdme openapi upload > given that the API definition is a URL > and the 
 }
 `;
 
+exports[`rdme openapi upload > given that the API definition is a URL > and the \`--slug\` flag is passed > should create a new API definition in ReadMe with the specified slug where URL has no path 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/branches/1.0.0/apis/custom-slug.json.json",
+  },
+  "stderr": "- Validating the API definition located at https://example.com...
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... done!
+",
+  "stdout": "🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a URL > and the \`--slug\` flag is passed > should create a new API definition in ReadMe with the specified slug where URL is a query param 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/branches/1.0.0/apis/custom-slug.json.json",
+  },
+  "stderr": "- Validating the API definition located at https://example.com/openapi.json?somequery=true...
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... done!
+",
+  "stdout": "🚀 Your API definition (custom-slug.json) was successfully created in ReadMe!
+",
+}
+`;
+
 exports[`rdme openapi upload > given that the API definition is a URL > should create a new API definition in ReadMe 1`] = `
 {
   "result": {

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -612,6 +612,64 @@ describe('rdme openapi upload', () => {
         fileMock.done();
         mock.done();
       });
+
+      it('should create a new API definition in ReadMe with the specified slug where URL is a query param', async () => {
+        const customFilename = 'custom-slug.json';
+        const fileMock = nock('https://example.com').get('/openapi.json?somequery=true').reply(200, petstore);
+
+        const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
+          .get(`/branches/${branch}/apis`)
+          .reply(200, {})
+          .post(`/branches/${branch}/apis`, body =>
+            body.match(`form-data; name="schema"; filename="${customFilename}"`),
+          )
+          .reply(200, {
+            data: {
+              upload: { status: 'done' },
+              uri: `/branches/${branch}/apis/${customFilename}.json`,
+            },
+          });
+
+        const result = await run([
+          '--branch',
+          branch,
+          `${fileUrl}?somequery=true`,
+          '--key',
+          key,
+          '--slug',
+          'custom-slug',
+        ]);
+
+        expect(result).toMatchSnapshot();
+
+        fileMock.done();
+        mock.done();
+      });
+
+      it('should create a new API definition in ReadMe with the specified slug where URL has no path', async () => {
+        const customFilename = 'custom-slug.json';
+        const fileMock = nock('https://example.com').get('/').reply(200, petstore);
+
+        const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
+          .get(`/branches/${branch}/apis`)
+          .reply(200, {})
+          .post(`/branches/${branch}/apis`, body =>
+            body.match(`form-data; name="schema"; filename="${customFilename}"`),
+          )
+          .reply(200, {
+            data: {
+              upload: { status: 'done' },
+              uri: `/branches/${branch}/apis/${customFilename}.json`,
+            },
+          });
+
+        const result = await run(['--branch', branch, `https://example.com`, '--key', key, '--slug', 'custom-slug']);
+
+        expect(result).toMatchSnapshot();
+
+        fileMock.done();
+        mock.done();
+      });
     });
   });
 

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -128,7 +128,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
 
     const specFileTypeIsUrl = specFileType === 'url';
 
-    let filename = specFileTypeIsUrl ? nodePath.basename(specPath) : slugify.default(specPath);
+    let filename = specFileTypeIsUrl ? nodePath.basename(new URL(specPath).pathname) : slugify.default(specPath);
 
     // Our support for Postman collections relies on an internal fork of an archived project and
     // can be subject to quirks in the conversion. We should let users know that this is all very
@@ -157,7 +157,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
      */
     let updateLegacyIdViaSlug = false;
 
-    const fileExtension = nodePath.extname(filename);
+    const fileExtension = nodePath.extname(filename) || '.json';
     if (this.flags.slug) {
       // verify that the slug's extension matches the file's extension
       const slugExtension = nodePath.extname(this.flags.slug);


### PR DESCRIPTION
| 🚥 Resolves RM-13895 |
| :------------------- |

## 🧰 Changes

fixes a few issues where URLs with no path (e.g., `https://example.com`) or URLs with query params (e.g., `https://example.com/openapi?something=true`) weren't being handled properly.

## 🧬 QA & Testing

do tests pass?
