### PR TITLE
fix(gha): argument parsing when using quotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,5 +163,3 @@ jobs:
         uses: ./rdme-repo/
         with:
           rdme: openapi upload "oas-examples-repo/3.1/json/petstore.json" --key="${{ secrets.RDME_REFACTORED_TEST_PROJECT_API_KEY }}"
-        env:
-          DEBUG: "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,3 +163,5 @@ jobs:
         uses: ./rdme-repo/
         with:
           rdme: openapi upload "oas-examples-repo/3.1/json/petstore.json" --key="${{ secrets.RDME_REFACTORED_TEST_PROJECT_API_KEY }}"
+        env:
+          DEBUG: "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,3 +159,7 @@ jobs:
         uses: ./rdme-repo/
         with:
           rdme: openapi upload "oas-examples-repo/3.1/json/petstore.json" --key "${{ secrets.RDME_REFACTORED_TEST_PROJECT_API_KEY }}"
+      - name: Run `openapi upload` command with weird arg syntax and equal sign
+        uses: ./rdme-repo/
+        with:
+          rdme: openapi upload "oas-examples-repo/3.1/json/petstore.json" --key="${{ secrets.RDME_REFACTORED_TEST_PROJECT_API_KEY }}"

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-
 import stringArgv from 'string-argv';
+
+import { normalizeStringArgvForGha } from '../dist/lib/normalizeStringArgvForGha.js';
 
 async function main() {
   /**
@@ -14,7 +15,7 @@ async function main() {
   const { execute } = await import('@oclif/core');
   const opts = { dir: import.meta.url };
   if (process.env.INPUT_RDME) {
-    opts.args = stringArgv(process.env.INPUT_RDME);
+    opts.args = normalizeStringArgvForGha(stringArgv(process.env.INPUT_RDME));
   }
   await execute(opts).then(msg => {
     if (msg && typeof msg === 'string') {

--- a/src/lib/normalizeStringArgvForGha.ts
+++ b/src/lib/normalizeStringArgvForGha.ts
@@ -1,0 +1,27 @@
+/**
+ * When `INPUT_RDME` is parsed with `string-argv`, tokens like `--flag="value"` remain a single
+ * argv element whose suffix includes literal quote characters. A real shell strips those quotes
+ * before invoking Node, so we normalize to match shell and `process.argv` behavior.
+ *
+ */
+export function normalizeStringArgvForGha(argv: string[]): string[] {
+  return argv.map(token => {
+    if (!token.startsWith('--') || !token.includes('=')) {
+      return token;
+    }
+
+    const eq = token.indexOf('=');
+    const prefix = token.slice(0, eq + 1);
+    const value = token.slice(eq + 1);
+
+    if (value.length >= 2) {
+      const open = value[0];
+      const close = value[value.length - 1];
+      if ((open === '"' && close === '"') || (open === "'" && close === "'")) {
+        return prefix + value.slice(1, -1);
+      }
+    }
+
+    return token;
+  });
+}

--- a/test/lib/normalizeStringArgvForGha.test.ts
+++ b/test/lib/normalizeStringArgvForGha.test.ts
@@ -1,0 +1,50 @@
+import stringArgv from 'string-argv';
+import { describe, expect, it } from 'vitest';
+
+import { normalizeStringArgvForGha } from '../../src/lib/normalizeStringArgvForGha.js';
+
+describe('normalizeStringArgvForGha()', () => {
+  it('strips double quotes from `--long=value` tokens', () => {
+    const argv = stringArgv('openapi upload --key="secret"');
+    expect(normalizeStringArgvForGha(argv)).toStrictEqual(['openapi', 'upload', '--key=secret']);
+  });
+
+  it('strips single quotes from `--long=value` tokens', () => {
+    const argv = stringArgv("openapi upload --key='secret'");
+    expect(normalizeStringArgvForGha(argv)).toStrictEqual(['openapi', 'upload', '--key=secret']);
+  });
+
+  it('leaves unquoted equals-form flags unchanged', () => {
+    expect(normalizeStringArgvForGha(['openapi', 'upload', '--key=secret'])).toStrictEqual([
+      'openapi',
+      'upload',
+      '--key=secret',
+    ]);
+  });
+
+  it('strips quotes when value contains spaces (`string-argv` single token)', () => {
+    const argv = stringArgv('whoami --branch="name with spaces"');
+    expect(normalizeStringArgvForGha(argv)).toStrictEqual(['whoami', '--branch=name with spaces']);
+  });
+
+  it('does not change positional args or flags without `=`', () => {
+    expect(normalizeStringArgvForGha(['openapi', 'upload', './spec.json', '--dry-run'])).toStrictEqual([
+      'openapi',
+      'upload',
+      './spec.json',
+      '--dry-run',
+    ]);
+  });
+
+  it('normalizes empty quoted value to bare equals suffix', () => {
+    const argv = stringArgv('whoami --title=""');
+    expect(normalizeStringArgvForGha(argv)).toStrictEqual(['whoami', '--title=']);
+  });
+
+  it('does not strip mismatched or partial quotes', () => {
+    expect(normalizeStringArgvForGha(['--key="unfinished'])).toStrictEqual(['--key="unfinished']);
+    expect(normalizeStringArgvForGha(['--url=https://example.com?q="x"'])).toStrictEqual([
+      '--url=https://example.com?q="x"',
+    ]);
+  });
+});


### PR DESCRIPTION
| 🚥 Resolves #1374 |
| :------------------- |

## 🧰 Changes

This works around a quirk with the library we use in our GHA action to parse arguments, [string-argv](https://npm.im/string-argv), where if you have an argument string like `rdme openapi upload --key="MY_API_KEY"` it'll parse the `--key` argument to `--key="MY_API_KEY"`. This then, when fed into Oclif's argument parsing systems, ends up with our API key being used as `"MY_API_KEY"`.

This issue is only prevalent in our GHA flow because we supply the GitHub Action a single string as our arguments, rather than individually. To resolve this I've created a new wrapper for `string-argv` that handles stripping quotations. The result is the folowing:

#### Before

```ts
// openapi upload "oas-examples-repo/3.1/json/petstore.json" --key="MY_API_KEY"

[
  'openapi',
  'upload',
  'oas-examples-repo/3.1/json/petstore.json',
  '--key="MY_API_KEY"'
]
```

#### After

```ts
[
  'openapi',
  'upload',
  'oas-examples-repo/3.1/json/petstore.json',
  '--key=MY_API_KEY'
]
```
