### PR TITLE
feat: improved messaging around inferred OpenAPI slugs when `--slug` is missing

### DIFF
--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -1,5 +1,7 @@
+import type { SpecType } from '../../lib/prepareOas.js';
 import type {
   APIDefinitionsRepresentation,
+  APIUploadFailureReason,
   APIUploadSingleResponseRepresentation,
   APIUploadStatus,
   StagedAPIUploadResponseRepresentation,
@@ -21,6 +23,10 @@ import prepareOas from '../../lib/prepareOas.js';
 import promptTerminal from '../../lib/promptWrapper.js';
 
 const yamlExtensions = ['.yaml', '.yml'];
+
+function isNestedLocalSpecPath(specPath: string): boolean {
+  return nodePath.dirname(nodePath.normalize(specPath)) !== '.';
+}
 
 export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUploadCommand> {
   id = 'openapi upload' as const;
@@ -101,12 +107,17 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     return status.includes('pending');
   }
 
+  private isStatusFailed(status: APIUploadStatus): status is 'pending_update' | 'pending' {
+    return status === 'failed' || status === 'failed_update';
+  }
+
   /**
    * Poll the ReadMe API until the upload is complete.
    */
   private async pollAPIUntilUploadIsComplete(slug: string, headers: Headers) {
     let count = 0;
     let status: APIUploadStatus = 'pending';
+    let reason: APIUploadFailureReason | undefined;
 
     // oxlint-disable no-await-in-loop -- We need to wait between requests to avoid hitting rate limits.
     while (this.isStatusPending(status) && count < 25) {
@@ -122,6 +133,10 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
       )) as APIUploadSingleResponseRepresentation;
 
       status = response?.data?.upload?.status;
+      if (this.isStatusFailed(status)) {
+        reason = response?.data?.upload?.reason;
+      }
+
       count += 1;
     }
     // oxlint-enable no-await-in-loop
@@ -130,7 +145,34 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
       throw new Error('Sorry, this upload timed out. Please try again later.');
     }
 
-    return status;
+    return { status, reason };
+  }
+
+  private slugifiedFilenameWarningMessage(specPath: string, filename: string, specType: SpecType): string {
+    const suggestedSlug = nodePath.basename(specPath);
+
+    let specTypeLabel: string;
+    if (specType === 'Postman') {
+      specTypeLabel = 'Postman collection';
+    } else if (specType === 'Swagger') {
+      specTypeLabel = 'Swagger file';
+    } else {
+      specTypeLabel = 'OpenAPI file';
+    }
+
+    return [
+      `This ${specTypeLabel} is located in a subfolder and no \`--slug\` was provided.`,
+      '',
+      `You are uploading:\n  ${specPath}`,
+      '',
+      `In rdme v10, the file path is flattened and used to infer a slug:\n  ${specPath}  →  ${filename}`,
+      '',
+      'If you intend to update an existing definition, this often creates a new API definition instead of updating an existing one.',
+      '',
+      `We recommend you cancel and rerun with:\n  ${this.config.bin} ${this.id} ${specPath} --slug=${suggestedSlug}`,
+      '',
+      'To suppress this warning and confirmation in the future, use `--confirm-overwrite`.',
+    ].join('\n');
   }
 
   async run() {
@@ -264,13 +306,6 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
         `No filename could be inferred from the provided URL, so the slug will default to ${filename}. To set a custom slug, use the \`--slug\` flag.`,
       );
     }
-    // if the resulting file name is different than the original path input and the user hasn't provided a slug or legacy ID,
-    // warn them that the slug may not be what they expect
-    else if (filename !== specPath && !this.flags['legacy-id'] && !this.flags.slug) {
-      this.warn(
-        `The slug of your API Definition will be set to ${filename} in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.`,
-      );
-    }
 
     const matchingAPIDefinition = existingAPIDefinitions.find(d => {
       if (this.flags['legacy-id']) {
@@ -295,6 +330,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
           ),
         );
       }
