### PR TITLE
feat(openapi): add configurable upload timeout

### DIFF
--- a/documentation/commands/openapi.md
+++ b/documentation/commands/openapi.md
@@ -186,7 +186,7 @@ Upload (or re-upload) your API definition to ReadMe.
 ```
 USAGE
   $ rdme openapi upload [SPEC] --key <value> [--confirm-overwrite] [--dry-run] [--slug <value>] [--title <value>]
-    [--useSpecVersion | --branch <value>] [--working-directory <value>]
+    [--useSpecVersion | --branch <value>] [--timeout <value>] [--working-directory <value>]
 
 ARGUMENTS
   [SPEC]  A path to your API definition — either a local file path or a URL. If your working directory and all
@@ -201,6 +201,7 @@ FLAGS
   --slug=<value>               Override the slug (i.e., the unique identifier) for your API definition.
   --title=<value>              An override value for the `info.title` field in the API definition
   --useSpecVersion             Use the OpenAPI `info.version` field for your ReadMe project version
+  --timeout=<value>            [default: 720] Number of seconds to wait for the upload to finish processing.
   --working-directory=<value>  Working directory (for usage with relative external references)
 
 DESCRIPTION
@@ -268,6 +269,11 @@ FLAG DESCRIPTIONS
 
     If included, use the version specified in the `info.version` field in your OpenAPI definition for your ReadMe
     project version. This flag is mutually exclusive with `--branch`.
+
+  --timeout=<value>  Number of seconds to wait for the upload to finish processing.
+
+    Must be between 1 and 3,600 seconds. If the API definition is still processing when the timeout is reached, the
+    command will exit successfully while processing continues in the background.
 ```
 
 ## `rdme openapi validate [SPEC]`

--- a/src/commands/openapi/upload.ts
+++ b/src/commands/openapi/upload.ts
@@ -23,6 +23,7 @@ import prepareOas from '../../lib/prepareOas.js';
 import promptTerminal from '../../lib/promptWrapper.js';
 
 const yamlExtensions = ['.yaml', '.yml'];
+const defaultWaitTimeoutSeconds = 12 * 60;
 
 function isNestedLocalSpecPath(specPath: string): boolean {
   return nodePath.dirname(nodePath.normalize(specPath)) !== '.';
@@ -80,6 +81,14 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
         'If included, use the version specified in the `info.version` field in your OpenAPI definition for your ReadMe project version. This flag is mutually exclusive with `--branch`.',
       exclusive: ['branch'],
     }),
+    timeout: Flags.integer({
+      summary: 'Number of seconds to wait for the upload to finish processing.',
+      description:
+        'Must be between 1 and 3,600 seconds. If the API definition is still processing when the timeout is reached, the command will exit successfully while processing continues in the background.',
+      default: defaultWaitTimeoutSeconds,
+      max: 3600,
+      min: 1,
+    }),
     'working-directory': workingDirectoryFlag,
   };
 
@@ -115,20 +124,31 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
   /**
    * Poll the ReadMe API until the upload is complete or the polling window ends.
    */
