### PR TITLE
fix(gha): move from node 20 to node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,6 @@ outputs:
   rdme:
     description: The rdme command result output
 runs:
-  using: node20
+  using: node24
   pre: bin/write-gha-pjson.js
   main: dist-gha/run.cjs


### PR DESCRIPTION
| 🚥 Resolves #1469 |
| :------------------- |

## 🧰 Changes

GitHub is EOL'ing Node 20 in actions at the end of next month so this upgrades our GHA Workflow to Node 24.