### PR TITLE
chore(deps): remove `validator` lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,7 @@
         "tmp-promise": "^3.0.3",
         "toposort": "^2.0.2",
         "undici": "^5.28.4",
-        "unzipper": "^0.12.3",
-        "validator": "^13.7.0"
+        "unzipper": "^0.12.3"
       },
       "bin": {
         "rdme": "bin/run.js"
@@ -63,7 +62,6 @@
         "@types/semver": "^7.3.12",
         "@types/toposort": "^2.0.7",
         "@types/unzipper": "^0.10.11",
-        "@types/validator": "^13.7.6",
         "@vitest/coverage-v8": "^3.0.0",
         "@vitest/expect": "^3.0.0",
         "alex": "^11.0.0",
@@ -5488,13 +5486,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/validator": {
-      "version": "13.15.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.3.tgz",
-      "integrity": "sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -17014,15 +17005,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
       "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
-    },
-    "node_modules/validator": {
-      "version": "13.15.15",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
-      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/vfile": {
       "version": "5.3.7",

--- a/package.json
+++ b/package.json
@@ -76,8 +76,7 @@
     "tmp-promise": "^3.0.3",
     "toposort": "^2.0.2",
     "undici": "^5.28.4",
-    "unzipper": "^0.12.3",
-    "validator": "^13.7.0"
+    "unzipper": "^0.12.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.4",
@@ -98,7 +97,6 @@
     "@types/semver": "^7.3.12",
     "@types/toposort": "^2.0.7",
     "@types/unzipper": "^0.10.11",
-    "@types/validator": "^13.7.6",
     "@vitest/coverage-v8": "^3.0.0",
     "@vitest/expect": "^3.0.0",
     "alex": "^11.0.0",

--- a/src/lib/loginFlow.ts
+++ b/src/lib/loginFlow.ts
@@ -1,7 +1,6 @@
 import type { Hook } from '@oclif/core';
 
 import chalk from 'chalk';
-import isEmail from 'validator/lib/isEmail.js';
 
 import configStore from './configstore.js';
 import getCurrentConfig from './getCurrentConfig.js';
@@ -22,6 +21,14 @@ function loginFetch(body: LoginBody) {
     headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+}
+
+function isEmail(value: string) {
+  // Simple email regex sourced from https://emailregex.com/
+  const emailRegex =
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+  return emailRegex.test(value);
 }
 
 /**
@@ -47,7 +54,7 @@ export default async function loginFlow(
       message: 'What is your email address?',
       initial: storedConfig.email,
       validate(val) {
-        return isEmail.default(val) ? true : 'Please provide a valid email address.';
+        return isEmail(val) ? true : 'Please provide a valid email address.';
       },
     },
     {
@@ -68,7 +75,7 @@ export default async function loginFlow(
     return Promise.reject(new Error('No project subdomain provided. Please use `--project`.'));
   }
 
-  if (!isEmail.default(email)) {
+  if (!isEmail(email)) {
     return Promise.reject(new Error('You must provide a valid email address.'));
   }
 


### PR DESCRIPTION
| 🚥 Resolves https://github.com/readmeio/rdme/security/dependabot/46 |
| :------------------- |

## 🧰 Changes

the dependabot alert above is technically for a function we don't use, but in digging into this i realized we really don't need this `validator` library at all.

decided to swap out the `isEmail` function for a li'l regex and call it a day 💨
