### PR TITLE
fix(openapi): treat pending uploads as accepted

### DIFF
--- a/documentation/commands/openapi.md
+++ b/documentation/commands/openapi.md
@@ -220,6 +220,9 @@ DESCRIPTION
   For the best and most explicit results, we recommend using the `--slug` flag to set a slug for your API definition,
   especially if you're managing many API definitions at scale.
 
+  If your API definition is still processing when the polling window ends, the command will exit successfully while
+  processing continues in the background.
+
 EXAMPLES
   You can pass in a file name like so:
 

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -38,6 +38,7 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
     'If the spec is a local file, the inferred slug takes the relative path and slugifies it (e.g., the slug for `docs/api/petstore.json` will be `docs-api-petstore.json`).',
     'If the spec is a URL, the inferred slug is the base file name from the URL (e.g., the slug for `https://example.com/docs/petstore.json` will be `petstore.json`).',
     "For the best and most explicit results, we recommend using the `--slug` flag to set a slug for your API definition, especially if you're managing many API definitions at scale.",
+    'If your API definition is still processing when the polling window ends, the command will exit successfully while processing continues in the background.',
   ].join('\n\n');
 
   static args = {
@@ -112,9 +113,9 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
   }
 
   /**
-   * Poll the ReadMe API until the upload is complete.
+   * Poll the ReadMe API until the upload is complete or the polling window ends.
    */
-  private async pollAPIUntilUploadIsComplete(slug: string, headers: Headers) {
+  private async pollAPIUntilUploadCompletesOrPollingEnds(slug: string, headers: Headers) {
     let count = 0;
     let status: APIUploadStatus = 'pending';
     let reason: APIUploadFailureReason | undefined;
@@ -140,10 +141,6 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
       count += 1;
     }
     // oxlint-enable no-await-in-loop
-
-    if (this.isStatusPending(status)) {
-      throw new Error('Sorry, this upload timed out. Please try again later.');
-    }
 
     return { status, reason };
   }
@@ -442,13 +439,21 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
 
       if (this.isStatusPending(status)) {
         spinner.text = `${spinner.text} uploaded but not yet processed by ReadMe. Polling for completion...`;
-        ({ status, reason } = await this.pollAPIUntilUploadIsComplete(response.data.uri, headers));
+        ({ status, reason } = await this.pollAPIUntilUploadCompletesOrPollingEnds(response.data.uri, headers));
       }
 
       if (this.isStatusFailed(status)) {
         if (reason) {
           throw new Error(`Your API definition upload failed with the following reason:\n\n${reason}`);
         }
+      }
+
+      if (this.isStatusPending(status)) {
+        spinner.info(`${spinner.text} still processing in the background.`);
+        this.log(
+          `Your API definition (${filename}) was accepted and is still being processed by ReadMe. Processing will continue in the background. Do not retry this upload while it is still processing. Check ReadMe later to confirm that processing completed successfully.`,
+        );
+        return { uri: response.data.uri, status };
       }
 
       if (status === 'done') {

--- a/test/commands/openapi/__snapshots__/upload.test.ts.snap
+++ b/test/commands/openapi/__snapshots__/upload.test.ts.snap
@@ -484,9 +484,12 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
 }
 `;
 
-exports[`rdme openapi upload > given that the API definition is a local file > and the upload status initially is a pending state > should poll the API and handle timeouts 1`] = `
+exports[`rdme openapi upload > given that the API definition is a local file > and the upload status initially is a pending state > should poll the API and handle a pending result when the polling window ends 1`] = `
 {
-  "error": [Error: Sorry, this upload timed out. Please try again later.],
+  "result": {
+    "status": "pending",
+    "uri": "/branches/1.0.0/apis/test__fixtures__petstore-simple-weird-version.json",
+  },
   "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
  ›   Warning: This OpenAPI file is located in a subfolder and no \`--slug\` was 
  ›   provided.
@@ -508,8 +511,25 @@ exports[`rdme openapi upload > given that the API definition is a local file > a
  ›   To suppress this warning and confirmation in the future, use 
  ›   \`--confirm-overwrite\`.
 - Creating your API definition to ReadMe...
+ℹ Creating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion... still processing in the background.
 ",
-  "stdout": "",
+  "stdout": "Your API definition (test__fixtures__petstore-simple-weird-version.json) was accepted and is still being processed by ReadMe. Processing will continue in the background. Do not retry this upload while it is still processing. Check ReadMe later to confirm that processing completed successfully.
+",
+}
+`;
+
+exports[`rdme openapi upload > given that the API definition is a local file > and the upload status initially is a pending state > should poll the API and handle a pending update result when the polling window ends 1`] = `
+{
+  "result": {
+    "status": "pending_update",
+    "uri": "/branches/1.0.0/apis/test__fixtures__petstore-simple-weird-version.json",
+  },
+  "stderr": "- Validating the API definition located at test/__fixtures__/petstore-simple-weird-version.json...
+- Updating your API definition to ReadMe...
+ℹ Updating your API definition to ReadMe... uploaded but not yet processed by ReadMe. Polling for completion... still processing in the background.
+",
+  "stdout": "Your API definition (test__fixtures__petstore-simple-weird-version.json) was accepted and is still being processed by ReadMe. Processing will continue in the background. Do not retry this upload while it is still processing. Check ReadMe later to confirm that processing completed successfully.
+",
 }
 `;
 

