### PR TITLE
fix: `position` sorts should dictate the order that files are uploaded

### DIFF
--- a/src/lib/syncPagePath.ts
+++ b/src/lib/syncPagePath.ts
@@ -6,7 +6,6 @@ import path from 'node:path';
 
 import chalk from 'chalk';
 import ora from 'ora';
-import toposort from 'toposort';
 
 import { APIv2Error } from './apiError.js';
 import { oraOptions } from './logger.js';
@@ -203,16 +202,42 @@ async function pushPage(
   }
 }
 
-function byParentPage(
+function numericPosition(data: GuidesOrReferenceRequestSchema): number {
+  const p = data.position;
+  if (typeof p === 'number' && Number.isFinite(p)) return p;
+  if (typeof p === 'string') {
+    const n = Number(p);
+    if (Number.isFinite(n)) return n;
+  }
+
+  return Number.POSITIVE_INFINITY;
+}
+
+function compareUploadPriority(
   left: PageMetadata<GuidesOrReferenceRequestSchema>,
   right: PageMetadata<GuidesOrReferenceRequestSchema>,
-) {
-  return (right.data.parent?.uri ? 1 : 0) - (left.data.parent?.uri ? 1 : 0);
+): number {
+  const leftPos = numericPosition(left.data);
+  const rightPos = numericPosition(right.data);
+  if (leftPos !== rightPos) {
+    // Avoid `Infinity - Infinity` -> `NaN` which would poison sort when both sides do not have a
+    // `position`.
+    return leftPos < rightPos ? -1 : 1;
+  }
+
+  return left.slug.localeCompare(right.slug, undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
 }
 
 /**
- * Sorts files based on their `parent.uri` attribute. If a file has a `parent.uri` attribute,
- * it will be sorted after the file it references.
+ * Sort files for uploading.
+ *
+ * Every page is uploaded after its parent as defined by `parent.uri` when present and when the
+ * parent is in the same upload batch. Pages within these batches are then sorted by ascending
+ * `position` when present; ties are broken by natural order of the page `slug` (numeric substrings
+ * compare as numbers, e.g. `page-4` before `page-10`).
  *
  * @see {@link https://github.com/readmeio/rdme/pull/973}
  * @returns An array of sorted PageMetadata objects
@@ -226,17 +251,47 @@ function sortFiles(
     return bySlug;
   }, {});
 
-  const dependencies = Object.values(filesBySlug).reduce<
-    [PageMetadata<GuidesOrReferenceRequestSchema>, PageMetadata<GuidesOrReferenceRequestSchema>][]
-  >((edges, obj) => {
-    if (obj.data.parent?.uri && filesBySlug[obj.data.parent.uri]) {
-      edges.push([filesBySlug[obj.data.parent.uri], filesBySlug[obj.slug]]);
+  const slugs = Object.keys(filesBySlug);
+  const inDegree = new Map<string, number>();
+  const childrenByParent = new Map<string, string[]>();
+
+  for (const obj of Object.values(filesBySlug)) {
+    const parentKey = obj.data.parent?.uri;
+    if (parentKey && filesBySlug[parentKey]) {
+      if (!childrenByParent.has(parentKey)) {
+        childrenByParent.set(parentKey, []);
+      }
+
+      childrenByParent.get(parentKey)!.push(obj.slug);
+      inDegree.set(obj.slug, (inDegree.get(obj.slug) ?? 0) + 1);
+    } else {
+      inDegree.set(obj.slug, 0);
     }
+  }
 
-    return edges;
-  }, []);
+  const sorted: PageMetadata<GuidesOrReferenceRequestSchema>[] = [];
+  const ready = slugs.filter(slug => (inDegree.get(slug) ?? 0) === 0);
+  ready.sort((a, b) => compareUploadPriority(filesBySlug[a], filesBySlug[b]));
 
-  return toposort.array(files, dependencies);
+  while (ready.length > 0) {
+    const nextSlug = ready.shift()!;
+    sorted.push(filesBySlug[nextSlug]);
+
+    for (const childSlug of childrenByParent.get(nextSlug) ?? []) {
+      const newDeg = (inDegree.get(childSlug) ?? 0) - 1;
+      inDegree.set(childSlug, newDeg);
+      if (newDeg === 0) {
+        ready.push(childSlug);
+        ready.sort((a, b) => compareUploadPriority(filesBySlug[a], filesBySlug[b]));
+      }
+    }
+  }
+
+  if (sorted.length !== files.length) {
+    throw new Error('Cyclic dependency');
+  }
+
+  return sorted;
 }
 
 /**
@@ -289,7 +344,7 @@ export default async function syncPagePath(this: APIv2PageUploadCommands): Promi
   const sortedFiles =
     this.route === 'changelogs' || this.route === 'custom_pages'
       ? (unsortedFiles as PageMetadata<PageRequestSchema<typeof this.route>>[])
-      : sortFiles((unsortedFiles as PageMetadata<PageRequestSchema<typeof this.route>>[]).toSorted(byParentPage));
+      : sortFiles(unsortedFiles as PageMetadata<GuidesOrReferenceRequestSchema>[]);
 
   // push the files to ReadMe
   const rawResults: PromiseSettledResult<PushResult>[] = [];

--- a/test/__fixtures__/docs/position-order-missing/page-1.md
+++ b/test/__fixtures__/docs/position-order-missing/page-1.md
@@ -1,5 +1,5 @@
 ---
-title: "Page 1 (position #1)"
+title: 'Page 1 (position #1)'
 category:
   uri: category-slug
 ---

--- a/test/__fixtures__/docs/position-order-missing/page-1.md
+++ b/test/__fixtures__/docs/position-order-missing/page-1.md
@@ -1,0 +1,7 @@
+---
+title: "Page 1 (position #1)"
+category:
+  uri: category-slug
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-missing/page-10.md
+++ b/test/__fixtures__/docs/position-order-missing/page-10.md
@@ -1,0 +1,7 @@
+---
+title: "Page 10 (position #10)"
+category:
+  uri: category-slug
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-missing/page-10.md
+++ b/test/__fixtures__/docs/position-order-missing/page-10.md
@@ -1,5 +1,5 @@
 ---
-title: "Page 10 (position #10)"
+title: 'Page 10 (position #10)'
 category:
   uri: category-slug
 ---

--- a/test/__fixtures__/docs/position-order-missing/page-2.md
+++ b/test/__fixtures__/docs/position-order-missing/page-2.md
@@ -1,0 +1,7 @@
+---
+title: "Page 2 (position #2)"
+category:
+  uri: category-slug
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-missing/page-2.md
+++ b/test/__fixtures__/docs/position-order-missing/page-2.md
@@ -1,5 +1,5 @@
 ---
-title: "Page 2 (position #2)"
+title: 'Page 2 (position #2)'
 category:
   uri: category-slug
 ---

--- a/test/__fixtures__/docs/position-order-missing/page-3.md
+++ b/test/__fixtures__/docs/position-order-missing/page-3.md
@@ -1,0 +1,7 @@
+---
+title: "Page 3 (position #3)"
+category:
+  uri: category-slug
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-missing/page-3.md
+++ b/test/__fixtures__/docs/position-order-missing/page-3.md
@@ -1,5 +1,5 @@
 ---
-title: "Page 3 (position #3)"
+title: 'Page 3 (position #3)'
 category:
   uri: category-slug
 ---

--- a/test/__fixtures__/docs/position-order-missing/page-4.md
+++ b/test/__fixtures__/docs/position-order-missing/page-4.md
@@ -1,5 +1,5 @@
 ---
-title: "Page 4 (position #4)"
+title: 'Page 4 (position #4)'
 category:
   uri: category-slug
 ---

--- a/test/__fixtures__/docs/position-order-missing/page-4.md
+++ b/test/__fixtures__/docs/position-order-missing/page-4.md
@@ -1,0 +1,7 @@
+---
+title: "Page 4 (position #4)"
+category:
+  uri: category-slug
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-natural/page-1.md
+++ b/test/__fixtures__/docs/position-order-natural/page-1.md
@@ -1,0 +1,8 @@
+---
+title: "Page 1 (position #1)"
+category:
+  uri: category-slug
+position: 1
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-natural/page-1.md
+++ b/test/__fixtures__/docs/position-order-natural/page-1.md
@@ -1,5 +1,5 @@
 ---
-title: "Page 1 (position #1)"
+title: 'Page 1 (position #1)'
 category:
   uri: category-slug
 position: 1

--- a/test/__fixtures__/docs/position-order-natural/page-10.md
+++ b/test/__fixtures__/docs/position-order-natural/page-10.md
@@ -1,5 +1,5 @@
 ---
-title: "Page 10 (position #10)"
+title: 'Page 10 (position #10)'
 category:
   uri: category-slug
 position: 10

--- a/test/__fixtures__/docs/position-order-natural/page-10.md
+++ b/test/__fixtures__/docs/position-order-natural/page-10.md
@@ -1,0 +1,8 @@
+---
+title: "Page 10 (position #10)"
+category:
+  uri: category-slug
+position: 10
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-natural/page-2.md
+++ b/test/__fixtures__/docs/position-order-natural/page-2.md
@@ -1,0 +1,8 @@
+---
+title: "Page 2 (position #2)"
+category:
+  uri: category-slug
+position: 2
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-natural/page-2.md
+++ b/test/__fixtures__/docs/position-order-natural/page-2.md
@@ -1,5 +1,5 @@
 ---
-title: "Page 2 (position #2)"
+title: 'Page 2 (position #2)'
 category:
   uri: category-slug
 position: 2

--- a/test/__fixtures__/docs/position-order-natural/page-3.md
+++ b/test/__fixtures__/docs/position-order-natural/page-3.md
@@ -1,0 +1,8 @@
+---
+title: "Page 3 (position #3)"
+category:
+  uri: category-slug
+position: 3
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-natural/page-3.md
+++ b/test/__fixtures__/docs/position-order-natural/page-3.md
@@ -1,5 +1,5 @@
 ---
-title: "Page 3 (position #3)"
+title: 'Page 3 (position #3)'
 category:
   uri: category-slug
 position: 3

--- a/test/__fixtures__/docs/position-order-natural/page-4.md
+++ b/test/__fixtures__/docs/position-order-natural/page-4.md
@@ -1,5 +1,5 @@
 ---
-title: "Page 4 (position #4)"
+title: 'Page 4 (position #4)'
 category:
   uri: category-slug
 position: 4

--- a/test/__fixtures__/docs/position-order-natural/page-4.md
+++ b/test/__fixtures__/docs/position-order-natural/page-4.md
@@ -1,0 +1,8 @@
+---
+title: "Page 4 (position #4)"
+category:
+  uri: category-slug
+position: 4
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-roots/a-second.md
+++ b/test/__fixtures__/docs/position-order-roots/a-second.md
@@ -1,5 +1,5 @@
 ---
-title: "A file (position #2)"
+title: 'A file (position #2)'
 category:
   uri: category-slug
 position: 1

--- a/test/__fixtures__/docs/position-order-roots/a-second.md
+++ b/test/__fixtures__/docs/position-order-roots/a-second.md
@@ -1,0 +1,8 @@
+---
+title: "A file (position #2)"
+category:
+  uri: category-slug
+position: 1
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-roots/z-first.md
+++ b/test/__fixtures__/docs/position-order-roots/z-first.md
@@ -1,5 +1,5 @@
 ---
-title: "Z file (position #1)"
+title: 'Z file (position #1)'
 category:
   uri: category-slug
 position: 0

--- a/test/__fixtures__/docs/position-order-roots/z-first.md
+++ b/test/__fixtures__/docs/position-order-roots/z-first.md
@@ -1,0 +1,8 @@
+---
+title: "Z file (position #1)"
+category:
+  uri: category-slug
+position: 0
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-siblings/child-a.md
+++ b/test/__fixtures__/docs/position-order-siblings/child-a.md
@@ -1,5 +1,5 @@
 ---
-title: "Child A - position #2"
+title: 'Child A - position #2'
 category:
   uri: category-slug
 position: 20

--- a/test/__fixtures__/docs/position-order-siblings/child-a.md
+++ b/test/__fixtures__/docs/position-order-siblings/child-a.md
@@ -1,0 +1,10 @@
+---
+title: "Child A - position #2"
+category:
+  uri: category-slug
+position: 20
+parent:
+  uri: parent-hub
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-siblings/child-b.md
+++ b/test/__fixtures__/docs/position-order-siblings/child-b.md
@@ -1,5 +1,5 @@
 ---
-title: "Child B - position #3"
+title: 'Child B - position #3'
 category:
   uri: category-slug
 position: 30

--- a/test/__fixtures__/docs/position-order-siblings/child-b.md
+++ b/test/__fixtures__/docs/position-order-siblings/child-b.md
@@ -1,0 +1,10 @@
+---
+title: "Child B - position #3"
+category:
+  uri: category-slug
+position: 30
+parent:
+  uri: parent-hub
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-siblings/child-c.md
+++ b/test/__fixtures__/docs/position-order-siblings/child-c.md
@@ -1,5 +1,5 @@
 ---
-title: "Child C - position #1"
+title: 'Child C - position #1'
 category:
   uri: category-slug
 position: 10

--- a/test/__fixtures__/docs/position-order-siblings/child-c.md
+++ b/test/__fixtures__/docs/position-order-siblings/child-c.md
@@ -1,0 +1,10 @@
+---
+title: "Child C - position #1"
+category:
+  uri: category-slug
+position: 10
+parent:
+  uri: parent-hub
+---
+
+Body

--- a/test/__fixtures__/docs/position-order-siblings/parent-hub.md
+++ b/test/__fixtures__/docs/position-order-siblings/parent-hub.md
@@ -1,0 +1,8 @@
+---
+title: Parent hub
+category:
+  uri: category-slug
+position: 0
+---
+
+Body

--- a/test/commands/pages/__snapshots__/upload.test.ts.snap
+++ b/test/commands/pages/__snapshots__/upload.test.ts.snap
@@ -1,5 +1,61 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`rdme docs upload > given that the file path is a directory > given that the direcotry does NOT have explicit frontmatter positions set > should upload root pages using a natural sort order of their slugs when \`position\` is missing 1`] = `
+{
+  "result": {
+    "created": [
+      {
+        "filePath": "test/__fixtures__/docs/position-order-missing/page-1.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-1",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-missing/page-2.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-2",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-missing/page-3.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-3",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-missing/page-4.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-4",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-missing/page-10.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-10",
+      },
+    ],
+    "failed": [],
+    "skipped": [],
+    "updated": [],
+  },
+  "stderr": "- 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-missing\` directory...
+✔ 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-missing\` directory... 5 file(s) found!
+- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🚀 Uploading files to ReadMe...
+✔ 🚀 Uploading files to ReadMe... done!
+",
+  "stdout": "🌱 Successfully created 5 page(s) in ReadMe:
+   - page-1 (test/__fixtures__/docs/position-order-missing/page-1.md)
+   - page-2 (test/__fixtures__/docs/position-order-missing/page-2.md)
+   - page-3 (test/__fixtures__/docs/position-order-missing/page-3.md)
+   - page-4 (test/__fixtures__/docs/position-order-missing/page-4.md)
+   - page-10 (test/__fixtures__/docs/position-order-missing/page-10.md)
+",
+}
+`;
+
 exports[`rdme docs upload > given that the file path is a directory > given that the directory contains parent/child docs > should upload parents before children 1`] = `
 {
   "result": {
@@ -49,21 +105,161 @@ exports[`rdme docs upload > given that the file path is a directory > given that
 }
 `;
 
+exports[`rdme docs upload > given that the file path is a directory > given that the directory has explicit frontmatter positions set > should order sibling uploads by ascending position under the same parent 1`] = `
+{
+  "result": {
+    "created": [
+      {
+        "filePath": "test/__fixtures__/docs/position-order-siblings/parent-hub.md",
+        "response": {},
+        "result": "created",
+        "slug": "parent-hub",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-siblings/child-c.md",
+        "response": {},
+        "result": "created",
+        "slug": "child-c",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-siblings/child-a.md",
+        "response": {},
+        "result": "created",
+        "slug": "child-a",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-siblings/child-b.md",
+        "response": {},
+        "result": "created",
+        "slug": "child-b",
+      },
+    ],
+    "failed": [],
+    "skipped": [],
+    "updated": [],
+  },
+  "stderr": "- 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-siblings\` directory...
+✔ 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-siblings\` directory... 4 file(s) found!
+- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🚀 Uploading files to ReadMe...
+✔ 🚀 Uploading files to ReadMe... done!
+",
+  "stdout": "🌱 Successfully created 4 page(s) in ReadMe:
+   - parent-hub (test/__fixtures__/docs/position-order-siblings/parent-hub.md)
+   - child-c (test/__fixtures__/docs/position-order-siblings/child-c.md)
+   - child-a (test/__fixtures__/docs/position-order-siblings/child-a.md)
+   - child-b (test/__fixtures__/docs/position-order-siblings/child-b.md)
+",
+}
+`;
+
+exports[`rdme docs upload > given that the file path is a directory > given that the directory has explicit frontmatter positions set > should upload root pages by ascending position (not filename order) 1`] = `
+{
+  "result": {
+    "created": [
+      {
+        "filePath": "test/__fixtures__/docs/position-order-roots/z-first.md",
+        "response": {},
+        "result": "created",
+        "slug": "z-first",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-roots/a-second.md",
+        "response": {},
+        "result": "created",
+        "slug": "a-second",
+      },
+    ],
+    "failed": [],
+    "skipped": [],
+    "updated": [],
+  },
+  "stderr": "- 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-roots\` directory...
+✔ 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-roots\` directory... 2 file(s) found!
+- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🚀 Uploading files to ReadMe...
+✔ 🚀 Uploading files to ReadMe... done!
+",
+  "stdout": "🌱 Successfully created 2 page(s) in ReadMe:
+   - z-first (test/__fixtures__/docs/position-order-roots/z-first.md)
+   - a-second (test/__fixtures__/docs/position-order-roots/a-second.md)
+",
+}
+`;
+
+exports[`rdme docs upload > given that the file path is a directory > given that the directory has explicit frontmatter positions set > should upload root pages using a natural sort order of their \`position\` values (1 -> 2 -> 3 -> 20) 1`] = `
+{
+  "result": {
+    "created": [
+      {
+        "filePath": "test/__fixtures__/docs/position-order-natural/page-1.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-1",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-natural/page-2.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-2",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-natural/page-3.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-3",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-natural/page-4.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-4",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-natural/page-10.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-10",
+      },
+    ],
+    "failed": [],
+    "skipped": [],
+    "updated": [],
+  },
+  "stderr": "- 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-natural\` directory...
+✔ 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-natural\` directory... 5 file(s) found!
+- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🚀 Uploading files to ReadMe...
+✔ 🚀 Uploading files to ReadMe... done!
+",
+  "stdout": "🌱 Successfully created 5 page(s) in ReadMe:
+   - page-1 (test/__fixtures__/docs/position-order-natural/page-1.md)
+   - page-2 (test/__fixtures__/docs/position-order-natural/page-2.md)
+   - page-3 (test/__fixtures__/docs/position-order-natural/page-3.md)
+   - page-4 (test/__fixtures__/docs/position-order-natural/page-4.md)
+   - page-10 (test/__fixtures__/docs/position-order-natural/page-10.md)
+",
+}
+`;
+
 exports[`rdme docs upload > given that the file path is a directory > should create a page in ReadMe for each file in the directory and its subdirectories 1`] = `
 {
   "result": {
     "created": [
       {
-        "filePath": "test/__fixtures__/docs/existing-docs/simple-doc.md",
-        "response": {},
-        "result": "created",
-        "slug": "simple-doc",
-      },
-      {
         "filePath": "test/__fixtures__/docs/existing-docs/subdir/another-doc.md",
         "response": {},
         "result": "created",
         "slug": "another-doc",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/existing-docs/simple-doc.md",
+        "response": {},
+        "result": "created",
+        "slug": "simple-doc",
       },
     ],
     "failed": [],
@@ -78,8 +274,8 @@ exports[`rdme docs upload > given that the file path is a directory > should cre
 ✔ 🚀 Uploading files to ReadMe... done!
 ",
   "stdout": "🌱 Successfully created 2 page(s) in ReadMe:
-   - simple-doc (test/__fixtures__/docs/existing-docs/simple-doc.md)
    - another-doc (test/__fixtures__/docs/existing-docs/subdir/another-doc.md)
+   - simple-doc (test/__fixtures__/docs/existing-docs/simple-doc.md)
 ",
 }
 `;
@@ -111,8 +307,8 @@ exports[`rdme docs upload > given that the file path is a directory > should han
 ⏭️ The following 1 page(s) will be skipped due to no frontmatter data:
    - doc-sans-attributes (test/__fixtures__/docs/mixed-docs/doc-sans-attributes.md)
 🚨 Unable to fetch data about the following 2 page(s):
-   - test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
    - test/__fixtures__/docs/mixed-docs/simple-doc.md: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
+   - test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
 ",
 }
 `;
@@ -134,8 +330,8 @@ exports[`rdme docs upload > given that the file path is a directory > should han
 ⏭️ Skipped 1 page(s) in ReadMe due to no frontmatter data:
    - doc-sans-attributes (test/__fixtures__/docs/mixed-docs/doc-sans-attributes.md)
 🚨 Received errors when attempting to upload 2 page(s):
-   - test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
    - test/__fixtures__/docs/mixed-docs/simple-doc.md: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
+   - test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
 ",
 }
 `;
@@ -154,15 +350,15 @@ exports[`rdme docs upload > given that the file path is a directory > should han
     "failed": [
       {
         "error": [APIv2Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
-        "filePath": "test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx",
-        "result": "failed",
-        "slug": "some-slug",
-      },
-      {
-        "error": [APIv2Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
         "filePath": "test/__fixtures__/docs/mixed-docs/simple-doc.md",
         "result": "failed",
         "slug": "simple-doc",
+      },
+      {
+        "error": [APIv2Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
+        "filePath": "test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx",
+        "result": "failed",
+        "slug": "some-slug",
       },
     ],
     "skipped": [
@@ -195,8 +391,8 @@ exports[`rdme docs upload > given that the file path is a directory > should han
 ⏭️ Skipped 1 page(s) in ReadMe due to no frontmatter data:
    - doc-sans-attributes (test/__fixtures__/docs/mixed-docs/doc-sans-attributes.md)
 🚨 Received errors when attempting to upload 2 page(s):
-   - test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
    - test/__fixtures__/docs/mixed-docs/simple-doc.md: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
+   - test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
 ",
 }
 `;
@@ -339,16 +535,16 @@ exports[`rdme docs upload > given that the file path is a directory > should upd
     "skipped": [],
     "updated": [
       {
-        "filePath": "test/__fixtures__/docs/existing-docs/simple-doc.md",
-        "response": {},
-        "result": "updated",
-        "slug": "simple-doc",
-      },
-      {
         "filePath": "test/__fixtures__/docs/existing-docs/subdir/another-doc.md",
         "response": {},
         "result": "updated",
         "slug": "another-doc",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/existing-docs/simple-doc.md",
+        "response": {},
+        "result": "updated",
+        "slug": "simple-doc",
       },
     ],
   },
@@ -360,8 +556,8 @@ exports[`rdme docs upload > given that the file path is a directory > should upd
 ✔ 🚀 Uploading files to ReadMe... done!
 ",
   "stdout": "🔄 Successfully updated 2 page(s) in ReadMe:
-   - simple-doc (test/__fixtures__/docs/existing-docs/simple-doc.md)
    - another-doc (test/__fixtures__/docs/existing-docs/subdir/another-doc.md)
+   - simple-doc (test/__fixtures__/docs/existing-docs/simple-doc.md)
 ",
 }
 `;
@@ -864,6 +1060,62 @@ something went so so wrong],
 }
 `;
 
+exports[`rdme reference upload > given that the file path is a directory > given that the direcotry does NOT have explicit frontmatter positions set > should upload root pages using a natural sort order of their slugs when \`position\` is missing 1`] = `
+{
+  "result": {
+    "created": [
+      {
+        "filePath": "test/__fixtures__/docs/position-order-missing/page-1.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-1",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-missing/page-2.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-2",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-missing/page-3.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-3",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-missing/page-4.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-4",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-missing/page-10.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-10",
+      },
+    ],
+    "failed": [],
+    "skipped": [],
+    "updated": [],
+  },
+  "stderr": "- 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-missing\` directory...
+✔ 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-missing\` directory... 5 file(s) found!
+- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🚀 Uploading files to ReadMe...
+✔ 🚀 Uploading files to ReadMe... done!
+",
+  "stdout": "🌱 Successfully created 5 page(s) in ReadMe:
+   - page-1 (test/__fixtures__/docs/position-order-missing/page-1.md)
+   - page-2 (test/__fixtures__/docs/position-order-missing/page-2.md)
+   - page-3 (test/__fixtures__/docs/position-order-missing/page-3.md)
+   - page-4 (test/__fixtures__/docs/position-order-missing/page-4.md)
+   - page-10 (test/__fixtures__/docs/position-order-missing/page-10.md)
+",
+}
+`;
+
 exports[`rdme reference upload > given that the file path is a directory > given that the directory contains parent/child docs > should upload parents before children 1`] = `
 {
   "result": {
@@ -913,21 +1165,161 @@ exports[`rdme reference upload > given that the file path is a directory > given
 }
 `;
 
+exports[`rdme reference upload > given that the file path is a directory > given that the directory has explicit frontmatter positions set > should order sibling uploads by ascending position under the same parent 1`] = `
+{
+  "result": {
+    "created": [
+      {
+        "filePath": "test/__fixtures__/docs/position-order-siblings/parent-hub.md",
+        "response": {},
+        "result": "created",
+        "slug": "parent-hub",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-siblings/child-c.md",
+        "response": {},
+        "result": "created",
+        "slug": "child-c",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-siblings/child-a.md",
+        "response": {},
+        "result": "created",
+        "slug": "child-a",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-siblings/child-b.md",
+        "response": {},
+        "result": "created",
+        "slug": "child-b",
+      },
+    ],
+    "failed": [],
+    "skipped": [],
+    "updated": [],
+  },
+  "stderr": "- 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-siblings\` directory...
+✔ 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-siblings\` directory... 4 file(s) found!
+- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🚀 Uploading files to ReadMe...
+✔ 🚀 Uploading files to ReadMe... done!
+",
+  "stdout": "🌱 Successfully created 4 page(s) in ReadMe:
+   - parent-hub (test/__fixtures__/docs/position-order-siblings/parent-hub.md)
+   - child-c (test/__fixtures__/docs/position-order-siblings/child-c.md)
+   - child-a (test/__fixtures__/docs/position-order-siblings/child-a.md)
+   - child-b (test/__fixtures__/docs/position-order-siblings/child-b.md)
+",
+}
+`;
+
+exports[`rdme reference upload > given that the file path is a directory > given that the directory has explicit frontmatter positions set > should upload root pages by ascending position (not filename order) 1`] = `
+{
+  "result": {
+    "created": [
+      {
+        "filePath": "test/__fixtures__/docs/position-order-roots/z-first.md",
+        "response": {},
+        "result": "created",
+        "slug": "z-first",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-roots/a-second.md",
+        "response": {},
+        "result": "created",
+        "slug": "a-second",
+      },
+    ],
+    "failed": [],
+    "skipped": [],
+    "updated": [],
+  },
+  "stderr": "- 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-roots\` directory...
+✔ 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-roots\` directory... 2 file(s) found!
+- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🚀 Uploading files to ReadMe...
+✔ 🚀 Uploading files to ReadMe... done!
+",
+  "stdout": "🌱 Successfully created 2 page(s) in ReadMe:
+   - z-first (test/__fixtures__/docs/position-order-roots/z-first.md)
+   - a-second (test/__fixtures__/docs/position-order-roots/a-second.md)
+",
+}
+`;
+
+exports[`rdme reference upload > given that the file path is a directory > given that the directory has explicit frontmatter positions set > should upload root pages using a natural sort order of their \`position\` values (1 -> 2 -> 3 -> 20) 1`] = `
+{
+  "result": {
+    "created": [
+      {
+        "filePath": "test/__fixtures__/docs/position-order-natural/page-1.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-1",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-natural/page-2.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-2",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-natural/page-3.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-3",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-natural/page-4.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-4",
+      },
+      {
+        "filePath": "test/__fixtures__/docs/position-order-natural/page-10.md",
+        "response": {},
+        "result": "created",
+        "slug": "page-10",
+      },
+    ],
+    "failed": [],
+    "skipped": [],
+    "updated": [],
+  },
+  "stderr": "- 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-natural\` directory...
+✔ 🔍 Looking for Markdown files in the \`test/__fixtures__/docs/position-order-natural\` directory... 5 file(s) found!
+- 🔬 Validating frontmatter data...
+✔ 🔬 Validating frontmatter data... no issues found!
+- 🚀 Uploading files to ReadMe...
+✔ 🚀 Uploading files to ReadMe... done!
+",
+  "stdout": "🌱 Successfully created 5 page(s) in ReadMe:
+   - page-1 (test/__fixtures__/docs/position-order-natural/page-1.md)
+   - page-2 (test/__fixtures__/docs/position-order-natural/page-2.md)
+   - page-3 (test/__fixtures__/docs/position-order-natural/page-3.md)
+   - page-4 (test/__fixtures__/docs/position-order-natural/page-4.md)
+   - page-10 (test/__fixtures__/docs/position-order-natural/page-10.md)
+",
+}
+`;
+
 exports[`rdme reference upload > given that the file path is a directory > should create a page in ReadMe for each file in the directory and its subdirectories 1`] = `
 {
   "result": {
     "created": [
       {
-        "filePath": "test/__fixtures__/reference/existing-docs/simple-doc.md",
-        "response": {},
-        "result": "created",
-        "slug": "simple-doc",
-      },
-      {
         "filePath": "test/__fixtures__/reference/existing-docs/subdir/another-doc.md",
         "response": {},
         "result": "created",
         "slug": "another-doc",
+      },
+      {
+        "filePath": "test/__fixtures__/reference/existing-docs/simple-doc.md",
+        "response": {},
+        "result": "created",
+        "slug": "simple-doc",
       },
     ],
     "failed": [],
@@ -942,8 +1334,8 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
 ✔ 🚀 Uploading files to ReadMe... done!
 ",
   "stdout": "🌱 Successfully created 2 page(s) in ReadMe:
-   - simple-doc (test/__fixtures__/reference/existing-docs/simple-doc.md)
    - another-doc (test/__fixtures__/reference/existing-docs/subdir/another-doc.md)
+   - simple-doc (test/__fixtures__/reference/existing-docs/simple-doc.md)
 ",
 }
 `;
@@ -975,8 +1367,8 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
 ⏭️ The following 1 page(s) will be skipped due to no frontmatter data:
    - doc-sans-attributes (test/__fixtures__/docs/mixed-docs/doc-sans-attributes.md)
 🚨 Unable to fetch data about the following 2 page(s):
-   - test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
    - test/__fixtures__/docs/mixed-docs/simple-doc.md: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
+   - test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
 ",
 }
 `;
@@ -998,8 +1390,8 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
 ⏭️ Skipped 1 page(s) in ReadMe due to no frontmatter data:
    - doc-sans-attributes (test/__fixtures__/docs/mixed-docs/doc-sans-attributes.md)
 🚨 Received errors when attempting to upload 2 page(s):
-   - test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
    - test/__fixtures__/docs/mixed-docs/simple-doc.md: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
+   - test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
 ",
 }
 `;
@@ -1018,15 +1410,15 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
     "failed": [
       {
         "error": [APIv2Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
-        "filePath": "test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx",
-        "result": "failed",
-        "slug": "some-slug",
-      },
-      {
-        "error": [APIv2Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
         "filePath": "test/__fixtures__/docs/mixed-docs/simple-doc.md",
         "result": "failed",
         "slug": "simple-doc",
+      },
+      {
+        "error": [APIv2Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
+        "filePath": "test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx",
+        "result": "failed",
+        "slug": "some-slug",
       },
     ],
     "skipped": [
@@ -1059,8 +1451,8 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
 ⏭️ Skipped 1 page(s) in ReadMe due to no frontmatter data:
    - doc-sans-attributes (test/__fixtures__/docs/mixed-docs/doc-sans-attributes.md)
 🚨 Received errors when attempting to upload 2 page(s):
-   - test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
    - test/__fixtures__/docs/mixed-docs/simple-doc.md: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
+   - test/__fixtures__/docs/mixed-docs/new-doc-slug.mdx: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.
 ",
 }
 `;
@@ -1203,16 +1595,16 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
     "skipped": [],
     "updated": [
       {
-        "filePath": "test/__fixtures__/reference/existing-docs/simple-doc.md",
-        "response": {},
-        "result": "updated",
-        "slug": "simple-doc",
-      },
-      {
         "filePath": "test/__fixtures__/reference/existing-docs/subdir/another-doc.md",
         "response": {},
         "result": "updated",
         "slug": "another-doc",
+      },
+      {
+        "filePath": "test/__fixtures__/reference/existing-docs/simple-doc.md",
+        "response": {},
+        "result": "updated",
+        "slug": "simple-doc",
       },
     ],
   },
@@ -1224,8 +1616,8 @@ exports[`rdme reference upload > given that the file path is a directory > shoul
 ✔ 🚀 Uploading files to ReadMe... done!
 ",
   "stdout": "🔄 Successfully updated 2 page(s) in ReadMe:
-   - simple-doc (test/__fixtures__/reference/existing-docs/simple-doc.md)
    - another-doc (test/__fixtures__/reference/existing-docs/subdir/another-doc.md)
+   - simple-doc (test/__fixtures__/reference/existing-docs/simple-doc.md)
 ",
 }
 `;

--- a/test/commands/pages/upload.test.ts
+++ b/test/commands/pages/upload.test.ts
@@ -1,3 +1,4 @@
+import type { FullUploadResults } from '../../../src/lib/syncPagePath.js';
 import type { OclifOutput } from '../../helpers/oclif.js';
 
 import fs from 'node:fs';
@@ -565,6 +566,247 @@ describe.each([
 
         expect(result).toMatchSnapshot();
         expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+        mock.done();
+      });
+    });
+
+    describe('given that the directory has explicit frontmatter positions set', () => {
+      it('should upload root pages by ascending position (not filename order)', async () => {
+        const mock = getAPIv2Mock({ authorization })
+          .get(`/branches/stable/${route}/z-first`)
+          .reply(404)
+          .post(`/branches/stable/${route}`, {
+            slug: 'z-first',
+            title: 'Z file (position #1)',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            position: 0,
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {})
+          .get(`/branches/stable/${route}/a-second`)
+          .reply(404)
+          .post(`/branches/stable/${route}`, {
+            slug: 'a-second',
+            title: 'A file (position #2)',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            position: 1,
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {});
+
+        const result = await run(['test/__fixtures__/docs/position-order-roots', '--key', key]);
+
+        expect(result).toMatchSnapshot();
+        expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+        expect((result.result as unknown as FullUploadResults).created.map(page => page.slug)).toStrictEqual([
+          'z-first',
+          'a-second',
+        ]);
+
+        mock.done();
+      });
+
+      it('should upload root pages using a natural sort order of their `position` values (1 -> 2 -> 3 -> 20)', async () => {
+        const mock = getAPIv2Mock({ authorization })
+          .get(`/branches/stable/${route}/page-1`)
+          .reply(404)
+          .get(`/branches/stable/${route}/page-2`)
+          .reply(404)
+          .get(`/branches/stable/${route}/page-3`)
+          .reply(404)
+          .get(`/branches/stable/${route}/page-4`)
+          .reply(404)
+          .get(`/branches/stable/${route}/page-10`)
+          .reply(404)
+
+          .post(`/branches/stable/${route}`, {
+            slug: 'page-1',
+            title: 'Page 1 (position #1)',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            position: 1,
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {})
+          .post(`/branches/stable/${route}`, {
+            slug: 'page-2',
+            title: 'Page 2 (position #2)',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            position: 2,
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {})
+          .post(`/branches/stable/${route}`, {
+            slug: 'page-3',
+            title: 'Page 3 (position #3)',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            position: 3,
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {})
+          .post(`/branches/stable/${route}`, {
+            slug: 'page-4',
+            title: 'Page 4 (position #4)',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            position: 4,
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {})
+          .post(`/branches/stable/${route}`, {
+            slug: 'page-10',
+            title: 'Page 10 (position #10)',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            position: 10,
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {});
+
+        const result = await run(['test/__fixtures__/docs/position-order-natural', '--key', key]);
+
+        expect(result).toMatchSnapshot();
+        expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+        expect((result.result as unknown as FullUploadResults).created.map(page => page.slug)).toStrictEqual([
+          'page-1',
+          'page-2',
+          'page-3',
+          'page-4',
+          'page-10',
+        ]);
+
+        mock.done();
+      });
+
+      it('should order sibling uploads by ascending position under the same parent', async () => {
+        const mock = getAPIv2Mock({ authorization })
+          .get(`/branches/stable/${route}/parent-hub`)
+          .reply(404)
+          .post(`/branches/stable/${route}`, {
+            slug: 'parent-hub',
+            title: 'Parent hub',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            position: 0,
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {})
+
+          // `child-c`, `child-a`, and `child-b` should not have been uploaded yet.
+          .get(`/branches/stable/${route}/child-a`)
+          .reply(404)
+          .get(`/branches/stable/${route}/child-b`)
+          .reply(404)
+          .get(`/branches/stable/${route}/child-c`)
+          .reply(404)
+
+          // `child-c` should be uploaded first because its position is lowest, then `child-a`
+          // followed by `child-b`
+          .post(`/branches/stable/${route}`, {
+            slug: 'child-c',
+            title: 'Child C - position #1',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            position: 10,
+            parent: { uri: `/branches/stable/${route}/parent-hub` },
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {})
+          .post(`/branches/stable/${route}`, {
+            slug: 'child-a',
+            title: 'Child A - position #2',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            position: 20,
+            parent: { uri: `/branches/stable/${route}/parent-hub` },
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {})
+          .post(`/branches/stable/${route}`, {
+            slug: 'child-b',
+            title: 'Child B - position #3',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            position: 30,
+            parent: { uri: `/branches/stable/${route}/parent-hub` },
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {});
+
+        const result = await run(['test/__fixtures__/docs/position-order-siblings', '--key', key]);
+
+        expect(result).toMatchSnapshot();
+        expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+        expect((result.result as unknown as FullUploadResults).created.map(page => page.slug)).toStrictEqual([
+          'parent-hub',
+          'child-c',
+          'child-a',
+          'child-b',
+        ]);
+
+        mock.done();
+      });
+    });
+
+    describe('given that the direcotry does NOT have explicit frontmatter positions set', () => {
+      it('should upload root pages using a natural sort order of their slugs when `position` is missing', async () => {
+        const mock = getAPIv2Mock({ authorization })
+          .get(`/branches/stable/${route}/page-1`)
+          .reply(404)
+          .get(`/branches/stable/${route}/page-2`)
+          .reply(404)
+          .get(`/branches/stable/${route}/page-3`)
+          .reply(404)
+          .get(`/branches/stable/${route}/page-4`)
+          .reply(404)
+          .get(`/branches/stable/${route}/page-10`)
+          .reply(404)
+
+          .post(`/branches/stable/${route}`, {
+            slug: 'page-1',
+            title: 'Page 1 (position #1)',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {})
+          .post(`/branches/stable/${route}`, {
+            slug: 'page-2',
+            title: 'Page 2 (position #2)',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {})
+          .post(`/branches/stable/${route}`, {
+            slug: 'page-3',
+            title: 'Page 3 (position #3)',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {})
+          .post(`/branches/stable/${route}`, {
+            slug: 'page-4',
+            title: 'Page 4 (position #4)',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {})
+          .post(`/branches/stable/${route}`, {
+            slug: 'page-10',
+            title: 'Page 10 (position #10)',
+            category: { uri: `/branches/stable/categories/${route}/category-slug` },
+            content: { body: '\nBody\n' },
+          })
+          .reply(201, {});
+
+        const result = await run(['test/__fixtures__/docs/position-order-missing', '--key', key]);
+
+        expect(result).toMatchSnapshot();
+        expect(fs.writeFileSync).not.toHaveBeenCalled();
+
+        expect((result.result as unknown as FullUploadResults).created.map(page => page.slug)).toStrictEqual([
+          'page-1',
+          'page-2',
+          'page-3',
+          'page-4',
+          'page-10',
+        ]);
 
         mock.done();
       });


### PR DESCRIPTION
| 🚥 Resolves CX-3309, https://github.com/readmeio/rdme/issues/1405, https://github.com/readmeio/rdme/issues/1367 |
| :------------------- |

## 🧰 Changes

With ReadMe Refactored the `position` value that we use in our API is not _quite_ the same as it was pre-refactored because it dictates the position that your page should be sorted within the `_order.yaml` file that we create for you in Git. If `page-2` has a `position` of `2` and is created _before_ `page-1`, which has a position of `1`, then the `_order.yaml` file will have `page-2` sorted before `page-1` because it came in first.

Pre-Refactored these `position` values were stored as the value you had alongside the page in our database so a file with a `position` of `2` would forever have that position until it explicitly changed.

The work I've done here is to change the way that rdme batches up its API requests to ensure that we make these requests in the order of the `position` value that we have present. If we don't have a `position` then we'll fall back to the `slug` available, sorting it naturally (ensuring that `page-10` is not sorted between `page-1` and `page-2`)