### PR TITLE
feat: creation of a new `export` command for rdme-compatible files

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,13 +187,13 @@ npm run build && npm run build:docs
 * [`rdme autocomplete`](documentation/commands/autocomplete.md) - Display autocomplete installation instructions.
 * [`rdme changelog`](documentation/commands/changelog.md) - Upload Markdown files to the Changelog section of your ReadMe project.
 * [`rdme custompages`](documentation/commands/custompages.md) - Upload Markdown or HTML files to the Custom Pages section of your ReadMe project.
-* [`rdme docs`](documentation/commands/docs.md) - Upload Markdown files to the Guides section of your ReadMe project.
+* [`rdme docs`](documentation/commands/docs.md) - Upload or export Guides in your ReadMe project.
 * [`rdme help`](documentation/commands/help.md) - Display help for rdme.
 * [`rdme login`](documentation/commands/login.md) - Login to a ReadMe project.
 * [`rdme logout`](documentation/commands/logout.md) - Logs the currently authenticated user out of ReadMe.
 * [`rdme openapi`](documentation/commands/openapi.md) - Manage your API definition (e.g., syncing, validation, analysis, conversion, etc.). Supports OpenAPI, Swagger, and Postman collections, in either JSON or YAML formats.
 * [`rdme plugins`](documentation/commands/plugins.md) - List installed plugins.
-* [`rdme reference`](documentation/commands/reference.md) - Upload Markdown files to the Reference section of your ReadMe project.
+* [`rdme reference`](documentation/commands/reference.md) - Upload or export API Reference pages in your ReadMe project.
 * [`rdme whoami`](documentation/commands/whoami.md) - Displays the current user and project authenticated with ReadMe.
 
 <!-- commandsstop -->

--- a/documentation/commands/docs.md
+++ b/documentation/commands/docs.md
@@ -1,7 +1,7 @@
 `rdme docs`
 ===========
 
