### PR TITLE
fix(openapi/upload): better handling for mismatching files/slugs

### DIFF
--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -148,6 +148,22 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 }
 `;
 
+exports[`rdme openapi upload > given that the API definition is a local file > and the \`--slug\` flag is passed > should handle a slug with a valid but mismatching file extension (.json slug, YAML file) 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/branches/1.0.0/apis/custom-slug.json",
+  },
+  "stderr": "- Validating the API definition located at __tests__/__fixtures__/postman/petstore.collection.yaml...
+ ›   Warning: Support for Postman collections is currently experimental.
+- Updating your API definition to ReadMe...
+✔ Updating your API definition to ReadMe... done!
+",
+  "stdout": "🚀 Your API definition (custom-slug.json) was successfully updated in ReadMe!
+",
+}
+`;
+
 exports[`rdme openapi upload > given that the API definition is a local file > and the \`--slug\` flag is passed > should handle a slug with a valid but mismatching file extension (.yml slug, JSON file) 1`] = `
 {
   "result": {

--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -148,12 +148,18 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 }
 `;
 
-exports[`rdme openapi upload > given that the API definition is a local file > and the \`--slug\` flag is passed > should handle a slug with a valid but mismatching file extension 1`] = `
+exports[`rdme openapi upload > given that the API definition is a local file > and the \`--slug\` flag is passed > should handle a slug with a valid but mismatching file extension (.yml slug, JSON file) 1`] = `
 {
-  "error": [Error: Please provide a valid file extension that matches the extension on the file you provided. Must be \`.json\`, \`.yaml\`, or \`.yml\`.],
+  "result": {
+    "status": "done",
+    "uri": "/branches/1.0.0/apis/custom-slug.yml",
+  },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+- Updating your API definition to ReadMe...
+✔ Updating your API definition to ReadMe... done!
 ",
-  "stdout": "",
+  "stdout": "🚀 Your API definition (custom-slug.yml) was successfully updated in ReadMe!
+",
 }
 `;
 

--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -156,6 +156,9 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/postman/petstore.collection.yaml...
  ›   Warning: Support for Postman collections is currently experimental.
+ ›   Warning: The file extension in your provided slug (.json) does not match 
+ ›   the file extension of the file you're uploading (.yaml). Your API 
+ ›   definition will be uploaded as JSON.
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",
@@ -171,6 +174,9 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
     "uri": "/branches/1.0.0/apis/custom-slug.yml",
   },
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: The file extension in your provided slug (.yml) does not match 
+ ›   the file extension of the file you're uploading (.json). Your API 
+ ›   definition will be uploaded as YAML.
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",

--- a/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/__tests__/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -158,7 +158,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
  ›   Warning: Support for Postman collections is currently experimental.
  ›   Warning: The file extension in your provided slug (.json) does not match 
  ›   the file extension of the file you're uploading (.yaml). Your API 
- ›   definition will be uploaded as JSON.
+ ›   definition will be converted to JSON prior to upload.
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",
@@ -176,7 +176,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
   "stderr": "- Validating the API definition located at __tests__/__fixtures__/petstore-simple-weird-version.json...
  ›   Warning: The file extension in your provided slug (.yml) does not match 
  ›   the file extension of the file you're uploading (.json). Your API 