-  private async pollAPIUntilUploadCompletesOrPollingEnds(slug: string, headers: Headers) {
+  private async pollAPIUntilUploadCompletesOrPollingEnds(slug: string, headers: Headers, timeoutSeconds: number) {
     let count = 0;
     let status: APIUploadStatus = 'pending';
     let reason: APIUploadFailureReason | undefined;
+    let elapsedMilliseconds = 0;
+    const timeoutMilliseconds = timeoutSeconds * 1000;
 
     // oxlint-disable no-await-in-loop -- We need to wait between requests to avoid hitting rate limits.
-    while (this.isStatusPending(status) && count < 25) {
-      // oxlint-disable-next-line no-loop-func -- False positive.
+    while (this.isStatusPending(status)) {
+      const remainingMilliseconds = timeoutMilliseconds - elapsedMilliseconds;
+
+      if (remainingMilliseconds <= 0) {
+        break;
+      }
+
+      const pollingDelayMilliseconds = Math.min(1000 * 2 ** count, 30_000, remainingMilliseconds);
+
       await new Promise(resolve => {
-        // exponential backoff — wait 1s, 2s, 4s, 8s, 16s, 32s, 30s, 30s, 30s, 30s, etc.
-        setTimeout(resolve, Math.min(isTest() ? 1 : 1000 * 2 ** count, 30000));
+        // Exponential backoff — wait 1s, 2s, 4s, 8s, 16s, then up to 30s between requests.
+        setTimeout(resolve, isTest() ? 1 : pollingDelayMilliseconds);
       });
 
-      this.debug(`polling API for status of ${slug}, count is ${count}`);
+      elapsedMilliseconds += pollingDelayMilliseconds;
+
+      this.debug(`polling API for status of ${slug}, count is ${count}, timeout is ${timeoutSeconds}s`);
       const response = (await this.readmeAPIFetch(slug, { headers }).then(res =>
         this.handleAPIRes(res),
       )) as APIUploadSingleResponseRepresentation;
@@ -439,7 +459,11 @@ export default class OpenAPIUploadCommand extends BaseCommand<typeof OpenAPIUplo
 
       if (this.isStatusPending(status)) {
         spinner.text = `${spinner.text} uploaded but not yet processed by ReadMe. Polling for completion...`;
-        ({ status, reason } = await this.pollAPIUntilUploadCompletesOrPollingEnds(response.data.uri, headers));
+        ({ status, reason } = await this.pollAPIUntilUploadCompletesOrPollingEnds(
+          response.data.uri,
+          headers,
+          this.flags.timeout,
+        ));
       }
 
       if (this.isStatusFailed(status)) {

--- a/test/commands/openapi/upload.test.ts
+++ b/test/commands/openapi/upload.test.ts
@@ -84,6 +84,18 @@ describe('rdme openapi upload', () => {
       expect(result).toMatchSnapshot();
     });
 
+    it('should throw if `--timeout` is less than one second', async () => {
+      const result = await run([filename, '--key', key, '--timeout', '0']);
+
+      expect(result.error?.message).toContain('Expected an integer greater than or equal to 1 but received: 0');
+    });
+
+    it('should throw if `--timeout` is more than one hour', async () => {
+      const result = await run([filename, '--key', key, '--timeout', '3601']);
+
+      expect(result.error?.message).toContain('Expected an integer less than or equal to 3600 but received: 3601');
+    });
+
     describe('API key validation', () => {
       it('should error when `--key` is empty', async () => {
         const result = await run(['--branch', branch, filename, '--key', '']);
@@ -609,7 +621,7 @@ describe('rdme openapi upload', () => {
             },
           })
           .get(`/branches/${branch}/apis/${slugifiedFilename}`)
-          .times(25)
+          .times(28)
           .reply(200, {
             data: {
               upload: { status: 'pending' },
@@ -625,6 +637,46 @@ describe('rdme openapi upload', () => {
           uri: `/branches/${branch}/apis/${slugifiedFilename}`,
         });
         expect(result).toMatchSnapshot();
+
+        mock.done();
+      });
+
+      it('should use a custom polling timeout', async () => {
+        prompts.inject([true]);
+        const mock = getAPIv2Mock({ authorization: `Bearer ${key}` })
+          .get(`/branches/${branch}/apis`)
+          .reply(200, { data: [] })
+          .post(
+            `/branches/${branch}/apis`,
+            body =>
+              body.match(
+                `form-data; name="schema"; filename="${slugifiedFilename}"\r\nContent-Type: application/json`,
+              ) &&
+              // asserts that we're sending JSON
+              body.match(`{"openapi":"3.0.0","info":{"version":"1.2.3","title":"Single Path",`),
+          )
+          .reply(200, {
+            data: {
+              upload: { status: 'pending' },
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
+            },
+          })
+          .get(`/branches/${branch}/apis/${slugifiedFilename}`)
+          .times(2)
+          .reply(200, {
+            data: {
+              upload: { status: 'pending' },
+              uri: `/branches/${branch}/apis/${slugifiedFilename}`,
+            },
+          });
+
+        const result = await run(['--branch', branch, filename, '--key', key, '--timeout', '3']);
+
+        expect(result.error).toBeUndefined();
+        expect(result.result).toStrictEqual({
+          status: 'pending',
+          uri: `/branches/${branch}/apis/${slugifiedFilename}`,
+        });
 
         mock.done();
       });
@@ -650,7 +702,7 @@ describe('rdme openapi upload', () => {
             },
           })
           .get(`/branches/${branch}/apis/${slugifiedFilename}`)
-          .times(25)
+          .times(28)
           .reply(200, {
             data: {
               upload: { status: 'pending_update' },


### PR DESCRIPTION
| 🚥 Follow-up to [CX-3771](https://linear.app/readme-io/issue/CX-3771/rdme-openapi-upload-times-out-while-the-openapi-definition-continues) |
| :----------------------------------------------------------------------------------------------------------------------------- |

## 🧰 Changes

Adds `--timeout` so customers can choose how long `rdme openapi upload` waits for processing. It defaults to 12 minutes and accepts values from 1 second to 1 hour. The upper limit prevents accidental long-running CI jobs from polling indefinitely.

This is separate from the immediate CX-3771 fix because changing the wait duration is optional configuration rather than part of correcting the false failure.

## 🧬 QA & Testing

- Run an upload that remains pending and confirm the default polling window is 12 minutes.
- Pass `--timeout 3` and confirm the command stops polling after the custom window, then reports that processing continues in the background.
- Confirm `--timeout 0` and `--timeout 3601` are rejected.
- Confirm uploads that finish or fail during polling keep their existing behavior.
