### PR TITLE
fix(export): don't crash when a skipped empty page is the parent of exported pages

### DIFF
--- a/src/lib/exportDocs.ts
+++ b/src/lib/exportDocs.ts
@@ -42,6 +42,16 @@ interface FileMapEntry {
   parent: string | undefined;
   slug: string;
   title: unknown;
+  /**
+   * Pages that were skipped during download (e.g., empty non-link pages) but are still needed to
+   * resolve the directory hierarchy of their children. Virtual entries have no file of their own.
+   */
+  virtual?: boolean;
+}
+
+interface SkippedPageMeta {
+  category: string | undefined;
+  parent: string | undefined;
 }
 
 /**
@@ -164,13 +174,15 @@ function buildPath(
   visited: Set<string> = new Set(),
 ): string | null {
   if (visited.has(slug)) {
-    throw new Error(`Circular reference detected for slug: ${slug}`);
+    this.warn(`Circular parent reference detected for slug "${slug}". Its children will be placed under its category.`);
+    return null;
   }
   visited.add(slug);
 
   const fileInfo = fileMap.get(slug);
   if (!fileInfo) {
-    throw new Error(`File not found for slug: ${slug}`);
+    this.warn(`Parent page "${slug}" was not exported. Its children will be placed under its category.`);
+    return null;
   }
 
   const parts: string[] = [];
@@ -193,7 +205,12 @@ function buildPath(
   return parts.join('/');
 }
 
-function restructureFiles(this: APIv2PageExportCommands, tempFolder: string, finalFolder: string): void {
+function restructureFiles(
+  this: APIv2PageExportCommands,
+  tempFolder: string,
+  finalFolder: string,
+  skippedPages: Map<string, SkippedPageMeta> = new Map(),
+): void {
   const restructureSpinner = ora({ ...oraOptions() }).start('🗃️  Restructuring files...');
 
   const files = findMarkdownFiles(tempFolder);
@@ -202,17 +219,33 @@ function restructureFiles(this: APIv2PageExportCommands, tempFolder: string, fin
   const fileMap = buildFileMap.call(this, files);
   this.debug(`Parsed ${fileMap.size} files with valid frontmatter`);
 
-  const results: { slug: string; oldPath: string; newPath: string; title: unknown }[] = [];
-  for (const [slug] of fileMap) {
-    const newPathBuilt = buildPath.call(this, slug, fileMap);
-    if (newPathBuilt) {
-      const info = fileMap.get(slug)!;
-      results.push({
+  // Pages that were skipped during download can still be parents of exported pages, so add them
+  // as virtual entries to preserve the directory hierarchy of their children.
+  for (const [slug, meta] of skippedPages) {
+    if (!fileMap.has(slug)) {
+      fileMap.set(slug, {
+        category: meta.category,
+        filePath: '',
+        parent: meta.parent,
         slug,
-        oldPath: info.filePath,
-        newPath: `${newPathBuilt}.md`,
-        title: info.title,
+        title: undefined,
+        virtual: true,
       });
+    }
+  }
+
+  const results: { slug: string; oldPath: string; newPath: string; title: unknown }[] = [];
+  for (const [slug, info] of fileMap) {
+    if (!info.virtual) {
+      const newPathBuilt = buildPath.call(this, slug, fileMap);
+      if (newPathBuilt) {
+        results.push({
+          slug,
+          oldPath: info.filePath,
+          newPath: `${newPathBuilt}.md`,
+          title: info.title,
+        });
+      }
     }
   }
 
@@ -268,6 +301,8 @@ export async function exportDocs(this: APIv2PageExportCommands): Promise<FullExp
       failed: [],
       skipped: 0,
     };
+
+    const skippedPages = new Map<string, SkippedPageMeta>();
 
     this.debug(`Exporting pages from \`${branch}\` to ${tempFolder}`);
 
@@ -325,6 +360,24 @@ export async function exportDocs(this: APIv2PageExportCommands): Promise<FullExp
               if (skipForDocsOnly) {
                 this.debug(`Skipping empty ${output.type} page because it is not a link: ${output.slug}`);
                 downloads.skipped += 1;
+
+                // Skipped pages can still be parents of exported pages, so retain the metadata
+                // needed to resolve their children's directory hierarchy later on.
+                if (typeof output.slug === 'string' && isSafePathSegment(output.slug)) {
+                  const categoryName =
+                    isRecord(output.category) && typeof output.category.uri === 'string'
+                      ? decodeURILastSegment(output.category.uri)
+                      : null;
+                  const parentSlug =
+                    isRecord(output.parent) && typeof output.parent.uri === 'string'
+                      ? decodeURILastSegment(output.parent.uri)
+                      : null;
+
+                  skippedPages.set(output.slug, {
+                    category: categoryName ?? undefined,
+                    parent: parentSlug ?? undefined,
+                  });
+                }
               } else {
                 if (isGuideOrReferenceRequest(this.route, output)) {
                   const parentKey =
@@ -391,7 +444,7 @@ export async function exportDocs(this: APIv2PageExportCommands): Promise<FullExp
         this.log(`   - ${slug}`);
       });
     } else {
-      restructureFiles.call(this, tempFolder, outputDir);
+      restructureFiles.call(this, tempFolder, outputDir, skippedPages);
 
       this.log('');
       this.log(`All files have been saved to: ${outputDir}`);

--- a/test/commands/pages/export.test.ts
+++ b/test/commands/pages/export.test.ts
@@ -214,6 +214,93 @@ Child body`),
     }
   });
 
+  it('should nest children of skipped empty pages under the skipped page directory', async () => {
+    if (route !== 'reference') return;
+
+    const tmpDir = tempExportDir();
+    try {
+      const mock = getAPIv2Mock({ authorization })
+        .get(`/branches/stable/categories/${route}`)
+        .reply(200, { data: [{ title: 'Model API' }] })
+        .get(`/branches/stable/categories/${route}/${encodeURIComponent('Model API')}/pages`)
+        .reply(200, { data: [{ slug: 'model-jobs' }, { slug: 'update-model-job' }] })
+        .get(`/branches/stable/${route}/model-jobs`)
+        .reply(200, {
+          data: {
+            slug: 'model-jobs',
+            title: 'Model Jobs',
+            type: 'basic',
+            content: { body: null },
+            category: { uri: `/branches/stable/categories/${route}/${encodeURIComponent('Model API')}` },
+          },
+        })
+        .get(`/branches/stable/${route}/update-model-job`)
+        .reply(200, {
+          data: {
+            slug: 'update-model-job',
+            title: 'Update model job',
+            type: 'endpoint',
+            content: { body: 'Updates the specified model job.' },
+            category: { uri: `/branches/stable/categories/${route}/${encodeURIComponent('Model API')}` },
+            parent: { uri: `/branches/stable/${route}/model-jobs` },
+          },
+        });
+
+      const output = await run([tmpDir, '--key', key]);
+
+      expect(output.error).toBeUndefined();
+      expect(output.result).toMatchObject({ failed: [], skipped: 1 });
+
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+      expect(fs.copyFileSync).toHaveBeenCalledTimes(1);
+      expect(fs.copyFileSync).toHaveBeenCalledWith(
+        path.join(tmpDir, '.temp_download', 'update-model-job.md'),
+        path.join(tmpDir, 'Model API', 'model-jobs', 'update-model-job.md'),
+      );
+
+      mock.done();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should place children under their category when a parent page is missing entirely', async () => {
+    const tmpDir = tempExportDir();
+    try {
+      const mock = getAPIv2Mock({ authorization })
+        .get(`/branches/stable/categories/${route}`)
+        .reply(200, { data: [{ title: 'Docs' }] })
+        .get(`/branches/stable/categories/${route}/Docs/pages`)
+        .reply(200, { data: [{ slug: 'orphan-doc' }] })
+        .get(`/branches/stable/${route}/orphan-doc`)
+        .reply(200, {
+          data: {
+            slug: 'orphan-doc',
+            title: 'Orphan',
+            type: 'basic',
+            content: { body: 'Orphan body' },
+            category: { uri: `https://api.readme.com/v2/branches/stable/categories/${route}/docs` },
+            parent: { uri: `https://api.readme.com/v2/branches/stable/${route}/ghost-parent` },
+          },
+        });
+
+      const output = await run([tmpDir, '--key', key]);
+
+      expect(output.error).toBeUndefined();
+      expect(output.stderr).toContain('Parent page "ghost-parent" was not exported');
+
+      expect(fs.copyFileSync).toHaveBeenCalledTimes(1);
+      expect(fs.copyFileSync).toHaveBeenCalledWith(
+        path.join(tmpDir, '.temp_download', 'orphan-doc.md'),
+        path.join(tmpDir, 'docs', 'orphan-doc.md'),
+      );
+
+      mock.done();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('should not write outside the export directory when slug contains path traversal', async () => {
     const tmpDir = tempExportDir();
     const parentDir = path.dirname(tmpDir);


### PR DESCRIPTION
## 🧰 Changes

`rdme reference export` (and `docs export`, when a parent page is missing) could fail at the very end of an export with:

```
File not found for slug: <slug>
```

…and because the error handler removes the temporary download folder, **every already-downloaded file is discarded** right at the finish line.

### Root cause

For reference exports, empty non-link pages are always skipped during download (`docsOnly` is forced on for non-guides routes). In API reference sections these skipped pages are typically the auto-generated "container" pages that group endpoint pages — so the exported endpoint pages still reference them via `parent.uri`. During the restructure step, `buildPath()` looks the parent slug up in the file map built from the downloaded files, doesn't find it (its file was intentionally never written), and throws — aborting the whole export.

Reproduced against a real project: 533 pages downloaded successfully, then the export died on `File not found for slug: databases-1` (an empty container page that was skipped, but is the parent of downloaded endpoint pages) and deleted all 533 files.

### Fix

- While downloading, retain the category/parent metadata of skipped pages.
- Feed those into the restructure step as *virtual* file-map entries, so children of a skipped page still nest under the skipped page's directory (e.g. `Model API/model-jobs/updatemodeljob.md`) — the same hierarchy as before, just without an `index.md` for the page that has no content.
- If a parent genuinely can't be resolved (or a circular parent chain is detected), emit a warning and place the child directly under its category instead of aborting the entire export.

## 🧬 QA & Testing

- Added a regression test for the skipped-empty-parent case (reference route) and one for a completely unresolvable parent (both routes). Both fail on `main` and pass with this change.
- Ran the full export end-to-end against the real project that previously failed: exits 0, all pages exported and nested under their container-page directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
