### PR TITLE
chore: add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "rdme",
+  "install": "npm ci && npm run build"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a repository-managed Cloud Agent environment config at `.cursor/environment.json` so Cursor Cloud Agents boot `rdme` with a fully prepared development environment.

```json
{
  "name": "rdme",
  "install": "npm ci && npm run build"
}
```

- `npm ci` installs dependencies from the committed `package-lock.json` (deterministic).
- `npm run build` compiles TypeScript to `dist/` so the production entrypoint (`bin/run.js`) works immediately.

No custom Dockerfile is needed — the default image already provides Node (`>=20.10.0` engine requirement is satisfied). No `start`/`terminals` are needed because `rdme` is a CLI, not a long-running service. No secrets are required for install, build, test, or offline command runs (tests mock network via `nock`).

## Validation

All commands run from a clean checkout on the default VM Node (v22.14.0):

| Check | Result |
| --- | --- |
| `npm ci && npm run build` | Exit 0 (idempotent — ran twice) |
| `bin/run.js --version` | `rdme/10.10.0-next.4 linux-x64 node-v22.14.0` |
| `bin/run.js openapi validate` (fixture) | Valid OpenAPI definition |
| `bin/dev.js openapi validate` (via `tsx`) | Valid OpenAPI definition |
| `npm test` (vitest + coverage) | 37 files, 698 passed, ~98% statements |
| Fresh Cloud Agent draft build | SUCCEEDED (`npm ci` + `npm run build` exit 0, snapshot ready) |

## Notes

- `npm run lint`'s `oxlint` step loads a TypeScript config (`oxlint.config.ts`), which requires Node `^20.19.0 || >=22.18.0`. The Cloud Agent's pinned default `node` is v22.14.0, so bare `npm run lint` fails at that step. Under a CI-matching Node (CI uses `lts/*`; the VM has v22.22.2 / v24.15.0 via `nvm`), `knip`, `oxlint`, and `oxfmt` all pass clean. This is a Node-version detail, not caused by this config.
- `npm run lint`'s `schemas:check` step reports the committed `test/helpers/github-workflow-schema.json` is outdated vs. the upstream JSON Schema Store (fixed by maintainers with `npm run schemas:write`). This is pre-existing repo content drift, unrelated to environment setup.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22887882-cd6f-4c79-947b-42a1ee5c5ae3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22887882-cd6f-4c79-947b-42a1ee5c5ae3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