-Upload Markdown files to the Guides section of your ReadMe project.
+Upload or export Guides in your ReadMe project.
 
 * [`rdme docs upload PATH`](#rdme-docs-upload-path)
 

--- a/documentation/commands/docs.md
+++ b/documentation/commands/docs.md
@@ -3,7 +3,54 @@
 
 Upload or export Guides in your ReadMe project.
 
+* [`rdme docs export FOLDER`](#rdme-docs-export-folder)
 * [`rdme docs upload PATH`](#rdme-docs-upload-path)
+
+## `rdme docs export FOLDER`
+
+Export Guides from your ReadMe project to local Markdown files.
+
+```
+USAGE
+  $ rdme docs export FOLDER --key <value> [--branch <value>] [--docs-only]
+
+ARGUMENTS
+  FOLDER  Directory to write exported Markdown into.
+
+FLAGS
+  --key=<value>     (required) ReadMe project API key
+  --branch=<value>  [default: stable] ReadMe project version
+  --docs-only       Skip pages with an empty body unless the page type is `link`.
+
+DESCRIPTION
+  Export Guides from your ReadMe project to local Markdown files.
+
+  Downloads Guides from your ReadMe project API for the given branch and writes them to a directory to be later uploaded
+  with `rdme docs upload`.
+
+EXAMPLES
+  Export guides from the stable branch into `./guides`:
+
+    $ rdme docs export ./guides
+
+  Export guides from a specific project version:
+
+    $ rdme docs export ./guides --branch=1.0
+
+  Export a specific version, omitting empty guide pages:
+
+    $ rdme docs export ./guides --branch=1.0 --docs-only
+
+FLAG DESCRIPTIONS
+  --key=<value>  ReadMe project API key
+
+    An API key for your ReadMe project. Note that API authentication is required despite being omitted from the example
+    usage. See our docs for more information: https://github.com/readmeio/rdme/tree/v10#authentication
+
+  --branch=<value>  ReadMe project version
+
+    Defaults to `stable` (i.e., your main project version).
+```
 
 ## `rdme docs upload PATH`
 

--- a/documentation/commands/reference.md
+++ b/documentation/commands/reference.md
@@ -3,7 +3,54 @@
 
 Upload or export API Reference pages in your ReadMe project.
 
+* [`rdme reference export FOLDER`](#rdme-reference-export-folder)
 * [`rdme reference upload PATH`](#rdme-reference-upload-path)
+
+## `rdme reference export FOLDER`
+
+Export API References from your ReadMe project to local Markdown files.
+
+```
+USAGE
+  $ rdme reference export FOLDER --key <value> [--branch <value>] [--docs-only]
+
+ARGUMENTS
+  FOLDER  Directory to write exported Markdown into.
+
+FLAGS
+  --key=<value>     (required) ReadMe project API key
+  --branch=<value>  [default: stable] ReadMe project version
+  --docs-only       Skip pages with an empty body unless the page type is `link`.
+
+DESCRIPTION
+  Export API References from your ReadMe project to local Markdown files.
+
+  Downloads API References from your ReadMe project API for the given branch and writes them to a directory to be later
+  uploaded with `rdme reference upload`.
+
+EXAMPLES
+  Export API references from the stable branch into `./reference`:
+
+    $ rdme reference export ./reference
+
+  Export API references from a specific project version:
+
+    $ rdme reference export ./reference --branch=1.0
+
+  Export a specific version, omitting empty reference pages:
+
+    $ rdme reference export ./reference --branch=1.0 --docs-only
+
+FLAG DESCRIPTIONS
+  --key=<value>  ReadMe project API key
+
+    An API key for your ReadMe project. Note that API authentication is required despite being omitted from the example
+    usage. See our docs for more information: https://github.com/readmeio/rdme/tree/v10#authentication
+
+  --branch=<value>  ReadMe project version
+
+    Defaults to `stable` (i.e., your main project version).
+```
 
 ## `rdme reference upload PATH`
 

--- a/documentation/commands/reference.md
+++ b/documentation/commands/reference.md
@@ -1,7 +1,7 @@
 `rdme reference`
 ================
 
-Upload Markdown files to the Reference section of your ReadMe project.
+Upload or export API Reference pages in your ReadMe project.
 
 * [`rdme reference upload PATH`](#rdme-reference-upload-path)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "oas-normalize": "^16.0.4",
         "ora": "^9.4.0",
         "prompts": "^2.4.2",
+        "remove-undefined-objects": "^8.0.1",
         "semver": "^7.8.0",
         "simple-git": "^3.36.0",
         "slugify": "^1.6.9",
@@ -12333,6 +12334,15 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
+    "node_modules/oas/node_modules/remove-undefined-objects": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-7.0.0.tgz",
+      "integrity": "sha512-+9ycqqqpv6EdaOvHpyOkf81SXJ4MjARKX450Je6AmshEYeqAuiVcfbLx1coNICO3KulleXlOHd0GSHFkEdB3YQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/object-treeify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-4.0.1.tgz",
@@ -13053,12 +13063,12 @@
       }
     },
     "node_modules/remove-undefined-objects": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-7.0.0.tgz",
-      "integrity": "sha512-+9ycqqqpv6EdaOvHpyOkf81SXJ4MjARKX450Je6AmshEYeqAuiVcfbLx1coNICO3KulleXlOHd0GSHFkEdB3YQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-8.0.1.tgz",
+      "integrity": "sha512-Ucc4yJObLizuEbZtrdZHLvyqMA0FrE4gbC66bnkXLQF4jSAsZoTjlpz+IpKmAG9B4KrlEV8db2UEjYc4P1xpcQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "oas-normalize": "^16.0.4",
     "ora": "^9.4.0",
     "prompts": "^2.4.2",
+    "remove-undefined-objects": "^8.0.1",
     "semver": "^7.8.0",
     "simple-git": "^3.36.0",
     "slugify": "^1.6.9",
@@ -176,8 +177,20 @@
     "scope": "readme",
     "topicSeparator": " ",
     "topics": {
+      "changelog": {
+        "description": "Upload or export Changelogs in your ReadMe project."
+      },
+      "custompages": {
+        "description": "Upload or export Custom Pages in your ReadMe project."
+      },
+      "docs": {
+        "description": "Upload or export Guides in your ReadMe project."
+      },
       "openapi": {
         "description": "Manage your API definition (e.g., syncing, validation, analysis, conversion, etc.). Supports OpenAPI, Swagger, and Postman collections, in either JSON or YAML formats."
+      },
+      "reference": {
+        "description": "Upload or export API Reference pages in your ReadMe project."
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -177,12 +177,6 @@
     "scope": "readme",
     "topicSeparator": " ",
     "topics": {
-      "changelog": {
-        "description": "Upload or export Changelogs in your ReadMe project."
-      },
-      "custompages": {
-        "description": "Upload or export Custom Pages in your ReadMe project."
-      },
       "docs": {
         "description": "Upload or export Guides in your ReadMe project."
       },

--- a/src/commands/docs/export.ts
+++ b/src/commands/docs/export.ts
@@ -1,0 +1,27 @@
+import type { FullExportResults } from '../../lib/exportDocs.js';
+
+import BaseCommand from '../../lib/baseCommand.js';
+import { args, summary, description, examples, flags } from '../../lib/exportCommandProperties.js';
+import { exportDocs } from '../../lib/exportDocs.js';
+
+export default class DocsExportCommand extends BaseCommand<typeof DocsExportCommand> {
+  id = 'docs export' as const;
+
+  route = 'guides' as const;
+
+  static section = 'Guides' as const;
+
+  static summary = summary(this.section);
+
+  static description = description(this.section, 'docs');
+
+  static args = args(this.section);
+
+  static flags = flags(this.section);
+
+  static examples = examples(this.section);
+
+  async run(): Promise<FullExportResults> {
+    return exportDocs.call(this);
+  }
+}

--- a/src/commands/reference/export.ts
+++ b/src/commands/reference/export.ts
@@ -1,0 +1,27 @@
+import type { FullExportResults } from '../../lib/exportDocs.js';
+
+import BaseCommand from '../../lib/baseCommand.js';
+import { args, summary, description, examples, flags } from '../../lib/exportCommandProperties.js';
+import { exportDocs } from '../../lib/exportDocs.js';
+
+export default class ReferenceExportCommand extends BaseCommand<typeof ReferenceExportCommand> {
+  id = 'reference export' as const;
+
+  route = 'reference' as const;
+
+  static section = 'Reference' as const;
+
+  static summary = summary(this.section);
+
+  static description = description(this.section, 'reference');
+
+  static args = args(this.section);
+
+  static flags = flags(this.section);
+
+  static examples = examples(this.section);
+
+  async run(): Promise<FullExportResults> {
+    return exportDocs.call(this);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import ChangelogUploadCommand from './commands/changelog/upload.js';
 import ChangelogsCommand from './commands/changelogs.js';
 import CustomPagesUploadCommand from './commands/custompages/upload.js';
+import DocsExportCommand from './commands/docs/export.js';
 import DocsMigrateCommand from './commands/docs/migrate.js';
 import DocsUploadCommand from './commands/docs/upload.js';
 import LoginCommand from './commands/login.js';
@@ -12,6 +13,7 @@ import OpenAPIResolveCommand from './commands/openapi/resolve.js';
 import OpenAPIUploadCommand from './commands/openapi/upload.js';
 import OpenAPIValidateCommand from './commands/openapi/validate.js';
 import RageCommand from './commands/rage.js';
+import ReferenceExportCommand from './commands/reference/export.js';
 import RefUploadCommand from './commands/reference/upload.js';
 import WhoAmICommand from './commands/whoami.js';
 
@@ -38,6 +40,7 @@ export const COMMANDS = {
 
   'custompages:upload': CustomPagesUploadCommand,
 
+  'docs:export': DocsExportCommand,
   'docs:migrate': DocsMigrateCommand,
   'docs:upload': DocsUploadCommand,
 
@@ -53,6 +56,7 @@ export const COMMANDS = {
 
   rage: RageCommand,
 
+  'reference:export': ReferenceExportCommand,
   'reference:upload': RefUploadCommand,
 
   whoami: WhoAmICommand,
@@ -85,6 +89,13 @@ export type APIv2PageUploadCommands =
   | CustomPagesUploadCommand
   | DocsUploadCommand
   | RefUploadCommand;
+
+/**
+ * Commands that leverage the APIv2 representations for exporting pages (e.g., Guides, API
+ * Reference, etc.).
+ *
+ */
+export type APIv2PageExportCommands = DocsExportCommand | ReferenceExportCommand;
 
 /**
  * Commands that leverage the APIv2 representations for interfacing with pages

--- a/src/lib/exportCommandProperties.ts
+++ b/src/lib/exportCommandProperties.ts
@@ -1,0 +1,84 @@
+import { Args, Flags } from '@oclif/core';
+
+import { branchFlag, keyFlag } from './flags.js';
+
+type Section = 'Changelog' | 'Custom Pages' | 'Guides' | 'Reference';
+type Command = 'docs' | 'reference' | 'changelog' | 'custompages';
+
+function pluralizeSection(section: Section): string {
+  switch (section) {
+    case 'Reference':
+      return 'API References';
+    case 'Custom Pages':
+      return 'Custom Pages';
+    case 'Guides':
+      return 'Guides';
+    case 'Changelog':
+      return 'Changelogs';
+    default:
+      throw new TypeError(`Unknown section: ${section}`);
+  }
+}
+
+export function summary(section: Section): string {
+  const fileType = section === 'Custom Pages' ? 'Markdown or HTML' : 'Markdown';
+  const sectionIdentifier = pluralizeSection(section);
+
+  return `Export ${sectionIdentifier} from your ReadMe project to local ${fileType} files.`;
+}
+
+export function description(section: Section, command: Command): string {
+  const sectionIdentifier = pluralizeSection(section);
+
+  return `Downloads ${sectionIdentifier} from your ReadMe project API for the given branch and writes them to a directory to be later uploaded with \`<%= config.bin %> ${command} upload\`.`;
+}
+
+export function args(section: Section) {
+  const fileType = section === 'Custom Pages' ? 'Markdown/HTML' : 'Markdown';
+
+  return {
+    folder: Args.string({
+      description: `Directory to write exported ${fileType} into.`,
+      required: true,
+    }),
+  };
+}
+
+export function examples(section: Section) {
+  const directory = section === 'Custom Pages' ? 'custompages' : section.toLowerCase();
+  const usesBranch = section !== 'Changelog';
+  const docsOnly = section === 'Guides' || section === 'Reference';
+
+  let sectionIdentifier = pluralizeSection(section);
+  sectionIdentifier = sectionIdentifier === 'API References' ? 'API references' : section.toLowerCase();
+
+  return [
+    {
+      description: `Export ${sectionIdentifier} from the stable branch into \`./${directory}\`:`,
+      command: `<%= config.bin %> <%= command.id %> ./${directory}`,
+    },
+    usesBranch && {
+      description: `Export ${sectionIdentifier} from a specific project version:`,
+      command: `<%= config.bin %> <%= command.id %> ./${directory} --branch=1.0`,
+    },
+    docsOnly && {
+      description: `Export a specific version, omitting empty ${section === 'Guides' ? 'guide' : 'reference'} pages:`,
+      command: `<%= config.bin %> <%= command.id %> ./${directory} --branch=1.0 --docs-only`,
+    },
+  ].filter((ex): ex is { description: string; command: string } => ex !== undefined);
+}
+
+export function flags(section: Section) {
+  return {
+    key: keyFlag,
+    ...branchFlag(),
+    ...(section === 'Guides' || section === 'Reference'
+      ? {
+          'docs-only': Flags.boolean({
+            default: false,
+            description: 'Skip pages with an empty body unless the page type is `link`.',
+          }),
+        }
+      : {}),
+  };
+}

--- a/src/lib/exportDocs.ts
+++ b/src/lib/exportDocs.ts
@@ -236,7 +236,7 @@ function restructureFiles(this: APIv2PageExportCommands, tempFolder: string, fin
   }
 
   restructureSpinner.suffixText = '';
-  restructureSpinner.succeed(`${restructureSpinner.text}done!`);
+  restructureSpinner.succeed(`${restructureSpinner.text} done!`);
   this.debug(`Files moved: ${finalFolder}`);
 
   fs.rmSync(tempFolder, { recursive: true, force: true });

--- a/src/lib/exportDocs.ts
+++ b/src/lib/exportDocs.ts
@@ -1,0 +1,367 @@
+import type { APIv2PageExportCommands } from '../index.js';
+import type { PageRequestSchema } from '../types.js';
+import type { CategoryPagesResponseSchema, CategoryResponseSchema, PageResponseSchema } from './types/index.js';
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { dump as dumpYAML } from 'js-yaml';
+import ora from 'ora';
+import removeUndefinedObjects from 'remove-undefined-objects';
+
+import { isRecord } from '../utils.js';
+
+import { parse as parseFrontmatter } from './frontmatter.js';
+import { oraOptions } from './logger.js';
+
+type ChangelogsRequestSchema = PageRequestSchema<'changelogs'>;
+type CustomPagesRequestSchema = PageRequestSchema<'custom_pages'>;
+type GuidesOrReferenceRequestSchema = PageRequestSchema<'guides' | 'reference'>;
+type GeneralRequestSchema = ChangelogsRequestSchema | CustomPagesRequestSchema | GuidesOrReferenceRequestSchema;
+
+type GuidesOrReferenceResponseSchema = PageResponseSchema<'guides' | 'reference'>;
+
+function isGuideOrReferenceRequest(
+  route: string,
+  // oxlint-disable-next-line no-unused-vars
+  data: ChangelogsRequestSchema | CustomPagesRequestSchema | GuidesOrReferenceRequestSchema,
+): data is GuidesOrReferenceRequestSchema {
+  return route === 'guides' || route === 'reference';
+}
+
+export interface FullExportResults {
+  completed: GeneralRequestSchema[];
+  failed: string[];
+  skipped: number;
+}
+
+interface FileMapEntry {
+  category: string | undefined;
+  filePath: string;
+  parent: string | undefined;
+  slug: string;
+  title: unknown;
+}
+
+/**
+ * Scrub out unnecessary data from the API and simplify fields.
+ *
+ */
+function scrub(data: GeneralRequestSchema): Record<string, unknown> | undefined {
+  const denylist = new Set(['api', 'href', 'links', 'project', 'renderable', 'updated_at', 'uri']);
+
+  /** API defaults (to ensure we omit these when they're unchanged) */
+  const DEFAULTS = {
+    allow_crawlers: 'enabled',
+    state: 'current',
+    type: 'basic',
+  } as const;
+
+  const scrubbed: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(data)) {
+    if (denylist.has(key)) {
+      // no-op
+    } else if (key === 'content' && typeof value === 'object' && value !== null) {
+      const {
+        body: _body,
+        link,
+        ...rest
+      } = value as Record<string, unknown> & {
+        body?: unknown;
+        link?: unknown;
+      };
+
+      const filtered = { ...rest };
+      if ('type' in data && data.type === 'link' && link) {
+        filtered.link = link;
+      }
+
+      scrubbed[key] = filtered;
+    } else if (key === 'category' && isRecord(value) && typeof value.uri === 'string') {
+      const name = decodeURIComponent(value.uri.split('/').pop() || '');
+      scrubbed[key] = { uri: name };
+    } else if (key === 'parent' && isRecord(value) && typeof value.uri === 'string') {
+      const slugPart = decodeURIComponent(value.uri.split('/').pop() || '');
+      scrubbed[key] = { uri: slugPart };
+    } else if (!(key in DEFAULTS && value === DEFAULTS[key as keyof typeof DEFAULTS])) {
+      scrubbed[key] = value;
+    }
+  }
+
+  return removeUndefinedObjects(scrubbed, { removeAllFalsy: true });
+}
+
+function findMarkdownFiles(dir: string): string[] {
+  const files: string[] = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...findMarkdownFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function buildFileMap(this: APIv2PageExportCommands, files: string[]): Map<string, FileMapEntry> {
+  const fileMap = new Map<string, FileMapEntry>();
+
+  for (const filePath of files) {
+    const frontmatter = parseFrontmatter.call(this, filePath);
+    if (frontmatter) {
+      const slug = frontmatter.slug;
+      if (typeof slug === 'string' && slug) {
+        const categoryUri =
+          isRecord(frontmatter.category) && typeof frontmatter.category.uri === 'string'
+            ? frontmatter.category.uri
+            : undefined;
+        const parentUri =
+          isRecord(frontmatter.parent) && typeof frontmatter.parent.uri === 'string'
+            ? frontmatter.parent.uri
+            : undefined;
+
+        fileMap.set(slug, {
+          category: categoryUri,
+          filePath,
+          parent: parentUri,
+          slug,
+          title: frontmatter.title,
+        });
+      } else {
+        this.warn(`No slug found in ${filePath}`);
+      }
+    }
+  }
+
+  return fileMap;
+}
+
+function buildPath(
+  this: APIv2PageExportCommands,
+  slug: string,
+  fileMap: Map<string, FileMapEntry>,
+  visited: Set<string> = new Set(),
+): string | null {
+  if (visited.has(slug)) {
+    this.error(`Circular reference detected for slug: ${slug}`);
+  }
+  visited.add(slug);
+
+  const fileInfo = fileMap.get(slug);
+  if (!fileInfo) {
+    this.error(`File not found for slug: ${slug}`);
+    return null;
+  }
+
+  const parts: string[] = [];
+
+  if (fileInfo.category) parts.push(fileInfo.category);
+
+  if (fileInfo.parent) {
+    const parentPath = buildPath.call(this, fileInfo.parent, fileMap, visited);
+    if (parentPath) {
+      const segments = parentPath.split('/');
+      for (let i = 1; i < segments.length; i += 1) {
+        if (!parts.includes(segments[i])) {
+          parts.push(segments[i]);
+        }
+      }
+    }
+  }
+
+  parts.push(slug);
+  return parts.join('/');
+}
+
+function restructureFiles(this: APIv2PageExportCommands, tempFolder: string, finalFolder: string): void {
+  const restructureSpinner = ora({ ...oraOptions() }).start('🗃️  Restructuring files...');
+
+  const files = findMarkdownFiles(tempFolder);
+  this.debug(`Found ${files.length} markdown files`);
+
+  const fileMap = buildFileMap.call(this, files);
+  this.debug(`Parsed ${fileMap.size} files with valid frontmatter`);
+
+  const results: { slug: string; oldPath: string; newPath: string; title: unknown }[] = [];
+  for (const [slug] of fileMap) {
+    const newPathBuilt = buildPath.call(this, slug, fileMap);
+    if (newPathBuilt) {
+      const info = fileMap.get(slug)!;
+      results.push({
+        slug,
+        oldPath: info.filePath,
+        newPath: `${newPathBuilt}.md`,
+        title: info.title,
+      });
+    }
+  }
+
+  const hasChildren = new Set<string>();
+  for (const info of fileMap.values()) {
+    if (info.parent) hasChildren.add(info.parent);
+  }
+
+  for (const r of results) {
+    if (hasChildren.has(r.slug)) {
+      r.newPath = r.newPath.replace(/\.md$/, '/index.md');
+    }
+  }
+
+  results.sort((a, b) => a.newPath.localeCompare(b.newPath));
+
+  fs.mkdirSync(finalFolder, { recursive: true });
+
+  this.debug('Copying files to final structure:');
+
+  for (const r of results) {
+    const dest = path.join(finalFolder, r.newPath);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(r.oldPath, dest);
+  }
+
+  restructureSpinner.suffixText = '';
+  restructureSpinner.succeed(`${restructureSpinner.text} done!`);
+  this.debug(`Files moved: ${finalFolder}`);
+
+  fs.rmSync(tempFolder, { recursive: true, force: true });
+  this.debug(`Cleaned up temporary folder: ${tempFolder}`);
+}
+
+export async function exportDocs(this: APIv2PageExportCommands): Promise<FullExportResults> {
+  const outputDir = path.resolve(this.args.folder);
+  const tempFolder = path.join(outputDir, '.temp_download');
+
+  const { branch } = this.flags;
+  const docsOnly = this.route !== 'guides';
+
+  const key = this.flags.key;
+  const headers = new Headers({ authorization: `Bearer ${key}`, 'Content-Type': 'application/json' });
+
+  try {
+    const spinner = ora({ ...oraOptions() }).start('📩 Exporting files from ReadMe...');
+    const downloads: FullExportResults = {
+      completed: [],
+      failed: [],
+      skipped: 0,
+    };
+
+    this.debug(`Exporting pages from \`${branch}\` to ${tempFolder}`);
+
+    fs.mkdirSync(tempFolder, { recursive: true });
+
+    const categories = await this.readmeAPIFetch(`/branches/${encodeURIComponent(branch)}/categories/${this.route}`, {
+      method: 'GET',
+      headers,
+    })
+      .then(res => this.handleAPIRes<CategoryResponseSchema>(res))
+      .then(res => res?.data || []);
+
+    // oxlint-disable no-await-in-loop -- Sequential fetches per original script behavior.
+    for (const cat of categories) {
+      this.debug(`Obtaining the pages for category: ${cat.title}`);
+
+      const pages = await this.readmeAPIFetch(
+        `/branches/${encodeURIComponent(branch)}/categories/${this.route}/${encodeURIComponent(cat.title)}/pages`,
+        {
+          method: 'GET',
+          headers,
+        },
+      )
+        .then(res => this.handleAPIRes<CategoryPagesResponseSchema>(res))
+        .then(res => res?.data || []);
+
+      if (!pages.length) {
+        this.warn(`No pages found within the "${cat.title}" category. Skipping.`);
+      } else {
+        const parentCounts: Record<string, number> = {};
+        for (const page of pages) {
+          try {
+            const isReference = this.route === 'reference';
+            const pagePath = isReference
+              ? `/branches/${encodeURIComponent(branch)}/reference/${encodeURIComponent(page.slug)}`
+              : `/branches/${encodeURIComponent(branch)}/guides/${encodeURIComponent(page.slug)}`;
+
+            // const pageResult = await fetchJSON.call(this, pagePath);
+            const data = await this.readmeAPIFetch(pagePath, {
+              method: 'GET',
+              headers,
+            })
+              .then(res => this.handleAPIRes<GuidesOrReferenceResponseSchema>(res))
+              .then(res => res.data)
+              .catch(() => {
+                this.warn(`Failed to fetch page "${page.slug}". Skipping.`);
+                downloads.failed.push(page.slug);
+              });
+
+            if (data) {
+              const output = structuredClone<GeneralRequestSchema>(data);
+              const body = output.content?.body || '';
+              const skipForDocsOnly =
+                isGuideOrReferenceRequest(this.route, output) && docsOnly && !body.trim() && output.type !== 'link';
+
+              if (skipForDocsOnly) {
+                this.debug(`Skipping empty ${output.type} page because it is not a link: ${output.slug}`);
+                downloads.skipped += 1;
+              } else {
+                if (isGuideOrReferenceRequest(this.route, output)) {
+                  const parentKey =
+                    isRecord(output.parent) && typeof output.parent.uri === 'string' ? output.parent.uri : 'root';
+                  if (parentCounts[parentKey] === undefined) {
+                    parentCounts[parentKey] = 0;
+                  }
+
+                  output.position = parentCounts[parentKey];
+                  parentCounts[parentKey] += 1;
+                }
+
+                const frontmatter = scrub(output);
+                const yamlFront = dumpYAML(frontmatter, { sortKeys: true });
+                const md = `---\n${yamlFront}---\n${body}`;
+
+                fs.writeFileSync(path.join(tempFolder, `${output.slug}.md`), md, 'utf8');
+                downloads.completed.push(output);
+              }
+            }
+          } finally {
+            spinner.suffixText = `(${downloads.completed.length} succeeded, ${downloads.failed.length} failed, ${downloads.skipped} skipped)`;
+          }
+        }
+      }
+    }
+    // oxlint-enable no-await-in-loop
+
+    spinner.suffixText = '';
+
+    if (downloads.failed.length) {
+      spinner.fail(`${spinner.text} ${downloads.failed.length} file(s) failed.`);
+    } else {
+      spinner.succeed(`${spinner.text} done!`);
+    }
+
+    if (downloads.failed.length) {
+      this.log('');
+      this.log(`🚨 Received errors when attempting to download ${downloads.failed.length} page(s):`);
+      downloads.failed.forEach(slug => {
+        this.log(`   - ${slug}`);
+      });
+    } else {
+      restructureFiles.call(this, tempFolder, outputDir);
+
+      this.log('');
+      this.log(`All files have been saved to: ${outputDir}`);
+    }
+
+    return downloads;
+  } catch (err) {
+    if (fs.existsSync(tempFolder)) {
+      fs.rmSync(tempFolder, { recursive: true, force: true });
+    }
+
+    throw err;
+  }
+}

--- a/src/lib/exportDocs.ts
+++ b/src/lib/exportDocs.ts
@@ -112,7 +112,18 @@ function buildFileMap(this: APIv2PageExportCommands, files: string[]): Map<strin
   const fileMap = new Map<string, FileMapEntry>();
 
   for (const filePath of files) {
-    const frontmatter = parseFrontmatter.call(this, filePath);
+    let frontmatter: Record<string, unknown> | null = null;
+    try {
+      const content = fs.readFileSync(filePath, 'utf8');
+      frontmatter = parseFrontmatter(content);
+      if (frontmatter === null) {
+        this.warn(`no frontmatter found in ${filePath}`);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.error(`Error parsing frontmatter in ${filePath}: ${message}`);
+    }
+
     if (frontmatter) {
       const slug = frontmatter.slug;
       if (typeof slug === 'string' && slug) {
@@ -225,7 +236,7 @@ function restructureFiles(this: APIv2PageExportCommands, tempFolder: string, fin
   }
 
   restructureSpinner.suffixText = '';
-  restructureSpinner.succeed(`${restructureSpinner.text} done!`);
+  restructureSpinner.succeed(`${restructureSpinner.text}done!`);
   this.debug(`Files moved: ${finalFolder}`);
 
   fs.rmSync(tempFolder, { recursive: true, force: true });
@@ -286,7 +297,6 @@ export async function exportDocs(this: APIv2PageExportCommands): Promise<FullExp
               ? `/branches/${encodeURIComponent(branch)}/reference/${encodeURIComponent(page.slug)}`
               : `/branches/${encodeURIComponent(branch)}/guides/${encodeURIComponent(page.slug)}`;
 
-            // const pageResult = await fetchJSON.call(this, pagePath);
             const data = await this.readmeAPIFetch(pagePath, {
               method: 'GET',
               headers,
@@ -323,7 +333,7 @@ export async function exportDocs(this: APIv2PageExportCommands): Promise<FullExp
                 const yamlFront = dumpYAML(frontmatter, { sortKeys: true });
                 const md = `---\n${yamlFront}---\n${body}`;
 
-                fs.writeFileSync(path.join(tempFolder, `${output.slug}.md`), md, 'utf8');
+                fs.writeFileSync(path.join(tempFolder, `${output.slug}.md`), md, { encoding: 'utf-8' });
                 downloads.completed.push(output);
               }
             }

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -1,4 +1,5 @@
 import type { APIv2PageCommands } from '../index.js';
+import type { BaseCommand } from '../utils.js';
 import type { Mappings } from './readmeAPIFetch.js';
 import type { PageMetadata } from './readPage.js';
 import type { ErrorObject } from 'ajv';
@@ -10,9 +11,33 @@ import path from 'node:path';
 import { Ajv } from 'ajv';
 import _addFormats from 'ajv-formats';
 import grayMatter from 'gray-matter';
+import { load as loadYAML } from 'js-yaml';
+
+import { isRecord } from '../utils.js';
 
 // workaround from here: https://github.com/ajv-validator/ajv-formats/issues/85#issuecomment-2262652443
 const addFormats = _addFormats as unknown as typeof _addFormats.default;
+
+/**
+ * Parse and extract the frontmatter from a Markdown file.
+ *
+ */
+export function parse(this: BaseCommand<any>, filePath: string) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) {
+    this.warn(`no frontmatter found in ${filePath}`);
+    return null;
+  }
+
+  try {
+    const loaded = loadYAML(match[1]);
+    return isRecord(loaded) ? loaded : null;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    this.error(`Error parsing frontmatter in ${filePath}: ${message}`);
+  }
+}
 
 /**
  * Validates the frontmatter data, fixes any issues, and returns the results.

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -1,5 +1,4 @@
 import type { APIv2PageCommands } from '../index.js';
-import type { BaseCommand } from '../utils.js';
 import type { Mappings } from './readmeAPIFetch.js';
 import type { PageMetadata } from './readPage.js';
 import type { ErrorObject } from 'ajv';
@@ -22,21 +21,14 @@ const addFormats = _addFormats as unknown as typeof _addFormats.default;
  * Parse and extract the frontmatter from a Markdown file.
  *
  */
-export function parse(this: BaseCommand<any>, filePath: string) {
-  const content = fs.readFileSync(filePath, 'utf8');
+export function parse(content: string) {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) {
-    this.warn(`no frontmatter found in ${filePath}`);
     return null;
   }
 
-  try {
-    const loaded = loadYAML(match[1]);
-    return isRecord(loaded) ? loaded : null;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    this.error(`Error parsing frontmatter in ${filePath}: ${message}`);
-  }
+  const loaded = loadYAML(match[1]);
+  return isRecord(loaded) ? loaded : null;
 }
 
 /**

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -41,6 +41,13 @@ type PageResponseSchemaRaw<T extends PageRoute> = T extends 'custom_pages' | 'gu
     ? (typeof readmeAPIv2Oas)['paths']['/changelogs/{identifier}']['patch']['responses']['200']['content']['application/json']['schema']
     : never;
 
+/** Category schemas */
+type CategoryResponseSchemaRaw =
+  (typeof readmeAPIv2Oas)['paths']['/branches/{branch}/categories/{section}']['get']['responses']['200']['content']['application/json']['schema'];
+
+type CategoryPagesResponseSchemaRaw =
+  (typeof readmeAPIv2Oas)['paths']['/branches/{branch}/categories/{section}/{title}/pages']['get']['responses']['200']['content']['application/json']['schema'];
+
 /**
  * Derived from our API documentation, this is the schema for the `project` object
  * as we receive it from the ReadMe API.
@@ -92,6 +99,19 @@ export type PageRequestSchema<T extends PageRoute> = FromSchema<
  */
 export type PageResponseSchema<T extends PageRoute> = FromSchema<
   PageResponseSchemaRaw<T>,
+  { keepDefaultedPropertiesOptional: true }
+>;
+
+/**
+ * This is the schema for category as we receive them from the ReadMe API.
+ */
+export type CategoryResponseSchema = FromSchema<CategoryResponseSchemaRaw, { keepDefaultedPropertiesOptional: true }>;
+
+/**
+ * This is the schema for the pages within a category as we receive them from the ReadMe API.
+ */
+export type CategoryPagesResponseSchema = FromSchema<
+  CategoryPagesResponseSchemaRaw,
   { keepDefaultedPropertiesOptional: true }
 >;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,3 +5,11 @@ export { BaseCommand };
 
 export { handleAPIv2Res, readmeAPIv2Fetch } from './lib/readmeAPIFetch.js';
 export { readdirRecursive };
+
+/**
+ * Type guard to check that a given value is a record.
+ *
+ */
+export function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}

--- a/test/commands/pages/export.test.ts
+++ b/test/commands/pages/export.test.ts
@@ -1,0 +1,174 @@
+import type { OclifOutput } from '../../helpers/oclif.js';
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import nock from 'nock';
+import { afterEach, beforeEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import DocsExportCommand from '../../../src/commands/docs/export.js';
+import ReferenceExportCommand from '../../../src/commands/reference/export.js';
+import { getAPIv2Mock } from '../../helpers/get-api-mock.js';
+import { runCommand } from '../../helpers/oclif.js';
+
+const key = 'rdme_123';
+const authorization = `Bearer ${key}`;
+
+function tempExportDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'rdme-docs-export-test-'));
+}
+
+describe.each([
+  ['docs', DocsExportCommand, 'guides'],
+  ['reference', ReferenceExportCommand, 'reference'],
+] as const)('rdme %s upload', (topic, Command, route) => {
+  let run: (args?: string[]) => OclifOutput;
+
+  beforeAll(() => {
+    run = runCommand(Command);
+  });
+
+  beforeEach(() => {
+    vi.spyOn(fs, 'copyFileSync');
+    vi.spyOn(fs, 'writeFileSync');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  it('should error when folder arg is missing', async () => {
+    const output = await run(['--key', key]);
+    expect(output.error.message).toMatchInlineSnapshot(`
+      "Missing 1 required arg:
+      folder  Directory to write exported Markdown into.
+      See more help with --help"
+    `);
+  });
+
+  it('should download guides and restructure files', async () => {
+    const tmpDir = tempExportDir();
+    try {
+      const mock = getAPIv2Mock({ authorization })
+        .get(`/branches/stable/categories/${route}`)
+        .reply(200, { data: [{ title: 'Main' }] })
+        .get(`/branches/stable/categories/${route}/Main/pages`)
+        .reply(200, { data: [{ slug: 'intro' }] })
+        .get(`/branches/stable/${route}/intro`)
+        .reply(200, {
+          data: {
+            slug: 'intro',
+            title: 'Introduction',
+            type: 'basic',
+            content: { body: 'Hello world' },
+            category: { uri: `https://api.readme.com/v2/branches/stable/categories/${route}/main` },
+          },
+        });
+
+      await run([tmpDir, '--key', key]);
+
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        path.join(tmpDir, '.temp_download', 'intro.md'),
+        expect.stringContaining(`---
+category:
+  uri: main
+position: 0
+slug: intro
+title: Introduction
+---
+Hello world`),
+        { encoding: 'utf-8' },
+      );
+
+      expect(fs.copyFileSync).toHaveBeenCalledTimes(1);
+      expect(fs.copyFileSync).toHaveBeenCalledWith(
+        path.join(tmpDir, '.temp_download', 'intro.md'),
+        path.join(tmpDir, 'main', 'intro.md'),
+      );
+
+      mock.done();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should use `index.md` for pages that have children', async () => {
+    const tmpDir = tempExportDir();
+    try {
+      const mock = getAPIv2Mock({ authorization })
+        .get(`/branches/stable/categories/${route}`)
+        .reply(200, { data: [{ title: 'Docs' }] })
+        .get(`/branches/stable/categories/${route}/Docs/pages`)
+        .reply(200, { data: [{ slug: 'parent-doc' }, { slug: 'child-doc' }] })
+        .get(`/branches/stable/${route}/parent-doc`)
+        .reply(200, {
+          data: {
+            slug: 'parent-doc',
+            title: 'Parent',
+            type: 'basic',
+            content: { body: 'Parent body' },
+            category: { uri: `https://api.readme.com/v2/branches/stable/categories/${route}/docs` },
+          },
+        })
+        .get(`/branches/stable/${route}/child-doc`)
+        .reply(200, {
+          data: {
+            slug: 'child-doc',
+            title: 'Child',
+            type: 'basic',
+            content: { body: 'Child body' },
+            category: { uri: `https://api.readme.com/v2/branches/stable/categories/${route}/docs` },
+            parent: { uri: `https://api.readme.com/v2/branches/stable/${route}/parent-doc` },
+          },
+        });
+
+      await run([tmpDir, '--key', key]);
+
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        path.join(tmpDir, '.temp_download', 'parent-doc.md'),
+        expect.stringContaining(`---
+category:
+  uri: docs
+position: 0
+slug: parent-doc
+title: Parent
+---
+Parent body`),
+        { encoding: 'utf-8' },
+      );
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        path.join(tmpDir, '.temp_download', 'child-doc.md'),
+        expect.stringContaining(`---
+category:
+  uri: docs
+parent:
+  uri: parent-doc
+position: 0
+slug: child-doc
+title: Child
+---
+Child body`),
+        { encoding: 'utf-8' },
+      );
+
+      expect(fs.copyFileSync).toHaveBeenCalledTimes(2);
+      expect(fs.copyFileSync).toHaveBeenCalledWith(
+        path.join(tmpDir, '.temp_download', 'parent-doc.md'),
+        path.join(tmpDir, 'docs', 'parent-doc', 'index.md'),
+      );
+      expect(fs.copyFileSync).toHaveBeenCalledWith(
+        path.join(tmpDir, '.temp_download', 'child-doc.md'),
+        path.join(tmpDir, 'docs', 'parent-doc', 'child-doc.md'),
+      );
+
+      mock.done();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/lib/frontmatter.test.ts
+++ b/test/lib/frontmatter.test.ts
@@ -17,78 +17,42 @@ import { readPage } from '../../src/lib/readPage.js';
 import { setupOclifConfig } from '../helpers/oclif.js';
 
 describe('#parse', () => {
-  let ctx: APIv2PageCommands;
-
-  beforeEach(() => {
-    ctx = {
-      error: vi.fn(),
-      warn: vi.fn(),
-    } as unknown as APIv2PageCommands;
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('should return parsed frontmatter as a plain object', () => {
-    const filePath = '/tmp/rdme-parse-test.md';
-    vi.spyOn(fs, 'readFileSync').mockReturnValue(
-      `---
+    const content = `---
 slug: intro
 title: Introduction
 ---
-# Body`,
-    );
+# Body`;
 
-    const result = parse.call(ctx, filePath);
-
-    expect(result).toStrictEqual({ slug: 'intro', title: 'Introduction' });
-    expect(ctx.warn).not.toHaveBeenCalled();
-    expect(ctx.error).not.toHaveBeenCalled();
+    expect(parse(content)).toStrictEqual({ slug: 'intro', title: 'Introduction' });
   });
 
   it('should return null and warn when no YAML frontmatter block is found', () => {
-    const filePath = '/tmp/rdme-parse-no-fm.md';
-    vi.spyOn(fs, 'readFileSync').mockReturnValue('# Title only\n\nNo frontmatter here.');
+    const content = '# Title only\n\nNo frontmatter here.';
 
-    const result = parse.call(ctx, filePath);
-
-    expect(result).toBeNull();
-    expect(ctx.warn).toHaveBeenCalledWith(`no frontmatter found in ${filePath}`);
-    expect(ctx.error).not.toHaveBeenCalled();
+    expect(parse(content)).toBeNull();
   });
 
   it('should return null and error when YAML is invalid', () => {
-    const filePath = '/tmp/rdme-parse-bad-yaml.md';
-    vi.spyOn(fs, 'readFileSync').mockReturnValue(
-      `---
+    const content = `---
 slug: [
   bad: yaml
 ---
-`,
-    );
+`;
 
-    const result = parse.call(ctx, filePath);
-
-    expect(result).toBeUndefined();
-    expect(ctx.error).toHaveBeenCalledWith(expect.stringMatching(/^Error parsing frontmatter in .*bad-yaml/));
+    expect(() => {
+      parse(content);
+    }).toThrow(/unexpected end of the stream within a flow collection/);
   });
 
   it('should return null when YAML parses to a non-object root (e.g. array)', () => {
-    const filePath = '/tmp/rdme-parse-array-root.md';
-    vi.spyOn(fs, 'readFileSync').mockReturnValue(
-      `---
+    const content = `---
 - one
 - two
 ---
-`,
-    );
+`;
 
-    const result = parse.call(ctx, filePath);
-
-    expect(result).toBeNull();
-    expect(ctx.warn).not.toHaveBeenCalled();
-    expect(ctx.error).not.toHaveBeenCalled();
+    expect(parse(content)).toBeNull();
   });
 });
 

--- a/test/lib/frontmatter.test.ts
+++ b/test/lib/frontmatter.test.ts
@@ -11,10 +11,86 @@ import CustomPagesUploadCommand from '../../src/commands/custompages/upload.js';
 import DocsMigrateCommand from '../../src/commands/docs/migrate.js';
 import DocsUploadCommand from '../../src/commands/docs/upload.js';
 import RefUploadCommand from '../../src/commands/reference/upload.js';
-import { fix, writeFixes } from '../../src/lib/frontmatter.js';
+import { fix, parse, writeFixes } from '../../src/lib/frontmatter.js';
 import { emptyMappings, fetchSchema } from '../../src/lib/readmeAPIFetch.js';
 import { readPage } from '../../src/lib/readPage.js';
 import { setupOclifConfig } from '../helpers/oclif.js';
+
+describe('#parse', () => {
+  let ctx: APIv2PageCommands;
+
+  beforeEach(() => {
+    ctx = {
+      error: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as APIv2PageCommands;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return parsed frontmatter as a plain object', () => {
+    const filePath = '/tmp/rdme-parse-test.md';
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      `---
+slug: intro
+title: Introduction
+---
+# Body`,
+    );
+
+    const result = parse.call(ctx, filePath);
+
+    expect(result).toStrictEqual({ slug: 'intro', title: 'Introduction' });
+    expect(ctx.warn).not.toHaveBeenCalled();
+    expect(ctx.error).not.toHaveBeenCalled();
+  });
+
+  it('should return null and warn when no YAML frontmatter block is found', () => {
+    const filePath = '/tmp/rdme-parse-no-fm.md';
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('# Title only\n\nNo frontmatter here.');
+
+    const result = parse.call(ctx, filePath);
+
+    expect(result).toBeNull();
+    expect(ctx.warn).toHaveBeenCalledWith(`no frontmatter found in ${filePath}`);
+    expect(ctx.error).not.toHaveBeenCalled();
+  });
+
+  it('should return null and error when YAML is invalid', () => {
+    const filePath = '/tmp/rdme-parse-bad-yaml.md';
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      `---
+slug: [
+  bad: yaml
+---
+`,
+    );
+
+    const result = parse.call(ctx, filePath);
+
+    expect(result).toBeUndefined();
+    expect(ctx.error).toHaveBeenCalledWith(expect.stringMatching(/^Error parsing frontmatter in .*bad-yaml/));
+  });
+
+  it('should return null when YAML parses to a non-object root (e.g. array)', () => {
+    const filePath = '/tmp/rdme-parse-array-root.md';
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      `---
+- one
+- two
+---
+`,
+    );
+
+    const result = parse.call(ctx, filePath);
+
+    expect(result).toBeNull();
+    expect(ctx.warn).not.toHaveBeenCalled();
+    expect(ctx.error).not.toHaveBeenCalled();
+  });
+});
 
 describe.each([
   ['guides upload', DocsUploadCommand],


### PR DESCRIPTION
| 🚥 Resolves CX-2744 |
| :------------------- |

## 🧰 Changes

This creates new `rdme docs export` and `rdme reference export` commands that when used will export rdme-compatible files that you can then re-sync wtih `rdme docs upload` and `rdme reference upload`.

The reason we're creating this new command is that due to the way rdme and our Git bidirectional sync offering works, files in bidi are not directly compatible with rdme because rdme files do not have awareness of where it should live within the clients directory and sidebar structures. This product difference requires files synced with rdme to have their frontmatter heading be ReadMe API payloads -- a difference that has caused a number of issues with customers migrating to ReadMe Refactored.

When invoked, this command will download all guides and reference pages, and if they are not empty, store them in a supplied directory in the same fashion that they may be stored in a bidirectional sync repository.

Huge thanks to @rossrdme for the work he did in writing the original script that powers this work, I just put the rdme sauce on top.

## 🧬 QA & Testing

This is what it looks like:

```
$ ./bin/dev.js docs export --key=API_KEY ./output
✔ 📩 Exporting files from ReadMe... done!
✔ 🗃️  Restructuring files...done!

All files have been saved to: /Users/erunion/code/readme/rdme/output
```

```
$ ls -lah output
total 0
drwxr-xr-x  14 erunion  staff   448B May 15 17:14 .
drwxr-xr-x  36 erunion  staff   1.1K May 15 17:14 ..
drwxr-xr-x  12 erunion  staff   384B May 15 17:14 AI
drwxr-xr-x   7 erunion  staff   224B May 15 17:14 Administration
drwxr-xr-x   6 erunion  staff   192B May 15 17:14 Customizing Docs
drwxr-xr-x   6 erunion  staff   192B May 15 17:14 Developer Experience
drwxr-xr-x   9 erunion  staff   288B May 15 17:14 Getting Started
drwxr-xr-x  10 erunion  staff   320B May 15 17:14 Project Setup
drwxr-xr-x   6 erunion  staff   192B May 15 17:14 ReadMe Refactored
drwxr-xr-x   7 erunion  staff   224B May 15 17:14 Support
drwxr-xr-x   5 erunion  staff   160B May 15 17:14 Syncing Docs
drwxr-xr-x   3 erunion  staff    96B May 15 17:14 Syncing Your Content
drwxr-xr-x   6 erunion  staff   192B May 15 17:14 Version Control
drwxr-xr-x  11 erunion  staff   352B May 15 17:14 Writing Docs
```

```
$ ls -lah output/Getting\ Started/
total 88
drwxr-xr-x   9 erunion  staff   288B May 15 17:14 .
drwxr-xr-x  14 erunion  staff   448B May 15 17:14 ..
-rw-r--r--   1 erunion  staff   6.2K May 15 17:14 about-readme.md
-rw-r--r--   1 erunion  staff   3.1K May 15 17:14 ai-overview.md
-rw-r--r--   1 erunion  staff   209B May 15 17:14 asdfasdf.md
-rw-r--r--   1 erunion  staff   6.5K May 15 17:14 copy-of-welcome-to-readme.md
-rw-r--r--   1 erunion  staff   304B May 15 17:14 enterprise-guides.md
-rw-r--r--   1 erunion  staff   5.1K May 15 17:14 migration-moving-your-docs-to-their-new-home.md
-rw-r--r--   1 erunion  staff   4.8K May 15 17:14 quickstart.md
```

```
$ cat output/Getting\ Started/about-readme.md
---
appearance:
  icon:
    name: far fa-hand-wave
    type: icon
category:
  uri: Getting Started
content:
  excerpt: Helping you create docs that make your APIs easy to use and maintain.
metadata:
  description: Helping you create docs that make your APIs easy to use and maintain.
position: 0
privacy:
  view: public
slug: about-readme
title: Welcome to ReadMe
---
<Banner 
  header="A New ReadMe, Built to Work with AI" 
  href="https://readme.com/blog/may-launch"
  icon="fa-duotone fa-solid fa-rocket-launch"
  text="See what shipped"
/>

...
```