+
       filename = matchingAPIDefinition.filename;
       this.warn(
         `The \`--legacy-id\` flag will be removed in a future version. We recommend passing \`--slug ${filename}\` for maximum compatibility and readability.`,
@@ -302,8 +338,26 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
       this.debug(`using existing legacy ID ${this.flags['legacy-id']} with filename ${filename}`);
     }
 
+    // if we have a matching API definition based on legacy-id or slug, we'll use PUT to update it.
+    // otherwise, we'll use POST to create it
+    const method = matchingAPIDefinition ? 'PUT' : 'POST';
+
+    // if the file we're going to be creating is a nested local path and it wasn't supplied via
+    // the `--slug` or `--legacy-id` flags then we should confirm with the user that the slug we
+    // inferred from it is what they actually want it to be.
+    const shouldConfirmSlugifiedFilename =
+      method === 'POST' &&
+      !specFileTypeIsUrl &&
+      !this.flags.slug &&
+      !this.flags['legacy-id'] &&
+      isNestedLocalSpecPath(specPath);
+
     // this is where we return early if the --dry-run flag is provided
     if (this.flags['dry-run']) {
+      if (shouldConfirmSlugifiedFilename) {
+        this.warn(this.slugifiedFilenameWarningMessage(specPath, filename, specType));
+      }
+
       this.log('--- Dry Run Result 🌵 ---');
       this.log(`File slug: ${filename}`);
       this.log(`Branch: ${branch}`);
@@ -320,10 +374,26 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
       return;
     }
 
-    // if we have a matching API definition based on legacy-id or slug, we'll use PUT to update it. otherwise, we'll use POST to create it
-    const method = matchingAPIDefinition ? 'PUT' : 'POST';
-
     this.debug(`making a ${method} request`);
