### PR TITLE
fix: bumping up our polling queue for OpenAPI uploads from 10 to 25

### DIFF
--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -109,7 +109,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     let status: APIUploadStatus = 'pending';
 
     // oxlint-disable no-await-in-loop -- We need to wait between requests to avoid hitting rate limits.
-    while (this.isStatusPending(status) && count < 10) {
+    while (this.isStatusPending(status) && count < 25) {
       // oxlint-disable-next-line no-loop-func -- False positive.
       await new Promise(resolve => {
         // exponential backoff — wait 1s, 2s, 4s, 8s, 16s, 32s, 30s, 30s, 30s, 30s, etc.

--- a/test/commands/openapi/upload.test.ts
+++ b/test/commands/openapi/upload.test.ts
@@ -480,7 +480,7 @@ describe('rdme openapi upload', () => {
             },
           })
           .get(`/branches/${branch}/apis/${slugifiedFilename}`)
-          .times(10)
+          .times(25)
           .reply(200, {
             data: {
               upload: { status: 'pending' },


### PR DESCRIPTION
| 🚥 Resolves CX-3012 |
| :------------------- |

## 🧰 Changes

When uploading OpenAPI definitions with a very large amount of operations (2000+), it can take upwards of 5 minutes to process within our backend. The current polling interval we have for checking if an upload has finished currently has a cap of 10, however even  with exponential backoffs these large uploads can surpass that resulting in rdme throwing an incorrect "Your upload has timed out error." -- the upload still ends up getting processed.

This raises that polling interval from 10 to 25, raising our total wait time from 181,000ms (~3m) to a new maximum of 631,000ms (~10.5m).