### PR TITLE
fix: Disable javascript execution in 2nd frontmatter

### DIFF
--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -208,7 +208,13 @@ export function writeFixes(
 ) {
   // Pass content as object to prevent grayMatter from reparsing, which uses
   // its javascript engine and can execute arbitrary js.
-  const result = grayMatter.stringify({ content: metadata.content }, updatedData);
+  const result = grayMatter.stringify({ content: metadata.content }, updatedData, {
+    // disable the javascript engine, which is a built-in RCE
+    //
+    // * @see https://github.com/readmeio/rdme/security/advisories/GHSA-f65r-8r74-m6v5
+    // * @see https://github.com/jonschlinkert/gray-matter/issues/131#issuecomment-3566662412
+    engines: { javascript: { parse: () => ({}) } },
+  });
   const outputPath = outputDirArg ? path.join(outputDirArg, metadata.filePath) : metadata.filePath;
   this.debug(`writing fixes to ${outputPath}`);
   const outputDir = path.dirname(outputPath);

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -206,7 +206,9 @@ export function writeFixes(
   /** output directory to write to */
   outputDirArg?: string,
 ) {
-  const result = grayMatter.stringify(metadata.content, updatedData);
+  // Pass content as object to prevent grayMatter from reparsing, which uses
+  // its javascript engine and can execute arbitrary js.
+  const result = grayMatter.stringify({ content: metadata.content }, updatedData);
   const outputPath = outputDirArg ? path.join(outputDirArg, metadata.filePath) : metadata.filePath;
   this.debug(`writing fixes to ${outputPath}`);
   const outputDir = path.dirname(outputPath);

--- a/src/lib/readPage.ts
+++ b/src/lib/readPage.ts
@@ -57,9 +57,6 @@ export function readPage(
 ): PageMetadata {
   this.debug(`reading file ${filePath}`);
   const rawFileContents = fs.readFileSync(filePath, 'utf8');
-  // by default, grayMatter maintains a buggy cache with the page data,
-  // so we pass an empty object as second argument to avoid it entirely
-  // (so far we've seen this issue crop up in tests)
   const matter = grayMatter(rawFileContents, {
     // disable the javascript engine, which is a built-in RCE
     //

--- a/test/lib/frontmatter.test.ts
+++ b/test/lib/frontmatter.test.ts
@@ -381,6 +381,21 @@ describe('#writeFixes', () => {
     });
   });
 
+  it('should not execute JavaScript embedded in page content', () => {
+    const emitWarning = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
+    const maliciousPageData = {
+      ...mockPageData,
+      content: `---javascript
+({ malicious: process.emitWarning('JavaScript was executed') })
+---
+# Page content`,
+    };
+
+    writeFixes.call(command, maliciousPageData, { updated: true });
+
+    expect(emitWarning).not.toHaveBeenCalled();
+  });
+
   it('should write changes to current directory', () => {
     writeFixes.call(command, mockPageData, { updated: true }, '.');
 


### PR DESCRIPTION
| 🚥 Resolves RM-17682 |
| :------------------- |

## 🧰 Changes

Avoids a `gray-matter` rparse that can execute arbitrary js code that exists in a js frontmatter stored in body content. This would apply if there was js frontmatter that came immediately after the first frontmatter.

By putting into an object, it does not trigger the parse.

See here for a similar pr that was just done on the first frontmatter parse: https://github.com/readmeio/rdme/pull/1396

## 🧬 QA & Testing

Added test case coverage, ensured full test suite passing.

Verified that the test failed without the patch applied:

```sh
 FAIL  test/lib/frontmatter.test.ts > #writeFixes > should not execute JavaScript embedded in page content
Error: stringifying JavaScript is not supported
 ❯ Object.stringify node_modules/gray-matter/lib/engines.js:52:11
 ❯ module.exports node_modules/gray-matter/lib/stringify.js:38:25
 ❯ Function.matter.stringify node_modules/gray-matter/index.js:162:10
 ❯ DocsUploadCommand.writeFixes src/lib/frontmatter.ts:209:29
    207|   outputDirArg?: string,
    208| ) {
    209|   const result = grayMatter.stringify(metadata.content, updatedData);
       |                             ^
    210|   const outputPath = outputDirArg ? path.join(outputDirArg, metadata.filePath) : metadata.filePath;
    211|   this.debug(`writing fixes to ${outputPath}`);
 ❯ test/lib/frontmatter.test.ts:394:16
```