- ›   definition will be uploaded as YAML.
+ ›   definition will be converted to YAML prior to upload.
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -171,8 +171,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${branch}/apis`, body =>
-            body.match(`form-data; name="schema"; filename="${customSlugWithExtension}"`),
+          .post(
+            `/branches/${branch}/apis`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${customSlugWithExtension}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -214,8 +220,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${branch}/apis`, body =>
-            body.match(`form-data; name="schema"; filename="${customSlugWithExtension}"`),
+          .post(
+            `/branches/${branch}/apis`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${customSlugWithExtension}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -238,8 +250,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [{ legacy_id: customSlug, filename: existingFilename }] })
-          .put(`/branches/${branch}/apis/${existingFilename}`, body =>
-            body.match(`form-data; name="schema"; filename="${existingFilename}"`),
+          .put(
+            `/branches/${branch}/apis/${existingFilename}`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${existingFilename}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -669,8 +687,12 @@ describe('rdme openapi upload', () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, { data: [{ filename: 'openapi.json' }] })
-        .put('/branches/1.0.0/apis/openapi.json', body =>
-          body.match(`form-data; name="schema"; filename="${urlFilename}"`),
+        .put(
+          '/branches/1.0.0/apis/openapi.json',
+          body =>
+            body.match(`form-data; name="schema"; filename="${urlFilename}"\r\nContent-Type: application/json`) &&
+            // asserts that we're sending JSON
+            body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
         )
         .reply(200, {
           data: {
@@ -705,8 +727,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, {})
-          .post(`/branches/${branch}/apis`, body =>
-            body.match(`form-data; name="schema"; filename="${customFilename}.json"`),
+          .post(
+            `/branches/${branch}/apis`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${customFilename}.json"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -730,8 +758,12 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, {})
-          .post(`/branches/${branch}/apis`, body =>
-            body.match(`form-data; name="schema"; filename="${customFilename}"`),
+          .post(
+            `/branches/${branch}/apis`,
+            body =>
+              body.match(`form-data; name="schema"; filename="${customFilename}"\r\nContent-Type: application/json`) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -763,8 +795,12 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, {})
-          .post(`/branches/${branch}/apis`, body =>
-            body.match(`form-data; name="schema"; filename="${customFilename}"`),
+          .post(
+            `/branches/${branch}/apis`,
+            body =>
+              body.match(`form-data; name="schema"; filename="${customFilename}"\r\nContent-Type: application/json`) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -820,8 +856,12 @@ describe('rdme openapi upload', () => {
         .reply(200, { data: [{ legacy_id: legacyId, filename: existingFilename }] });
 
       const putMock = getAPIv2Mock({ authorization: `Bearer ${key}` })
-        .put(`/branches/${branch}/apis/${existingFilename}`, body =>
-          body.match(`form-data; name="schema"; filename="${existingFilename}"`),
+        .put(
+          `/branches/${branch}/apis/${existingFilename}`,
+          body =>
+            body.match(`form-data; name="schema"; filename="${existingFilename}"\r\nContent-Type: application/json`) &&
+            // asserts that we're sending JSON
+            body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
         )
         .reply(200, {
           data: {

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -268,12 +268,22 @@ describe('rdme openapi upload', () => {
         mock.done();
       });
 
-      it('should handle a slug with a valid but mismatching file extension', async () => {
+      it('should handle a slug with a valid but mismatching file extension (.yml slug, JSON file)', async () => {
+        prompts.inject([true]);
         const customSlug = 'custom-slug.yml';
 
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
-          .reply(200, { data: [] });
+          .reply(200, { data: [{ filename: customSlug }] })
+          .put(`/branches/${branch}/apis/${customSlug}`, body =>
+            body.match(`form-data; name="schema"; filename="${customSlug}"`),
+          )
+          .reply(200, {
+            data: {
+              upload: { status: 'done' },
+              uri: `/branches/${branch}/apis/${customSlug}`,
+            },
+          });
 
         const result = await run(['--branch', branch, filename, '--key', key, '--slug', customSlug]);
 

--- a/__tests__/commands/openapi/upload.test.ts
+++ b/__tests__/commands/openapi/upload.test.ts
@@ -45,8 +45,12 @@ describe('rdme openapi upload', () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, { data: [] })
-        .post(`/branches/${branch}/apis`, body =>
-          body.match(`form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`),
+        .post(
+          `/branches/${branch}/apis`,
+          body =>
+            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`) &&
+            // asserts that we're sending JSON
+            body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
         )
         .reply(200, {
           data: {
@@ -66,8 +70,12 @@ describe('rdme openapi upload', () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, { data: [] })
-        .post(`/branches/${branch}/apis`, body =>
-          body.match(`form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`),
+        .post(
+          `/branches/${branch}/apis`,
+          body =>
+            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`) &&
+            // asserts that we're sending JSON
+            body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
         )
         .reply(200, {
           data: {
@@ -110,8 +118,12 @@ describe('rdme openapi upload', () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, { data: [{ filename: slugifiedFilename }] })
-        .put(`/branches/1.0.0/apis/${slugifiedFilename}`, body =>
-          body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
+        .put(
+          `/branches/1.0.0/apis/${slugifiedFilename}`,
+          body =>
+            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`) &&
+            // asserts that we're sending JSON
+            body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
         )
         .reply(200, {
           data: {
@@ -131,8 +143,12 @@ describe('rdme openapi upload', () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, { data: [] })
-        .post(`/branches/${branch}/apis`, body =>
-          body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
+        .post(
+          `/branches/${branch}/apis`,
+          body =>
+            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`) &&
+            // asserts that we're sending JSON
+            body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
         )
         .reply(200, {
           data: {
@@ -275,8 +291,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [{ filename: customSlug }] })
-          .put(`/branches/${branch}/apis/${customSlug}`, body =>
-            body.match(`form-data; name="schema"; filename="${customSlug}"\r\nContent-Type: application/x-yaml`),
+          .put(
+            `/branches/${branch}/apis/${customSlug}`,
+            body =>
+              body.match(`form-data; name="schema"; filename="${customSlug}"\r\nContent-Type: application/x-yaml`) &&
+              // asserts that we're sending YAML
+              body.match(
+                `title: Single Path\n  description: This is a slimmed down single path version of the Petstore definition.`,
+              ),
           )
           .reply(200, {
             data: {
@@ -299,8 +321,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [{ filename: customSlug }] })
-          .put(`/branches/${branch}/apis/${customSlug}`, body =>
-            body.match(`form-data; name="schema"; filename="${customSlug}"\r\nContent-Type: application/json`),
+          .put(
+            `/branches/${branch}/apis/${customSlug}`,
+            body =>
+              body.match(`form-data; name="schema"; filename="${customSlug}"\r\nContent-Type: application/json`) &&
+              // asserts that we're sending JSON
+              body.match(
+                `{"openapi":"3.0.0","info":{"title":"Swagger Petstore","description":"This is a sample server Petstore server.`,
+              ),
           )
           .reply(200, {
             data: {
@@ -322,8 +350,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${branch}/apis`, body =>
-            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
+          .post(
+            `/branches/${branch}/apis`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -360,8 +394,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [{ filename: slugifiedFilename }] })
-          .put(`/branches/1.0.0/apis/${slugifiedFilename}`, body =>
-            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
+          .put(
+            `/branches/1.0.0/apis/${slugifiedFilename}`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -396,8 +436,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${branch}/apis`, body =>
-            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
+          .post(
+            `/branches/${branch}/apis`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -425,8 +471,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${branch}/apis`, body =>
-            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
+          .post(
+            `/branches/${branch}/apis`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -448,8 +500,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${branch}/apis`, body =>
-            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
+          .post(
+            `/branches/${branch}/apis`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -482,8 +540,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2MockForGHA({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [{ filename: slugifiedFilename }] })
-          .put(`/branches/1.0.0/apis/${slugifiedFilename}`, body =>
-            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
+          .put(
+            `/branches/1.0.0/apis/${slugifiedFilename}`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -519,8 +583,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get('/branches/stable/apis')
           .reply(200, { data: [] })
-          .post('/branches/stable/apis', body =>
-            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
+          .post(
+            '/branches/stable/apis',
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -541,8 +611,14 @@ describe('rdme openapi upload', () => {
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${altVersion}/apis`)
           .reply(200, { data: [] })
-          .post(`/branches/${altVersion}/apis`, body =>
-            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
+          .post(
+            `/branches/${altVersion}/apis`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
           )
           .reply(200, {
             data: {
@@ -654,8 +730,12 @@ describe('rdme openapi upload', () => {
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, { data: [{ filename: slugifiedFilename }] })
-        .put(`/branches/${branch}/apis/${slugifiedFilename}`, body =>
-          body.match(`form-data; name="schema"; filename="${slugifiedFilename}"`),
+        .put(
+          `/branches/${branch}/apis/${slugifiedFilename}`,
+          body =>
+            body.match(`form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`) &&
+            // asserts that we're sending JSON
+            body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
         )
         .reply(200, {
           data: {

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -20,7 +20,7 @@ import { oraOptions } from '../../lib/logger.js';
 import prepareOas from '../../lib/prepareOas.js';
 import promptTerminal from '../../lib/promptWrapper.js';
 
-const yamlFileTypes = ['.yaml', '.yml'];
+const yamlExtensions = ['.yaml', '.yml'];
 
 export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUploadCommand> {
   id = 'openapi upload' as const;
@@ -162,23 +162,20 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     let specToUpload = preparedSpec;
     const fileExtension = nodePath.extname(filename);
     let extensionsMatch = true;
-    const isFileYaml = yamlFileTypes.includes(fileExtension);
+    const isFileYaml = yamlExtensions.includes(fileExtension);
     if (this.flags.slug) {
       // verify that the slug's extension matches the file's extension
       const slugExtension = nodePath.extname(this.flags.slug);
       if (slugExtension) {
-        if (!['.json', ...yamlFileTypes].includes(slugExtension)) {
+        if (!['.json', ...yamlExtensions].includes(slugExtension)) {
           throw new Error(
             'Please provide a valid file extension that matches the extension on the file you provided. Must be `.json`, `.yaml`, or `.yml`.',
           );
         }
 
-        if (fileExtension !== slugExtension) {
-          if (isFileYaml && yamlFileTypes.includes(slugExtension)) {
-            // treat .yaml and .yml as interchangeable
-          } else {
-            extensionsMatch = false;
-          }
+        // if the file is JSON, the slug must be JSON. if the file is YAML, the slug must be YAML-like
+        if (fileExtension !== slugExtension && !(isFileYaml && yamlExtensions.includes(slugExtension))) {
+          extensionsMatch = false;
         }
       }
 

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -183,8 +183,12 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
       }
 
       // the API expects a file extension, so keep it if it's there, add it if it's not
-      // biome-ignore lint/nursery/noUnnecessaryConditions: false positive
-      filename = extensionsMatch ? `${this.flags.slug.replace(slugExtension, '')}${fileExtension}` : this.flags.slug;
+      filename =
+        // biome-ignore lint/nursery/noUnnecessaryConditions: false positive
+        extensionsMatch && fileExtension
+          ? `${this.flags.slug.replace(slugExtension, '')}${fileExtension}`
+          : this.flags.slug;
+
       // handling in the event that the slug is an object ID, in which case it's likely a faulty migration
       const objectIdRegex = /^[0-9a-fA-F]{24}$/;
       if (objectIdRegex.test(this.flags.slug)) {

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -159,10 +159,10 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
      */
     let updateLegacyIdViaSlug = false;
 
-    let specToUpload = preparedSpec;
     const fileExtension = nodePath.extname(filename) || '.json'; // default to .json if no extension is found
-    let extensionsMatch = true;
     const isFileYaml = yamlExtensions.includes(fileExtension);
+
+    let extensionsMatch = true;
     if (this.flags.slug) {
       // verify that the slug's extension matches the file's extension
       const slugExtension = nodePath.extname(this.flags.slug);
@@ -293,6 +293,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     // - the file is JSON and the slug has a YAML extension (meaning we need to convert the file back to YAML)
     const sendYaml = (isFileYaml && extensionsMatch) || (!isFileYaml && !extensionsMatch);
     // Convert YAML files back to YAML before uploading
+    let specToUpload = preparedSpec;
     if (sendYaml) {
       specToUpload = yaml.dump(JSON.parse(preparedSpec));
     }

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -173,9 +173,12 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
           );
         }
 
-        // if the file is JSON, the slug must be JSON. if the file is YAML, the slug must be YAML-like
+        // this means that the user is trying to upload a YAML file but provided a JSON slug, or vice versa
         if (fileExtension !== slugExtension && !(isFileYaml && yamlExtensions.includes(slugExtension))) {
           extensionsMatch = false;
+          this.warn(
+            `The file extension in your provided slug (${slugExtension}) does not match the file extension of the file you're uploading (${fileExtension}). Your API definition will be uploaded as ${isFileYaml ? 'JSON' : 'YAML'}.`,
+          );
         }
       }
 

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -177,7 +177,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
         if (fileExtension !== slugExtension && !(isFileYaml && yamlExtensions.includes(slugExtension))) {
           extensionsMatch = false;
           this.warn(
-            `The file extension in your provided slug (${slugExtension}) does not match the file extension of the file you're uploading (${fileExtension}). Your API definition will be uploaded as ${isFileYaml ? 'JSON' : 'YAML'}.`,
+            `The file extension in your provided slug (${slugExtension}) does not match the file extension of the file you're uploading (${fileExtension}). Your API definition will be converted to ${isFileYaml ? 'JSON' : 'YAML'} prior to upload.`,
           );
         }
       }


### PR DESCRIPTION
| 🚥 Resolves CX-2293 |
| :------------------- |

## 🧰 Changes

we previously had a restriction in place where you could not upload a JSON file (e.g., `petstore.json`) to a slug with a YAML file extension (e.g., `--slug file.yml`). the reasoning was that we didn't want to create any unexpected client-side behaviors and we wanted to prioritize explicitness.

however, we've been getting feedback that it's misleading how `rdme` directs customers towards certain slugs, only to see an error that they can't use that slug due to this file extension restriction.

this PR lifts that restriction and makes it so `rdme` will convert a JSON file to YAML prior to uploading if the slug has a YAML file extension (or vice versa). it will also emit a warning to the user when this happens!

## 🧬 QA & Testing

added a bunch of tests for this behavior!