--- a/test/commands/openapi/upload.test.ts
+++ b/test/commands/openapi/upload.test.ts
@@ -588,7 +588,7 @@ describe('rdme openapi upload', () => {
         mock.done();
       });
 
-      it('should poll the API and handle timeouts', async () => {
+      it('should poll the API and handle a pending result when the polling window ends', async () => {
         prompts.inject([true]);
         const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
           .get(`/branches/${branch}/apis`)
@@ -619,6 +619,52 @@ describe('rdme openapi upload', () => {
 
         const result = await run(['--branch', branch, filename, '--key', key]);
 
+        expect(result.error).toBeUndefined();
+        expect(result.result).toStrictEqual({
+          status: 'pending',
+          uri: `/branches/${branch}/apis/${slugifiedFilename}`,
+        });
+        expect(result).toMatchSnapshot();
+
+        mock.done();
+      });
+
+      it('should poll the API and handle a pending update result when the polling window ends', async () => {
+        prompts.inject([true]);
+        const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
+          .get(`/branches/${branch}/apis`)
+          .reply(200, { data: [{ filename: slugifiedFilename }] })
+          .put(
+            `/branches/${branch}/apis/${slugifiedFilename}`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
+          )
+          .reply(200, {
+            data: {
+              upload: { status: 'pending_update' },
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
+            },
+          })
+          .get(`/branches/${branch}/apis/${slugifiedFilename}`)
+          .times(25)
+          .reply(200, {
+            data: {
+              upload: { status: 'pending_update' },
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
+            },
+          });
+
+        const result = await run(['--branch', branch, filename, '--key', key]);
+
+        expect(result.error).toBeUndefined();
+        expect(result.result).toStrictEqual({
+          status: 'pending_update',
+          uri: `/branches/${branch}/apis/${slugifiedFilename}`,
+        });
         expect(result).toMatchSnapshot();
 
         mock.done();


### PR DESCRIPTION
| 🚥 Resolves [CX-3771](https://linear.app/readme-io/issue/CX-3771/rdme-openapi-upload-times-out-while-the-openapi-definition-continues) |
| :--------------------------------------------------------------------------------------------------------------- |

## 🧰 Changes

`rdme openapi upload` waits for queued API definitions to finish processing. When the polling window ends, it currently reports that the upload timed out and fails CI even if ReadMe confirms that the job is still processing in the background.

CX-3012 previously increased the polling limit from 10 checks (about 3 minutes) to 25 checks (about 10.5 minutes). CX-3771 shows that valid uploads can still take longer. Increasing the limit again would only move the cutoff, make CI wait longer, and keep treating an active backend job as a failed upload.

This changes the exhausted polling-window case to return the last confirmed `pending` or `pending_update` status successfully. The message includes the API definition slug, explains that processing is continuing, warns against retrying while it is still processing, and asks the customer to check ReadMe later for final completion. Actual upload failures and polling request errors remain errors.

## 🧬 QA & Testing

- A newly created definition that remains `pending` after all 25 polls exits successfully, returns the pending status, and includes its slug in the background-processing message.
- An updated definition that remains `pending_update` behaves the same way.
- Definitions that reach `done` keep the existing success behavior, while API and processing failures remain non-zero exits.