+
+    if (shouldConfirmSlugifiedFilename) {
+      this.warn(this.slugifiedFilenameWarningMessage(specPath, filename, specType));
+
+      prompts.override({
+        confirmNestedPathCreate: isCI() || this.flags['confirm-overwrite'] ? true : undefined,
+      });
+
+      const { confirmNestedPathCreate } = await promptTerminal({
+        type: 'confirm',
+        name: 'confirmNestedPathCreate',
+        message: 'Continue anyway?',
+        initial: false,
+      });
+
+      if (!confirmNestedPathCreate) {
+        throw new Error('Aborting, no changes were made.');
+      }
+    }
 
     // if the file already exists, ask the user if they want to overwrite it
     if (method === 'PUT') {
@@ -368,10 +438,17 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
 
     if (response?.data?.upload?.status && response?.data?.uri) {
       let status = response.data.upload.status;
+      let reason: APIUploadFailureReason | undefined;
 
       if (this.isStatusPending(status)) {
         spinner.text = `${spinner.text} uploaded but not yet processed by ReadMe. Polling for completion...`;
-        status = await this.pollAPIUntilUploadIsComplete(response.data.uri, headers);
+        ({ status, reason } = await this.pollAPIUntilUploadIsComplete(response.data.uri, headers));
+      }
+
+      if (this.isStatusFailed(status)) {
+        if (reason) {
+          throw new Error(`Your API definition upload failed with the following reason:\n\n${reason}`);
+        }
       }
 
       if (status === 'done') {

--- a/src/lib/prepareOas.ts
+++ b/src/lib/prepareOas.ts
@@ -13,7 +13,7 @@ import readdirRecursive from './readdirRecursive.js';
 
 export type SpecFileType = OASNormalize['type'];
 
-type SpecType = 'OpenAPI' | 'Postman' | 'Swagger';
+export type SpecType = 'OpenAPI' | 'Postman' | 'Swagger' | 'Unknown';
 
 interface FoundSpecFile {
   /** path to the spec file */
@@ -100,7 +100,7 @@ export default async function prepareOas(this: OpenAPICommands) {
               this.debug(`specification type for ${file}: ${specification}`);
               this.debug(`version for ${file}: ${version}`);
               return ['openapi', 'swagger', 'postman'].includes(specification)
-                ? { filePath: file, specType: capitalizeSpecType(specification) as SpecType, version }
+                ? { filePath: file, specType: capitalizeSpecType(specification), version }
                 : null;
             })
             .catch(e => {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -72,6 +72,7 @@ export type StagedAPIUploadResponseRepresentation = FromSchema<
 >;
 
 export type APIUploadStatus = APIUploadSingleResponseRepresentation['data']['upload']['status'];
+export type APIUploadFailureReason = APIUploadSingleResponseRepresentation['data']['upload']['reason'];
 
 /**
  * Derived from our API documentation, this is the schema for the page objects

--- a/test/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/test/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -69,10 +69,25 @@ exports[`rdme openapi upload > given that the --dry-run flag is passed > should 
 {
   "result": undefined,
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
+ ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
+ ›   provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/petstore-simple-weird-version.json
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/petstore-simple-weird-version.json  →  
+ ›   test__fixtures__petstore-simple-weird-version.json
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json
+ ›    --slug=petstore-simple-weird-version.json
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
 ",
   "stdout": "--- Dry Run Result 🌵 ---
 File slug: test__fixtures__petstore-simple-weird-version.json
@@ -92,10 +107,6 @@ exports[`rdme openapi upload > given that the --dry-run flag is passed > should 
 {
   "result": undefined,
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
 ",
   "stdout": "--- Dry Run Result 🌵 ---
 File slug: test__fixtures__petstore-simple-weird-version.json
@@ -196,9 +207,6 @@ exports[`rdme openapi upload > given that the API definition is a URL > should c
     "uri": "/branches/1.0.0/apis/openapi.json",
   },
   "stderr": "- Validating the API definition located at https://example.com/openapi.json...
- ›   Warning: The slug of your API Definition will be set to openapi.json in 
- ›   ReadMe. This slug is not visible to your end users. To set this slug to 
- ›   something else, use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
@@ -214,9 +222,6 @@ exports[`rdme openapi upload > given that the API definition is a URL > should c
     "uri": "/branches/1.0.0/apis/no-extension.json",
   },
   "stderr": "- Validating the API definition located at https://example.com/no-extension...
- ›   Warning: The slug of your API Definition will be set to no-extension.json 
- ›   in ReadMe. This slug is not visible to your end users. To set this slug to
- ›    something else, use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
@@ -233,9 +238,6 @@ exports[`rdme openapi upload > given that the API definition is a URL > should c
   },
   "stderr": "- Validating the API definition located at https://example.com/no-extension...
  ›   Warning: Support for Postman collections is currently experimental.
- ›   Warning: The slug of your API Definition will be set to no-extension.json 
- ›   in ReadMe. This slug is not visible to your end users. To set this slug to
- ›    something else, use the \`--slug\` flag.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
@@ -296,9 +298,6 @@ exports[`rdme openapi upload > given that the API definition is a URL > should u
     "uri": "/branches/1.0.0/apis/openapi.json",
   },
   "stderr": "- Validating the API definition located at https://example.com/openapi.json...
- ›   Warning: The slug of your API Definition will be set to openapi.json in 
- ›   ReadMe. This slug is not visible to your end users. To set this slug to 
- ›   something else, use the \`--slug\` flag.
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",
@@ -314,9 +313,6 @@ exports[`rdme openapi upload > given that the API definition is a URL > should u
     "uri": "/branches/1.0.0/apis/openapi.json",
   },
   "stderr": "- Validating the API definition located at https://example.com/no-extension...
- ›   Warning: The slug of your API Definition will be set to no-extension.json 
- ›   in ReadMe. This slug is not visible to your end users. To set this slug to
- ›    something else, use the \`--slug\` flag.
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",
@@ -448,6 +444,22 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 }
 `;
 
+exports[`rdme openapi upload > given that the API definition is a local file > and the command is being run in a CI environment > should create a new API definition from a nested path without prompting in CI 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/branches/1.0.0/apis/test__fixtures__petstore-simple-weird-version.json",
+  },
+  "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... done!
+",
+  "stdout": "::warning::This OpenAPI file is located in a subfolder and no \`--slug\` was provided.%0A%0AYou are uploading:%0A  test/__fixtures__/petstore-simple-weird-version.json%0A%0AIn rdme v10, the file path is flattened and used to infer a slug:%0A  test/__fixtures__/petstore-simple-weird-version.json  →  test__fixtures__petstore-simple-weird-version.json%0A%0AIf you intend to update an existing definition, this often creates a new API definition instead of updating an existing one.%0A%0AWe recommend you cancel and rerun with:%0A  rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json --slug=petstore-simple-weird-version.json%0A%0ATo suppress this warning and confirmation in the future, use \`--confirm-overwrite\`.
+🚀 Your API definition (test__fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
+",
+}
+`;
+
 exports[`rdme openapi upload > given that the API definition is a local file > and the command is being run in a CI environment > should error out if an object ID is passed and there is a legacy match found 1`] = `
 {
   "error": [Error: The slug you provided matches a legacy API definition ID, which have been deprecated in ReadMe. To fix this, update your \`--slug\` flag to  \`legacy-spec.json\`.],
@@ -467,8 +479,7 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",
-  "stdout": "::warning::The slug of your API Definition will be set to test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is not visible to your end users. To set this slug to something else, use the \`--slug\` flag.
-🚀 Your API definition (test__fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
+  "stdout": "🚀 Your API definition (test__fixtures__petstore-simple-weird-version.json) was successfully updated in ReadMe!
 ",
 }
 `;
@@ -477,10 +488,25 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 {
   "error": [Error: Sorry, this upload timed out. Please try again later.],
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
+ ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
+ ›   provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/petstore-simple-weird-version.json
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/petstore-simple-weird-version.json  →  
+ ›   test__fixtures__petstore-simple-weird-version.json
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json
+ ›    --slug=petstore-simple-weird-version.json
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
 - Creating your API definition to ReadMe...
 ",
   "stdout": "",
@@ -491,10 +517,25 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 {
   "error": [Error: The ReadMe API responded with an unexpected error. Please try again and if this issue persists, get in touch with us at support@readme.io.],
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
+ ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
+ ›   provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/petstore-simple-weird-version.json
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/petstore-simple-weird-version.json  →  
+ ›   test__fixtures__petstore-simple-weird-version.json
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json
+ ›    --slug=petstore-simple-weird-version.json
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
 - Creating your API definition to ReadMe...
 ",
   "stdout": "",
@@ -503,14 +544,30 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 
 exports[`rdme openapi upload > given that the API definition is a local file > and the upload status initially is a pending state > should poll the API once and handle an unexpected state with a 2xx 1`] = `
 {
-  "error": [Error: Your API definition upload failed with an unexpected error. Please get in touch with us at support@readme.io.],
+  "error": [Error: Your API definition upload failed with the following reason:
+
+The API definition has validation errors.],
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
+ ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
+ ›   provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/petstore-simple-weird-version.json
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/petstore-simple-weird-version.json  →  
+ ›   test__fixtures__petstore-simple-weird-version.json
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json
+ ›    --slug=petstore-simple-weird-version.json
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
 - Creating your API definition to ReadMe...
-✖ Creating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion...
 ",
   "stdout": "",
 }
@@ -523,10 +580,6 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
     "uri": "/branches/1.0.0/apis/test__fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion... done!
 ",
@@ -542,10 +595,25 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
     "uri": "/branches/1.0.0/apis/test__fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
+ ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
+ ›   provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/petstore-simple-weird-version.json
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/petstore-simple-weird-version.json  →  
+ ›   test__fixtures__petstore-simple-weird-version.json
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json
+ ›    --slug=petstore-simple-weird-version.json
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion... done!
 ",
@@ -561,10 +629,25 @@ exports[`rdme openapi upload > given that the API definition is a local file > g
     "uri": "/branches/stable/apis/test__fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
+ ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
+ ›   provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/petstore-simple-weird-version.json
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/petstore-simple-weird-version.json  →  
+ ›   test__fixtures__petstore-simple-weird-version.json
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json
+ ›    --slug=petstore-simple-weird-version.json
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
@@ -580,10 +663,87 @@ exports[`rdme openapi upload > given that the API definition is a local file > g
     "uri": "/branches/1.2.3/apis/test__fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
+ ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
+ ›   provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/petstore-simple-weird-version.json
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/petstore-simple-weird-version.json  →  
+ ›   test__fixtures__petstore-simple-weird-version.json
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json
+ ›    --slug=petstore-simple-weird-version.json
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
+- Creating your API definition to ReadMe...
+✔ Creating your API definition to ReadMe... done!
+",
+  "stdout": "🚀 Your API definition (test__fixtures__petstore-simple-weird-version.json) was successfully created in ReadMe!
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > nested path create confirmation (CX-2743) > should abort if the user declines the nested path prompt 1`] = `
+{
+  "error": [Error: Aborting, no changes were made.],
+  "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
+ ›   provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/petstore-simple-weird-version.json
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/petstore-simple-weird-version.json  →  
+ ›   test__fixtures__petstore-simple-weird-version.json
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json
+ ›    --slug=petstore-simple-weird-version.json
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
+",
+  "stdout": "",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > nested path create confirmation (CX-2743) > should create a new API definition without prompting when \`--confirm-overwrite\` is passed 1`] = `
+{
+  "result": {
+    "status": "done",
+    "uri": "/branches/1.0.0/apis/test__fixtures__petstore-simple-weird-version.json",
+  },
+  "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
+ ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
+ ›   provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/petstore-simple-weird-version.json
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/petstore-simple-weird-version.json  →  
+ ›   test__fixtures__petstore-simple-weird-version.json
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json
+ ›    --slug=petstore-simple-weird-version.json
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
@@ -599,10 +759,25 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
     "uri": "/branches/1.0.0/apis/test__fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
+ ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
+ ›   provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/petstore-simple-weird-version.json
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/petstore-simple-weird-version.json  →  
+ ›   test__fixtures__petstore-simple-weird-version.json
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json
+ ›    --slug=petstore-simple-weird-version.json
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
@@ -619,10 +794,25 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
   },
   "stderr": " ›   Warning: The "--version" flag has been deprecated. Use "--branch" instead.
 - Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
+ ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
+ ›   provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/petstore-simple-weird-version.json
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/petstore-simple-weird-version.json  →  
+ ›   test__fixtures__petstore-simple-weird-version.json
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json
+ ›    --slug=petstore-simple-weird-version.json
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
@@ -639,10 +829,25 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
   },
   "stderr": "- Validating the API definition located at test/__fixtures__/postman/petstore.collection.yaml...
  ›   Warning: Support for Postman collections is currently experimental.
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__postmanpetstore.collection.yaml in ReadMe. This slug is 
- ›   not visible to your end users. To set this slug to something else, use the
- ›    \`--slug\` flag.
+ ›   Warning: This Postman collection is located in a subfolder and no \`--slug\`
+ ›    was provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/postman/petstore.collection.yaml
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/postman/petstore.collection.yaml  →  
+ ›   test__fixtures__postmanpetstore.collection.yaml
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/postman/petstore.collection.yaml 
+ ›   --slug=petstore.collection.yaml
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
 - Creating your API definition to ReadMe...
 ✔ Creating your API definition to ReadMe... done!
 ",
@@ -655,10 +860,25 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
 {
   "error": [Error: Your API definition upload failed with an unexpected error. Please get in touch with us at support@readme.io.],
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
+ ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
+ ›   provided.
+ ›
+ ›   You are uploading:
+ ›     test/__fixtures__/petstore-simple-weird-version.json
+ ›
+ ›   In rdme v10, the file path is flattened and used to infer a slug:
+ ›     test/__fixtures__/petstore-simple-weird-version.json  →  
+ ›   test__fixtures__petstore-simple-weird-version.json
+ ›
+ ›   If you intend to update an existing definition, this often creates a new 
+ ›   API definition instead of updating an existing one.
+ ›
+ ›   We recommend you cancel and rerun with:
+ ›     rdme openapi upload test/__fixtures__/petstore-simple-weird-version.json
+ ›    --slug=petstore-simple-weird-version.json
+ ›
+ ›   To suppress this warning and confirmation in the future, use 
+ ›   \`--confirm-overwrite\`.
 - Creating your API definition to ReadMe...
 ✖ Creating your API definition to ReadMe...
 ",
@@ -673,10 +893,6 @@ exports[`rdme openapi upload > given that the API definition is a local file > s
     "uri": "/branches/1.0.0/apis/test__fixtures__petstore-simple-weird-version.json",
   },
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
- ›   Warning: The slug of your API Definition will be set to 
- ›   test__fixtures__petstore-simple-weird-version.json in ReadMe. This slug is
- ›    not visible to your end users. To set this slug to something else, use 
- ›   the \`--slug\` flag.
 - Updating your API definition to ReadMe...
 ✔ Updating your API definition to ReadMe... done!
 ",

--- a/test/commands/openapi/upload.test.ts
+++ b/test/commands/openapi/upload.test.ts
@@ -46,6 +46,7 @@ describe('rdme openapi upload', () => {
 
   describe('given that the API definition is a local file', () => {
     it('should create a new JSON API definition in ReadMe', async () => {
+      prompts.inject([true]);
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, { data: [] })
@@ -71,6 +72,7 @@ describe('rdme openapi upload', () => {
     });
 
     it('should create a new JSON API definition in ReadMe with deprecated `--version` flag', async () => {
+      prompts.inject([true]);
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, { data: [] })
@@ -96,6 +98,7 @@ describe('rdme openapi upload', () => {
     });
 
     it('should create a new YAML API definition in ReadMe', async () => {
+      prompts.inject([true]);
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, { data: [] })
@@ -144,6 +147,8 @@ describe('rdme openapi upload', () => {
     });
 
     it('should handle upload failures', async () => {
+      prompts.inject([true]);
+
       const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
         .get(`/branches/${branch}/apis`)
         .reply(200, { data: [] })
@@ -156,7 +161,7 @@ describe('rdme openapi upload', () => {
         )
         .reply(200, {
           data: {
-            upload: { status: 'fail' },
+            upload: { status: 'failed' },
             uri: `/branches/${branch}/apis/${slugifiedFilename}`,
           },
         });
@@ -166,6 +171,46 @@ describe('rdme openapi upload', () => {
       expect(result).toMatchSnapshot();
 
       mock.done();
+    });
+
+    describe('nested path create confirmation (CX-2743)', () => {
+      it('should abort if the user declines the nested path prompt', async () => {
+        prompts.inject([false]);
+        const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
+          .get(`/branches/${branch}/apis`)
+          .reply(200, { data: [] });
+
+        const result = await run(['--branch', branch, filename, '--key', key]);
+
+        expect(result).toMatchSnapshot();
+
+        mock.done();
+      });
+
+      it('should create a new API definition without prompting when `--confirm-overwrite` is passed', async () => {
+        const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
+          .get(`/branches/${branch}/apis`)
+          .reply(200, { data: [] })
+          .post(
+            `/branches/${branch}/apis`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`,
+              ) && body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
+          )
+          .reply(200, {
+            data: {
+              upload: { status: 'done' },
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
+            },
+          });
+
+        const result = await run(['--branch', branch, filename, '--key', key, '--confirm-overwrite']);
+
+        expect(result).toMatchSnapshot();
+
+        mock.done();
+      });
     });
 
     describe('and the `--slug` flag is passed', () => {
@@ -375,6 +420,7 @@ describe('rdme openapi upload', () => {
 
     describe('and the upload status initially is a pending state', () => {
       it('should poll the API until the upload is complete', async () => {
+        prompts.inject([true]);
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
@@ -461,6 +507,7 @@ describe('rdme openapi upload', () => {
       });
 
       it('should poll the API and handle timeouts', async () => {
+        prompts.inject([true]);
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
@@ -496,6 +543,7 @@ describe('rdme openapi upload', () => {
       });
 
       it('should poll the API once and handle a failure state with a 4xx', async () => {
+        prompts.inject([true]);
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
@@ -525,6 +573,7 @@ describe('rdme openapi upload', () => {
       });
 
       it('should poll the API once and handle an unexpected state with a 2xx', async () => {
+        prompts.inject([true]);
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
           .reply(200, { data: [] })
@@ -546,13 +595,17 @@ describe('rdme openapi upload', () => {
           .get(`/branches/${branch}/apis/${slugifiedFilename}`)
           .reply(200, {
             data: {
-              upload: { status: 'something-unexpected' },
+              upload: {
+                status: 'failed',
+                reason: 'The API definition has validation errors.',
+              },
               uri: `/branches/${branch}/apis/${slugifiedFilename}`,
             },
           });
 
         const result = await run(['--branch', branch, filename, '--key', key]);
 
+        expect(result.error.message).toContain('The API definition has validation errors.');
         expect(result).toMatchSnapshot();
 
         mock.done();
@@ -591,6 +644,31 @@ describe('rdme openapi upload', () => {
         mock.done();
       });
 
+      it('should create a new API definition from a nested path without prompting in CI', async () => {
+        const mock = getAPIv2MockForGHA({ authorization: `Bearer ${key}` })
+          .get(`/branches/${branch}/apis`)
+          .reply(200, { data: [] })
+          .post(
+            `/branches/${branch}/apis`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`,
+              ) && body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
+          )
+          .reply(200, {
+            data: {
+              upload: { status: 'done' },
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
+            },
+          });
+
+        const result = await run(['--branch', branch, filename, '--key', key]);
+
+        expect(result).toMatchSnapshot();
+
+        mock.done();
+      });
+
       it('should error out if an object ID is passed and there is a legacy match found', async () => {
         const customSlug = '687855c3600c6e14c79a94cb';
         const existingFilename = 'legacy-spec.json';
@@ -608,6 +686,7 @@ describe('rdme openapi upload', () => {
 
     describe('given that the `--branch` flag is not set', () => {
       it('should default to the `stable` version', async () => {
+        prompts.inject([true]);
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get('/branches/stable/apis')
           .reply(200, { data: [] })
@@ -635,6 +714,7 @@ describe('rdme openapi upload', () => {
       });
 
       it('should use the version from the spec file if --`useSpecVersion` is passed', async () => {
+        prompts.inject([true]);
         const altVersion = '1.2.3';
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${altVersion}/apis`)

--- a/test/helpers/github-workflow-schema.json
+++ b/test/helpers/github-workflow-schema.json
@@ -15,13 +15,20 @@
       "properties": {
         "group": {
           "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run-1",
-          "description": "When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled.",
+          "description": "When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. By default any previously pending job or workflow in the concurrency group will be canceled; this behavior can be changed with `queue`.",
           "type": "string"
         },
         "cancel-in-progress": {
           "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run-1",
           "description": "To cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.",
           "oneOf": [{ "type": "boolean" }, { "$ref": "#/definitions/expressionSyntax" }]
+        },
+        "queue": {
+          "$comment": "https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-queueing-multiple-pending-runs",
+          "description": "Controls how pending jobs or workflow runs are queued within a concurrency group. With the default `single`, at most one run can be pending — additional pending runs cancel the previous one. With `max`, up to 100 runs can be pending and are processed in FIFO order. The combination of `queue: max` and `cancel-in-progress: true` is not allowed.",
+          "type": "string",
+          "enum": ["single", "max"],
+          "default": "single"
         }
       },
       "required": ["group"],
@@ -477,7 +484,7 @@
         },
         "concurrency": {
           "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency",
-          "description": "Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. A concurrency group can be any string or expression. The expression can use any context except for the secrets context. \nYou can also specify concurrency at the workflow level. \nWhen a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled. To also cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.",
+          "description": "Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. A concurrency group can be any string or expression. The expression can use any context except for the secrets context. \nYou can also specify concurrency at the workflow level. \nWhen a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. By default any previously pending job or workflow in the concurrency group will be canceled; this behavior can be changed with `queue`. To also cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.",
           "oneOf": [{ "type": "string" }, { "$ref": "#/definitions/concurrency" }]
         }
       },
@@ -601,7 +608,7 @@
         },
         "concurrency": {
           "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency",
-          "description": "Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. A concurrency group can be any string or expression. The expression can use any context except for the secrets context. \nYou can also specify concurrency at the workflow level. \nWhen a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled. To also cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.",
+          "description": "Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. A concurrency group can be any string or expression. The expression can use any context except for the secrets context. \nYou can also specify concurrency at the workflow level. \nWhen a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. By default any previously pending job or workflow in the concurrency group will be canceled; this behavior can be changed with `queue`. To also cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.",
           "oneOf": [{ "type": "string" }, { "$ref": "#/definitions/concurrency" }]
         }
       },
@@ -1314,7 +1321,7 @@
     },
     "concurrency": {
       "$comment": "https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency",
-      "description": "Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. A concurrency group can be any string or expression. The expression can use any context except for the secrets context. \nYou can also specify concurrency at the workflow level. \nWhen a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled. To also cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.",
+      "description": "Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. A concurrency group can be any string or expression. The expression can use any context except for the secrets context. \nYou can also specify concurrency at the workflow level. \nWhen a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. By default any previously pending job or workflow in the concurrency group will be canceled; this behavior can be changed with `queue`. To also cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true.",
       "oneOf": [{ "type": "string" }, { "$ref": "#/definitions/concurrency" }]
     },
     "jobs": {


### PR DESCRIPTION
| 🚥 Resolves CX-2743 |
| :------------------- |

## 🧰 Changes

When you upload a new OpenAPI definition with `openapi upload` and don't supply the `--slug` or `--legacy-id` flags we create an inferred slug for the filename based on its path; this results in cases like `~/Desktop/petstore.json` getting created as `desktoppetstore.json`. Now normally this isn't a problem because we don't show these slugs to end-users but if you happen to move `~/Desktop/petstore.json` to `~/code/application/petstore.json` then the next time you invoke `openapi upload` we'll end up creating `codeapplicationpetstore.json` instead of overwriting `desktoppetstore.json`.

What this does is add a new step into the upload process so that  whenever we end up in a situation where we' re going to slugify a nested directory path like `~/Desktop/petstore.json` we confirm with the user that that's the slug they want. It looks something like this:

```
$ ./bin/dev.js openapi upload --key=MY_API_KEY ~/Desktop/petstore.json
Warning: This OpenAPI file is located in a subfolder and no `--slug` was provided.

You are uploading:
  /Users/erunion/Desktop/petstore2.json

In rdme v10, the file path is flattened and used to infer a slug:
  /Users/erunion/Desktop/petstore2.json  →  UserserunionDesktoppetstore2.json

If you intend to update an existing definition, this often creates a new API definition instead of updating an existing one.

We recommend you cancel and rerun with:
  rdme openapi upload /Users/erunion/Desktop/petstore2.json --slug=petstore2.json

To suppress this warning and confirmation in the future, use `--confirm-overwrite`.
✖ Continue anyway? › (y/N)
```

Additionally as part of this I have also added in some improved error handling for when we encounter a case where an API definition fails to upload we'll now tell the user what happened, possibly with some OpenAPI validation errors, instead of a general "Your API definition upload failed with an unexpected error." crash.
