### PR TITLE
fix: disable javascript execution in frontmatter

### DIFF
--- a/__tests__/lib/frontmatter.test.ts
+++ b/__tests__/lib/frontmatter.test.ts
@@ -12,8 +12,8 @@ import DocsMigrateCommand from '../../src/commands/docs/migrate.js';
 import DocsUploadCommand from '../../src/commands/docs/upload.js';
 import RefUploadCommand from '../../src/commands/reference/upload.js';
 import { fix, writeFixes } from '../../src/lib/frontmatter.js';
-import { readPage } from '../../src/lib/readPage.js';
 import { emptyMappings, fetchSchema } from '../../src/lib/readmeAPIFetch.js';
+import { readPage } from '../../src/lib/readPage.js';
 import { setupOclifConfig } from '../helpers/oclif.js';
 
 describe.each([

--- a/src/lib/readPage.ts
+++ b/src/lib/readPage.ts
@@ -65,7 +65,7 @@ export function readPage(
     //
     // * @see https://github.com/readmeio/rdme/security/advisories/GHSA-f65r-8r74-m6v5
     // * @see https://github.com/jonschlinkert/gray-matter/issues/131#issuecomment-3566662412
-    // engines: { javascript: { parse: () => ({}) }, },
+    engines: { javascript: { parse: () => ({}) } },
   });
   const { content, data } = matter;
   this.debug(`frontmatter for ${filePath}: ${JSON.stringify(matter)}`);


### PR DESCRIPTION
## 🧰 Changes

Javascript execution in frontmatter could lead to security problems, so disable it

## 🧬 QA & Testing

See tests. I verified that they fail without this patch applied:

```
 FAIL  __tests__/lib/frontmatter.test.ts > #readPage > should not execute JavaScript in frontmatter (RCE prevention)
AssertionError: expected { Object (title, malicious) } to deeply equal {}

- Expected
+ Received

- {}
+ {
+   "malicious": "executed",
+   "title": "Test",
+ }
+
+
```
